### PR TITLE
Fix random cuts on small bounding boxes.

### DIFF
--- a/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -131,7 +131,11 @@ public class RandomCutTree {
         for (int i = 0; i < box.getDimensions(); i++) {
             double range = box.getRange(i);
             if (breakPoint <= range) {
-                return new Cut(i, box.getMinValue(i) + breakPoint);
+                double cutValue = box.getMinValue(i) + breakPoint;
+                if ((cutValue == box.getMaxValue(i)) && (box.getMinValue(i) < box.getMaxValue(i))) {
+                    cutValue = Math.nextAfter(box.getMaxValue(i), box.getMinValue(i));
+                }
+                return new Cut(i, cutValue);
             }
             breakPoint -= range;
         }

--- a/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -649,4 +649,25 @@ public class RandomCutForestTest {
         assertThat(neighbors.get(1).sequenceIndexes, is(expectedIndexes));
     }
 
+    @Test
+    public void testUpdateOnSmallBoundingBox() {
+        // verifies on small bounding boxes random cuts and tree updates are functional
+        RandomCutForest.Builder forestBuilder = RandomCutForest.builder()
+            .dimensions(1)
+            .numberOfTrees(1)
+            .sampleSize(2)
+            .lambda(0.5)
+            .randomSeed(0)
+            .parallelExecutionEnabled(false);
+
+       RandomCutForest forest = forestBuilder.build();
+       double[][] data = new double[][] {
+           {48.08}
+           ,{48.08000000000001}
+       };
+
+       for (int i = 0; i < 20000; i++) {
+           forest.update(data[i % data.length]);
+       }
+    }
 }

--- a/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
+++ b/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
@@ -457,4 +457,23 @@ public class RandomCutTreeTest {
         assertNotEquals(cut1.getDimension(), cut3.getDimension());
         assertNotEquals(cut1.getDimension(), cut3.getDimension());
     }
+
+    @Test
+    public void testUpdatesOnSmallBoundingBox() {
+        // verifies on small bounding boxes random cuts and tree updates are functional
+        RandomCutTree tree = RandomCutTree.defaultTree();
+
+        WeightedPoint[] points = new WeightedPoint[] {
+            new WeightedPoint(new double[] {48.08}, 1L, 0),
+            new WeightedPoint(new double[] {48.08000000000001}, 2L, 0) };
+
+        tree.addPoint(points[0]);
+        tree.addPoint(points[1]);
+
+        for (int i = 0; i < 10000; i++) {
+            WeightedPoint point = points[i % points.length];
+            tree.deletePoint(point);
+            tree.addPoint(point);
+        }
+    }
 }


### PR DESCRIPTION
When a bounding box is small, a random cut might fall on the max of the range and not separate the bounding box. This pr decreases the cut value in the slightest way so that the bounding box can be cut into two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
