### PR TITLE
support binary serialization with ion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-ion</artifactId>
+            <version>2.8.10</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.ion</groupId>
+            <artifactId>ion-java</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.5.2</version>

--- a/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
@@ -15,6 +15,8 @@
 
 package com.amazon.randomcutforest.serialize;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
@@ -22,9 +24,17 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import software.amazon.ion.system.IonBinaryWriterBuilder;
+import software.amazon.ion.system.IonReaderBuilder;
+import software.amazon.ion.system.IonTextWriterBuilder;
+import software.amazon.ion.IonException;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonWriter;
 import com.amazon.randomcutforest.AbstractForestTraversalExecutor;
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.TreeUpdater;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.ion.IonObjectMapper;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
@@ -78,6 +88,29 @@ public class RandomCutForestSerDe {
     }
 
     /**
+     * Serializes a RCF object to ion binary.
+     *
+     * @param rcf a RCF object
+     * @return ion binary serialized from the RCF
+     * @throws IonException when the input cannot be serialized
+     */
+    public byte[] toIon(RandomCutForest rcf) {
+        try {
+            IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+            IonReader reader = readerBuilder.build(toJson(rcf));
+            IonObjectMapper mapper = new IonObjectMapper();
+            mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+            SerializedRandomCutForest srcf = mapper.readValue(reader, SerializedRandomCutForest.class);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IonWriter ionWriter = IonBinaryWriterBuilder.standard().build(out);
+            mapper.writeValue(ionWriter, srcf);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IonException(e);
+        }
+    }
+
+    /**
      * Deserializes a serialized RCF json string to a RCF object.
      *
      * @param json a json string serialized from a RCF
@@ -85,5 +118,28 @@ public class RandomCutForestSerDe {
      */
     public RandomCutForest fromJson(String json) {
         return gson.fromJson(json, RandomCutForest.class);
+    }
+
+    /**
+     * Deserializes a serialized RCF ion binary to a RCF object.
+     *
+     * @param ionBinary ion binary serialized from a RCF
+     * @return a RCF deserialized from the byte array
+     * @throws IonException when the input cannot be deserialized
+     */
+    public RandomCutForest fromIon(byte[] ionBinary) {
+        try {
+            IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+            IonReader reader = readerBuilder.build(ionBinary);
+            IonObjectMapper mapper = new IonObjectMapper();
+            mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+            SerializedRandomCutForest srcf = mapper.readValue(reader, SerializedRandomCutForest.class);
+            StringBuilder out = new StringBuilder();
+            IonWriter ionWriter = IonTextWriterBuilder.json().build(out);
+            mapper.writeValue(ionWriter, srcf);
+            return gson.fromJson(out.toString(), RandomCutForest.class);
+        } catch (IOException e) {
+            throw new IonException(e);
+        }
     }
 }

