### PR TITLE
Add JMH microbenchmarks to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Build a local archive by running the Maven package command.
 You can then invoke an example CLI application by adding the resulting jar file to your classpath. For example:
 
 ```text
-% java -cp target/random-cut-forest-1.0.jar com.amazon.com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
-Usage: java -cp RandomCutForest-1.0-super.jar com.amazon.com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
+% java -cp target/random-cut-forest-1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
+Usage: java -cp RandomCutForest-1.0-super.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
 
 Compute scalar anomaly scores from the input rows and append them to the output rows.
 
@@ -165,7 +165,8 @@ To invoke the full benchmark suite:
 % java -jar target/random-cut-forest-1.0-benchmarks.jar
 ```
 
-You can also pass a regex at the command-line to filter which benchmarks are run:
+The full benchmark suite takes a long time to run. You can also pass a regex at the command-line, then only matching
+benchmark methods will be executed.
 
 ```text
 % java -jar target/random-cut-forest-1.0-benchmarks.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Random Cut Forest
 
-This package is an implementation of the Random Cut Forest probabilistic data 
-structure. Random Cut Forests (RCFs) were originally developed at Amazon to use in an
-anomaly detection algorithm. After anomaly detection was launched, new 
-algorithms based on RCFs were developed for density estimation, imputation,
-and forecasting. The goal of this library is to be easy to use and to strike
-a balance between efficiency and extensibility.
+This package is an implementation of the Random Cut Forest probabilistic data structure. Random Cut Forests (RCFs) were 
+originally developed at Amazon to use in a nonparametric anomaly detection algorithm for streaming data. Later new 
+algorithms based on RCFs were developed for density estimation, imputation, and forecasting. The goal of this library 
+is to be easy to use and to strike a balance between efficiency and extensibility.
 
-The public interface to this package is the RandomCutForest class, which 
-defines methods for anomaly detection, anomaly detection with attribution,
-density estimation, imputation, and forecasting.
+The public interface to this package is the RandomCutForest class, which defines methods for anomaly detection, anomaly 
+detection with attribution, density estimation, imputation, and forecasting.
 
 ## Limitations
 
@@ -109,8 +106,8 @@ Build a local archive by running the Maven package command.
 You can then invoke an example CLI application by adding the resulting jar file to your classpath. For example:
 
 ```text
-% java -cp target/random-cut-forest-1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
-Usage: java -cp RandomCutForest-1.0-super.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
+% java -cp target/random-cut-forest-1.0.jar com.amazon.com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
+Usage: java -cp RandomCutForest-1.0-super.jar com.amazon.com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
 
 Compute scalar anomaly scores from the input rows and append them to the output rows.
 
