### PR TITLE
Add rcf serialization support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
+target
+.*
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.5.2</version>

--- a/src/main/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapter.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import com.amazon.randomcutforest.AbstractForestTraversalExecutor;
+import com.amazon.randomcutforest.ParallelForestTraversalExecutor;
+import com.amazon.randomcutforest.SequentialForestTraversalExecutor;
+
+/**
+ * Adapter for serializing {@link AbstractForestTraversalExecutor} implementations.
+ */
+public class AbstractForestTraversalExecutorAdapter implements JsonSerializer<AbstractForestTraversalExecutor>,
+    JsonDeserializer<AbstractForestTraversalExecutor> {
+
+    public static final String PROPERTY_EXECUTOR_TYPE = "executor_type";
+    public static final String PROPERTY_EXECUTOR = "executor";
+
+    @Override
+    public JsonElement serialize(AbstractForestTraversalExecutor src, Type type, JsonSerializationContext context) {
+        JsonObject executorJson = new JsonObject();
+        if (src instanceof SequentialForestTraversalExecutor) {
+            executorJson.addProperty(PROPERTY_EXECUTOR_TYPE, SequentialForestTraversalExecutor.class.getSimpleName());
+            executorJson.add(PROPERTY_EXECUTOR, context.serialize(src, SequentialForestTraversalExecutor.class));
+        } else if (src instanceof ParallelForestTraversalExecutor) {
+            executorJson.addProperty(PROPERTY_EXECUTOR_TYPE, ParallelForestTraversalExecutor.class.getSimpleName());
+            executorJson.add(PROPERTY_EXECUTOR, context.serialize(src, ParallelForestTraversalExecutor.class));
+        } else {
+            throw new IllegalArgumentException("Unsupported executor type " + type.getTypeName());
+        }
+        return executorJson;
+    }
+
+    @Override
+    public AbstractForestTraversalExecutor deserialize(JsonElement json, Type type, JsonDeserializationContext ctx) {
+        AbstractForestTraversalExecutor executor = null;
+        JsonObject executorJson = json.getAsJsonObject();
+        String executorType = executorJson.getAsJsonPrimitive(PROPERTY_EXECUTOR_TYPE).getAsString();
+        if (SequentialForestTraversalExecutor.class.getSimpleName().equals(executorType)) {
+            executor = ctx.deserialize(executorJson.get(PROPERTY_EXECUTOR), SequentialForestTraversalExecutor.class);
+        } else if (ParallelForestTraversalExecutor.class.getSimpleName().equals(executorType)) {
+            executor = ctx.deserialize(
+                executorJson.get(PROPERTY_EXECUTOR), ParallelForestTraversalExecutor.class);
+        } else {
+            throw new IllegalArgumentException("Unsupported executor type " + type.getTypeName());
+        }
+        return executor;
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/serialize/RandomAdapter.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/RandomAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.lang.reflect.Type;
+import java.util.Random;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+/**
+ * Adapter for customizing {@link Random} serialization.
+ *
+ * {@link Random} states are not preserved during serialization and are always re-created, seeded with system time.
+ */
+public class RandomAdapter implements JsonSerializer<Random>, JsonDeserializer<Random> {
+
+    private Random rng = new Random();
+
+    @Override
+    public JsonElement serialize(Random src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonObject();
+    }
+
+    @Override
+    public Random deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        return new Random(rng.nextLong());
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestAdapter.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestAdapter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.lang.reflect.Type;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.google.gson.InstanceCreator;
+
+/**
+ * Adapter for customizing {@link RandomCutForest} serialization.
+ */
+public class RandomCutForestAdapter implements InstanceCreator<RandomCutForest> {
+
+    @Override
+    public RandomCutForest createInstance(Type type) {
+        return RandomCutForest.defaultForest(1);
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.amazon.randomcutforest.AbstractForestTraversalExecutor;
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.TreeUpdater;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import com.amazon.randomcutforest.tree.Node;
+
+/**
+ * {@link RandomCutForest} serialization.
+ */
+public class RandomCutForestSerDe {
+
+    private final Gson gson;
+
+    /**
+     * Constructor instantiating objects for default serialization.
+     */
+    public RandomCutForestSerDe() {
+        Set<Class<?>> serializationSkipClasses = Stream
+            .of(BiFunction.class, Node.class, ForkJoinPool.class)
+            .collect(Collectors.toSet());
+        this.gson = new GsonBuilder()
+            .addSerializationExclusionStrategy(
+                new ExclusionStrategy() {
+                    @Override
+                    public boolean shouldSkipClass(Class<?> clazz) {
+                        return serializationSkipClasses.contains(clazz);
+                    }
+
+                    @Override
+                    public boolean shouldSkipField(FieldAttributes field) {
+                        return false;
+                    }
+                }
+            )
+            .registerTypeAdapter(TreeUpdater.class, new TreeUpdaterAdapter())
+            .registerTypeAdapter(AbstractForestTraversalExecutor.class, new AbstractForestTraversalExecutorAdapter())
+            .registerTypeAdapter(RandomCutForest.class, new RandomCutForestAdapter())
+            .registerTypeAdapter(Random.class, new RandomAdapter())
+            .create();
+    }
+
+    /**
+     * Serializes a RCF object to a json string.
+     *
+     * @param rcf a RCF object
+     * @return a json string serialized from the RCF
+     */
+    public String toJson(RandomCutForest rcf) {
+        return gson.toJson(rcf);
+    }
+
+    /**
+     * Deserializes a serialized RCF json string to a RCF object.
+     *
+     * @param json a json string serialized from a RCF
+     * @return a RCF deserialized from the string
+     */
+    public RandomCutForest fromJson(String json) {
+        return gson.fromJson(json, RandomCutForest.class);
+    }
+}

--- a/src/main/java/com/amazon/randomcutforest/serialize/TreeUpdaterAdapter.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/TreeUpdaterAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.lang.reflect.Type;
+import java.util.Comparator;
+import java.util.List;
+
+import com.amazon.randomcutforest.TreeUpdater;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+
+import com.amazon.randomcutforest.sampler.WeightedPoint;
+
+/**
+ * Adapter for customizing {@link TreeUpdater} serialization.
+ */
+public class TreeUpdaterAdapter implements JsonDeserializer<TreeUpdater> {
+
+    @Override
+    public TreeUpdater deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        TreeUpdater treeUpdater = new Gson().fromJson(json, TreeUpdater.class);
+        List<WeightedPoint> points = treeUpdater.getSampler().getWeightedSamples();
+        points.sort(Comparator.comparingLong(WeightedPoint::getSequenceIndex));
+        points.stream().forEachOrdered(point -> treeUpdater.getTree().addPoint(point));
+        return treeUpdater;
+    }
+}

--- a/src/test/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapterTests.java
+++ b/src/test/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapterTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.AbstractForestTraversalExecutor;
+import com.amazon.randomcutforest.MultiVisitor;
+import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.returntypes.ConvergingAccumulator;
+import com.amazon.randomcutforest.tree.RandomCutTree;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AbstractForestTraversalExecutorAdapterTests {
+
+    private AbstractForestTraversalExecutorAdapter adapter = new AbstractForestTraversalExecutorAdapter();
+
+    @Test
+    public void serialize_throw_onUnknownExecutor() {
+        assertThrows(RuntimeException.class, () -> {
+            adapter.serialize(new AbstractForestTraversalExecutor(null) {
+
+                @Override
+                protected void update(double[] pointCopy, long entriesSeen) {
+                }
+
+                @Override
+                public <R, S> S traverseForest(double[] point, Function<RandomCutTree, Visitor<R>> visitorFactory, BinaryOperator<R> accumulator, Function<R, S> finisher) {
+                    return null;
+                }
+
+                @Override
+                public <R, S> S traverseForest(double[] point, Function<RandomCutTree, Visitor<R>> visitorFactory, Collector<R, ?, S> collector) {
+                    return null;
+                }
+
+                @Override
+                public <R, S> S traverseForest(double[] point, Function<RandomCutTree, Visitor<R>> visitorFactory, ConvergingAccumulator<R> accumulator, Function<R, S> finisher) {
+                    return null;
+                }
+
+                @Override
+                public <R, S> S traverseForestMulti(double[] point, Function<RandomCutTree, MultiVisitor<R>> visitorFactory, BinaryOperator<R> accumulator, Function<R, S> finisher) {
+                    return null;
+                }
+
+                @Override
+                public <R, S> S traverseForestMulti(double[] point, Function<RandomCutTree, MultiVisitor<R>> visitorFactory, Collector<R, ?, S> collector) {
+                    return null;
+                }
+            }, String.class, null);
+        });
+    }
+
+    @Test
+    public void deserialize_throw_onUnknownExecutor() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(AbstractForestTraversalExecutorAdapter.PROPERTY_EXECUTOR_TYPE, "Unsupported");
+        assertThrows(RuntimeException.class, () -> {
+            adapter.deserialize(jsonObject, String.class, null);
+        });
+    }
+}

--- a/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
+++ b/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.amazon.randomcutforest.RandomCutForest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RandomCutForestSerDeTests {
+
+    private RandomCutForestSerDe serializer = new RandomCutForestSerDe();
+
+    @ParameterizedTest(name = "{index} => numDims={0}, numTrees={1}, numSamples={2}, numTrainSamples={3}, "
+        + "numTestSamples={4}, enableParallel={5}, numThreads={6}")
+    @CsvSource({
+        "1, 100, 256, 32, 1024, 0, 0",
+        "1, 100, 256, 256, 1024, 0, 0",
+        "1, 100, 256, 512, 1024, 0, 0",
+        "1, 100, 256, 1024, 1024, 0, 0",
+        "10, 100, 256, 32, 1024, 0, 0",
+        "10, 100, 256, 256, 1024, 0, 0",
+        "10, 100, 256, 512, 1024, 0, 0",
+        "10, 100, 256, 1024, 1024, 0, 0",
+        "1, 100, 256, 32, 1024, 1, 0",
+        "1, 100, 256, 256, 1024, 1, 1",
+        "1, 100, 256, 512, 1024, 1, 2",
+        "1, 100, 256, 1024, 1024, 1, 4",
+        "10, 100, 256, 32, 1024, 1, 0",
+        "10, 100, 256, 256, 1024, 1, 1",
+        "10, 100, 256, 512, 1024, 1, 2",
+        "10, 100, 256, 1024, 1024, 1, 4",
+    })
+    public void toJsonString(int numDims, int numTrees, int numSamples, int numTrainSamples, int numTestSamples, int enableParallel, int numThreads) {
+        RandomCutForest.Builder forestBuilder = RandomCutForest.builder()
+            .dimensions(numDims)
+            .numberOfTrees(numTrees)
+            .sampleSize(numSamples)
+            .randomSeed(0);
+        if (enableParallel == 0) {
+            forestBuilder.parallelExecutionEnabled(false);
+        }
+        if (numThreads > 0) {
+            forestBuilder.threadPoolSize(numThreads);
+        }
+        RandomCutForest forest = forestBuilder.build();
+
+        for (double[] point : generate(numTrainSamples, numDims)) {
+            forest.update(point);
+        }
+
+        String json = serializer.toJson(forest);
+        RandomCutForest reForest = serializer.fromJson(json);
+
+        double delta = Math.log(numSamples) / Math.log(2) * 0.05;
+        for (double[] point : generate(numTestSamples, numDims)) {
+            assertEquals(forest.getAnomalyScore(point), reForest.getAnomalyScore(point), delta);
+            forest.update(point);
+            reForest.update(point);
+        }
+    }
+
+    private double[][] generate(int numSamples, int numDimensions) {
+        return IntStream.range(0, numSamples)
+            .mapToObj(i -> new Random().doubles(numDimensions).toArray())
+            .toArray(double[][]::new);
+    }
+}


### PR DESCRIPTION
This pr supports rcf serialization using json format.

An API example:
```
RandomCutForestSerDe rcfSerde = new RandomCutForestSerDe();
String json = rcfSerde.toJson(forest);
RandomCutForest reForest = rcfSerde.fromJson(json);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
