### PR TITLE
Add unit test coverage to RandomCutForest

### DIFF
--- a/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -652,8 +652,12 @@ public class RandomCutForest {
      * @return a forecasted time series.
      */
     public double[] extrapolateBasic(double[] point, int horizon, int blockSize, boolean cyclic, int shingleIndex) {
-        checkArgument(blockSize < dimensions && dimensions % blockSize == 0,
+        checkArgument(0 < blockSize && blockSize < dimensions,
+                "blockSize must be between 0 and dimensions (exclusive)");
+        checkArgument(dimensions % blockSize == 0,
             "dimensions must be evenly divisible by blockSize");
+        checkArgument(0 <= shingleIndex && shingleIndex <  dimensions / blockSize,
+                "shingleIndex must be between 0 (inclusive) and dimensions / blockSize");
 
         double[] result = new double[blockSize * horizon];
         int[] missingIndexes = new int[blockSize];


### PR DESCRIPTION
Add missing unit tests to cover extrapolation, near neighbors, samplers
full, and total updates.

This commit also adds new checks to extrapolateBasic to validate the
shingleIndex value. In a cyclic shingle, the shingle index refers to the
position in the shingle where the next "raw" input point should be
written. In terms of extrapolateBasic arguments, the shingle index
should be a value between 0 (inclusive) and dimensions / blockSize
(exclusive).

Closes #10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