@@ -152,6 +149,27 @@ test contributions. After running tests with Maven, you can see the test coverag
 
 Our tests are implemented in [JUnit 5](https://junit.org/junit5/) with [Mockito](https://site.mockito.org/), [Powermock](https://github.com/powermock/powermock), and [Hamcrest](http://hamcrest.org/) for testing. 
 Test dependencies will be downloaded automatically when invoking `mvn test` or `mvn package`.
+
+## Benchmarks
+
+This package includes [JMH](https://openjdk.java.net/projects/code-tools/jmh/) microbenchmarks. Build an executable
+jar containing the benchmark code by running
+
+```text
+% mvn package assembly:single -DexcludedGroups=functional
+```
+
+To invoke the full benchmark suite:
+
+```text
+% java -jar target/random-cut-forest-1.0-benchmarks.jar
+```
+
+You can also pass a regex at the command-line to filter which benchmarks are run:
+
+```text
+% java -jar target/random-cut-forest-1.0-benchmarks.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
+```
 
 ## Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.22</jmh.version>
     </properties>
 
     <dependencies>
@@ -51,6 +52,18 @@
             <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -82,6 +95,39 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/benchmarks</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/benchmarks.xml</descriptor>
+                    </descriptors>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.openjdk.jmh.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/assembly/benchmarks.xml
+++ b/src/assembly/benchmarks.xml
@@ -1,0 +1,43 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>benchmarks</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory/>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        <excludes>
+            <exclude>org.junit.jupiter:junit-jupiter-engine</exclude>
+            <exclude>org.junit.jupiter:junit-jupiter-params</exclude>
+            <exclude>org.hamcrest:hamcrest</exclude>
+            <exclude>org.mockito:mockito-all</exclude>
+            <exclude>org.powermock:powermock-api-easymock</exclude>
+        </excludes>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/classes</directory>
+            <outputDirectory/>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory/>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>
+

--- a/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-@Warmup(iterations = 10)
+@Warmup(iterations = 5)
 @Measurement(iterations = 10)
 @Fork(value = 1)
 @State(Scope.Benchmark)
@@ -40,14 +40,11 @@ public class RandomCutForestBenchmark {
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
-        @Param({"1", "8", "64"})
+        @Param({"1", "16", "256"})
         int dimensions;
 
         @Param({"50", "100"})
         int numberOfTrees;
-
-        @Param({"256"})
-        int sampleSize;
 
         @Param({"false", "true"})
         boolean parallelExecutionEnabled;
@@ -65,7 +62,6 @@ public class RandomCutForestBenchmark {
         public void setUpForest() {
             forest = RandomCutForest.builder()
                     .numberOfTrees(numberOfTrees)
-                    .sampleSize(sampleSize)
                     .dimensions(dimensions)
                     .parallelExecutionEnabled(parallelExecutionEnabled)
                     .randomSeed(99)

--- a/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest;
+
+import com.amazon.randomcutforest.returntypes.DensityOutput;
+import com.amazon.randomcutforest.returntypes.DiVector;
+import com.amazon.randomcutforest.util.NormalMixtureTestData;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class RandomCutForestBenchmark {
+
+    public final static int DATA_SIZE = 50_000;
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        @Param({"1", "8", "64"})
+        int dimensions;
+
+        @Param({"50", "100"})
+        int numberOfTrees;
+
+        @Param({"256"})
+        int sampleSize;
+
+        @Param({"false", "true"})
+        boolean parallelExecutionEnabled;
+
+        double[][] data;
+        RandomCutForest forest;
+
+        @Setup(Level.Trial)
+        public void setUpData() {
+            NormalMixtureTestData testData = new NormalMixtureTestData();
+            data = testData.generateTestData(DATA_SIZE, dimensions);
+        }
+
+        @Setup(Level.Iteration)
+        public void setUpForest() {
+            forest = RandomCutForest.builder()
+                    .numberOfTrees(numberOfTrees)
+                    .sampleSize(sampleSize)
+                    .dimensions(dimensions)
+                    .parallelExecutionEnabled(parallelExecutionEnabled)
+                    .randomSeed(99)
+                    .build();
+        }
+    }
+
+    private RandomCutForest forest;
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_SIZE)
+    public RandomCutForest updateOnly(BenchmarkState state) {
+        double[][] data = state.data;
+        forest = state.forest;
+
+        for (int i = 0; i < data.length; i++) {
+            forest.update(data[i]);
+        }
+
+        return forest;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_SIZE)
+    public RandomCutForest updateAndGetAnomalyScore(BenchmarkState state, Blackhole blackhole) {
+        double[][] data = state.data;
+        forest = state.forest;
+        double score = 0.0;
+
+        for (int i = 0; i < data.length; i++) {
+            score = forest.getAnomalyScore(data[i]);
+            forest.update(data[i]);
+        }
+
+        blackhole.consume(score);
+        return forest;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_SIZE)
+    public RandomCutForest updateAndGetAnomalyAttribution(BenchmarkState state, Blackhole blackhole) {
+        double[][] data = state.data;
+        forest = state.forest;
+        DiVector vector = new DiVector(forest.getDimensions());
+
+        for (int i = 0; i < data.length; i++) {
+            vector = forest.getAnomalyAttribution(data[i]);
+            forest.update(data[i]);
+        }
+
+        blackhole.consume(vector);
+        return forest;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_SIZE)
+    public RandomCutForest updateAndGetBasicDensity(BenchmarkState state, Blackhole blackhole) {
+        double[][] data = state.data;
+        forest = state.forest;
+        DensityOutput output = new DensityOutput(forest.getDimensions(), forest.getSampleSize());
+
+        for (int i = 0; i < data.length; i++) {
+            output = forest.getSimpleDensity(data[i]);
+            forest.update(data[i]);
+        }
+
+        blackhole.consume(output);
+        return forest;
+    }
+}

--- a/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-@Warmup(iterations = 10)
+@Warmup(iterations = 5)
 @Measurement(iterations = 10)
 @Fork(value = 1)
 @State(Scope.Benchmark)
@@ -41,20 +41,14 @@ public class TreeUpdaterBenchmark {
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
-        @Param({"1", "8", "64"})
+        @Param({"1", "16", "256"})
         int dimensions;
-
-        @Param({"256"})
-        int sampleSize;
 
         @Param({"0.0", "1e-5"})
         double lambda;
 
         @Param({"false", "true"})
         boolean storeSequenceIndexesEnabled;
-
-        @Param({"false", "true"})
-        boolean centerOfMassEnabled;
 
         double[][] data;
         TreeUpdater treeUpdater;
@@ -67,11 +61,10 @@ public class TreeUpdaterBenchmark {
 
         @Setup(Level.Iteration)
         public void setUpTree() {
-            SimpleStreamSampler sampler = new SimpleStreamSampler(sampleSize, lambda, 99);
+            SimpleStreamSampler sampler = new SimpleStreamSampler(RandomCutForest.DEFAULT_SAMPLE_SIZE, lambda, 99);
             RandomCutTree tree = RandomCutTree.builder()
                     .randomSeed(101)
                     .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled)
-                    .centerOfMassEnabled(centerOfMassEnabled)
                     .build();
             treeUpdater = new TreeUpdater(sampler, tree);
         }

--- a/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
@@ -50,8 +50,7 @@ public class TreeUpdaterBenchmark {
         @Param({"0.0", "1e-5"})
         double lambda;
 
-        // @Param({"false", "true"})
-        @Param({"true"})
+        @Param({"false", "true"})
         boolean storeSequenceIndexesEnabled;
 
         @Param({"false", "true"})

--- a/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest;
+
+import java.util.Arrays;
+
+import com.amazon.randomcutforest.sampler.SimpleStreamSampler;
+import com.amazon.randomcutforest.tree.RandomCutTree;
+import com.amazon.randomcutforest.util.NormalMixtureTestData;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class TreeUpdaterBenchmark {
+
+    public static final int DATA_SIZE = 50_000;
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        @Param({"1", "8", "64"})
+        int dimensions;
+
+        @Param({"256"})
+        int sampleSize;
+
+        @Param({"0.0", "1e-5"})
+        double lambda;
+
+        // @Param({"false", "true"})
+        @Param({"true"})
+        boolean storeSequenceIndexesEnabled;
+
+        @Param({"false", "true"})
+        boolean centerOfMassEnabled;
+
+        double[][] data;
+        TreeUpdater treeUpdater;
+
+        @Setup(Level.Trial)
+        public void setUpData() {
+            NormalMixtureTestData testData = new NormalMixtureTestData();
+            data = testData.generateTestData(DATA_SIZE, dimensions);
+        }
+
+        @Setup(Level.Iteration)
+        public void setUpTree() {
+            SimpleStreamSampler sampler = new SimpleStreamSampler(sampleSize, lambda, 99);
+            RandomCutTree tree = RandomCutTree.builder()
+                    .randomSeed(101)
+                    .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled)
+                    .centerOfMassEnabled(centerOfMassEnabled)
+                    .build();
+            treeUpdater = new TreeUpdater(sampler, tree);
+        }
+    }
+
+    private TreeUpdater tree;
+
+    @Benchmark
+    @OperationsPerInvocation(DATA_SIZE)
+    public TreeUpdater update(BenchmarkState state) {
+        double[][] data = state.data;
+        tree = state.treeUpdater;
+        long entriesSeen = 0;
+
+        for (int i = 0; i < data.length; i++) {
+            try {
+                tree.update(data[i], ++entriesSeen);
+            } catch (Exception e) {
+                System.out.println("Point = " + Arrays.toString(data[i]));
+                System.out.println("Sequence Index = " + entriesSeen);
+                throw e;
+            }
+        }
+
+        return tree;
+    }
+}


### PR DESCRIPTION
This commit adds the bencmarking code and Maven configuration to build
and run benchmarks. The README is updated with instructions.

Closes #15 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
