### PR TITLE
Update scope/lifetime of benchmark state

### DIFF
--- a/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/RandomCutForestBenchmark.java
@@ -33,7 +33,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
 @Fork(value = 1)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class RandomCutForestBenchmark {
 
     public final static int DATA_SIZE = 50_000;
@@ -58,7 +58,7 @@ public class RandomCutForestBenchmark {
             data = testData.generateTestData(DATA_SIZE, dimensions);
         }
 
-        @Setup(Level.Iteration)
+        @Setup(Level.Invocation)
         public void setUpForest() {
             forest = RandomCutForest.builder()
                     .numberOfTrees(numberOfTrees)

--- a/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
+++ b/src/test/benchmarks/com/amazon/randomcutforest/TreeUpdaterBenchmark.java
@@ -39,7 +39,7 @@ public class TreeUpdaterBenchmark {
 
     public static final int DATA_SIZE = 50_000;
 
-    @State(Scope.Benchmark)
+    @State(Scope.Thread)
     public static class BenchmarkState {
         @Param({"1", "16", "256"})
         int dimensions;
@@ -59,7 +59,7 @@ public class TreeUpdaterBenchmark {
             data = testData.generateTestData(DATA_SIZE, dimensions);
         }
 
-        @Setup(Level.Iteration)
+        @Setup(Level.Invocation)
         public void setUpTree() {
             SimpleStreamSampler sampler = new SimpleStreamSampler(RandomCutForest.DEFAULT_SAMPLE_SIZE, lambda, 99);
             RandomCutTree tree = RandomCutTree.builder()
@@ -80,13 +80,7 @@ public class TreeUpdaterBenchmark {
         long entriesSeen = 0;
 
         for (int i = 0; i < data.length; i++) {
-            try {
-                tree.update(data[i], ++entriesSeen);
-            } catch (Exception e) {
-                System.out.println("Point = " + Arrays.toString(data[i]));
-                System.out.println("Sequence Index = " + entriesSeen);
-                throw e;
-            }
+            tree.update(data[i], ++entriesSeen);
         }
 
         return tree;


### PR DESCRIPTION
Benchmark state objects are now created per thread, and the setup of
forests and trees is done per benchmark method invocation.

Closes #17 

It seems that the issue with the TreeUpdater benchmark is that it was re-using the same tree. This resulted in the same point value with the same sequence index being added to a tree multiple times. The exception thrown by the benchmark runs is the correct behavior in that situation. This pull request changes the the benchmark state setup to create new test objects per thread and per benchmark method invocation. 

http://tutorials.jenkov.com/java-performance/jmh.html#benchmark-state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