--- a/src/main/java/com/amazon/randomcutforest/serialize/SerializedRandomCutForest.java
+++ b/src/main/java/com/amazon/randomcutforest/serialize/SerializedRandomCutForest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.serialize;
+
+/**
+ * Serialized RCF for internal use only.
+ */
+public class SerializedRandomCutForest {
+
+    public Random getRng() {
+        return rng;
+    }
+
+    public void setRng(Random rng) {
+        this.rng = rng;
+    }
+
+    public int getDimensions() {
+        return dimensions;
+    }
+
+    public void setDimensions(int dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public int getSampleSize() {
+        return sampleSize;
+    }
+
+    public void setSampleSize(int sampleSize) {
+        this.sampleSize = sampleSize;
+    }
+
+    public int getOutputAfter() {
+        return outputAfter;
+    }
+
+    public void setOutputAfter(int outputAfter) {
+        this.outputAfter = outputAfter;
+    }
+
+    public int getNumberOfTrees() {
+        return numberOfTrees;
+    }
+
+    public void setNumberOfTrees(int numberOfTrees) {
+        this.numberOfTrees = numberOfTrees;
+    }
+
+    public double getLambda() {
+        return lambda;
+    }
+
+    public void setLambda(double lambda) {
+        this.lambda = lambda;
+    }
+
+    public boolean isStoreSequenceIndexesEnabled() {
+        return storeSequenceIndexesEnabled;
+    }
+
+    public void setStoreSequenceIndexesEnabled(boolean storeSequenceIndexesEnabled) {
+        this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
+    }
+
+    public boolean isCenterOfMassEnabled() {
+        return centerOfMassEnabled;
+    }
+
+    public void setCenterOfMassEnabled(boolean centerOfMassEnabled) {
+        this.centerOfMassEnabled = centerOfMassEnabled;
+    }
+
+    public boolean isParallelExecutionEnabled() {
+        return parallelExecutionEnabled;
+    }
+
+    public void setParallelExecutionEnabled(boolean parallelExecutionEnabled) {
+        this.parallelExecutionEnabled = parallelExecutionEnabled;
+    }
+
+    public int getThreadPoolSize() {
+        return threadPoolSize;
+    }
+
+    public void setThreadPoolSize(int threadPoolSize) {
+        this.threadPoolSize = threadPoolSize;
+    }
+
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    public void setExecutor(Executor executor) {
+        this.executor = executor;
+    }
+
+    private static class Random {
+    }
+
+    private static class Tree {
+        private boolean storeSequenceIndexesEnabled;
+        private boolean centerOfMassEnabled;
+        private Random random;
+
+        public boolean isStoreSequenceIndexesEnabled() {
+            return storeSequenceIndexesEnabled;
+        }
+
+        public void setStoreSequenceIndexesEnabled(boolean storeSequenceIndexesEnabled) {
+            this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
+        }
+
+        public boolean isCenterOfMassEnabled() {
+            return centerOfMassEnabled;
+        }
+
+        public void setCenterOfMassEnabled(boolean centerOfMassEnabled) {
+            this.centerOfMassEnabled = centerOfMassEnabled;
+        }
+
+        public Random getRandom() {
+            return random;
+        }
+
+        public void setRandom(Random random) {
+            this.random = random;
+        }
+    }
+
+    private static class WeightedSamples {
+        private double[] point;
+        private double weight;
+        private long sequenceIndex;
+
+        public double[] getPoint() {
+            return point;
+        }
+
+        public void setPoint(double[] point) {
+            this.point = point;
+        }
+
+        public double getWeight() {
+            return weight;
+        }
+
+        public void setWeight(double weight) {
+            this.weight = weight;
+        }
+
+        public long getSequenceIndex() {
+            return sequenceIndex;
+        }
+
+        public void setSequenceIndex(long sequenceIndex) {
+            this.sequenceIndex = sequenceIndex;
+        }
+    }
+
+    private static class Sampler {
+        private WeightedSamples[] weightedSamples;
+        private int sampleSize;
+        private double lambda;
+        private Random random;
+        private long entriesSeen;
+
+        public WeightedSamples[] getWeightedSamples() {
+            return weightedSamples;
+        }
+
+        public void setWeightedSamples(WeightedSamples[] weightedSamples) {
+            this.weightedSamples = weightedSamples;
+        }
+
+        public int getSampleSize() {
+            return sampleSize;
+        }
+
+        public void setSampleSize(int sampleSize) {
+            this.sampleSize = sampleSize;
+        }
+
+        public double getLambda() {
+            return lambda;
+        }
+
+        public void setLambda(double lambda) {
+            this.lambda = lambda;
+        }
+
+        public Random getRandom() {
+            return random;
+        }
+
+        public void setRandom(Random random) {
+            this.random = random;
+        }
+
+        public long getEntriesSeen() {
+            return entriesSeen;
+        }
+
+        public void setEntriesSeen(long entriesSeen) {
+            this.entriesSeen = entriesSeen;
+        }
+    }
+
+    private static class TreeUpdater {
+        public Sampler getSampler() {
+            return sampler;
+        }
+
+        public void setSampler(Sampler sampler) {
+            this.sampler = sampler;
+        }
+
+        public Tree getTree() {
+            return tree;
+        }
+
+        public void setTree(Tree tree) {
+            this.tree = tree;
+        }
+
+        private Sampler sampler;
+        private Tree tree;    
+    }
+
+    private static class Exec {
+        private TreeUpdater[] treeUpdaters;
+        private long totalUpdates;
+        private int threadPoolSize;
+
+        public TreeUpdater[] getTreeUpdaters() {
+            return treeUpdaters;
+        }
+
+        public void setTreeUpdaters(TreeUpdater[] treeUpdaters) {
+            this.treeUpdaters = treeUpdaters;
+        }
+
+        public long getTotalUpdates() {
+            return totalUpdates;
+        }
+
+        public void setTotalUpdates(long totalUpdates) {
+            this.totalUpdates = totalUpdates;
+        }
+
+        public int getThreadPoolSize() {
+            return threadPoolSize;
+        }
+
+        public void setThreadPoolSize(int threadPoolSize) {
+            this.threadPoolSize = threadPoolSize;
+        }
+    }
+
+    private static class Executor {
+        private String executor_type;
+        private Exec executor;
+
+        public String getExecutor_type() {
+            return executor_type;
+        }
+
+        public void setExecutor_type(String executor_type) {
+            this.executor_type = executor_type;
+        }
+
+        public Exec getExecutor() {
+            return executor;
+        }
+
+        public void setExecutor(Exec executor) {
+            this.executor = executor;
+        }
+    }
+
+    private Random rng;
+    private int dimensions;
+    private int sampleSize;
+    private int outputAfter;
+    private int numberOfTrees;
+    private double lambda;
+    private boolean storeSequenceIndexesEnabled;
+    private boolean centerOfMassEnabled;
+    private boolean parallelExecutionEnabled;
+    private int threadPoolSize;
+    private Executor executor;
+}

--- a/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
+++ b/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
@@ -68,19 +68,23 @@ public class RandomCutForestSerDeTests {
         }
 
         String json = serializer.toJson(forest);
-        RandomCutForest reForest = serializer.fromJson(json);
+        RandomCutForest jsonForest = serializer.fromJson(json);
+        byte[] ion = serializer.toIon(forest);
+        RandomCutForest ionForest = serializer.fromIon(ion);
 
         double delta = Math.log(numSamples) / Math.log(2) * 0.05;
         for (double[] point : generate(numTestSamples, numDims)) {
-            assertEquals(forest.getAnomalyScore(point), reForest.getAnomalyScore(point), delta);
+            assertEquals(forest.getAnomalyScore(point), jsonForest.getAnomalyScore(point), delta);
+            assertEquals(forest.getAnomalyScore(point), ionForest.getAnomalyScore(point), delta);
             forest.update(point);
-            reForest.update(point);
+            jsonForest.update(point);
+            ionForest.update(point);
         }
     }
 
     private double[][] generate(int numSamples, int numDimensions) {
         return IntStream.range(0, numSamples)
-            .mapToObj(i -> new Random().doubles(numDimensions).toArray())
+            .mapToObj(i -> new Random(0L).doubles(numDimensions).toArray())
             .toArray(double[][]::new);
     }
 }


### PR DESCRIPTION
Current RCF serialization results are text json, which is less efficient than binary for storage. This change adds support for serialization into the [ion](https://github.com/amzn/ion-java/tree/master) binary format.

Experiments shows for the same model (100 trees, 256 samples, 1~10 dimension), binary format saves 57%~67% storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
