### PR TITLE
Update the maven group ID to include the project name

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.amazon</groupId>
+    <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -18,12 +18,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.amazon</groupId>
+      <groupId>software.amazon.randomcutforest</groupId>
       <artifactId>randomcutforest-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.amazon</groupId>
+      <groupId>software.amazon.randomcutforest</groupId>
       <artifactId>randomcutforest-testutils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.amazon</groupId>
+    <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -14,7 +14,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.amazon</groupId>
+      <groupId>software.amazon.randomcutforest</groupId>
       <artifactId>randomcutforest-testutils</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.amazon</groupId>
+    <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>

--- a/serialization-json/pom.xml
+++ b/serialization-json/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.amazon</groupId>
+    <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -14,7 +14,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.amazon</groupId>
+      <groupId>software.amazon.randomcutforest</groupId>
       <artifactId>randomcutforest-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
-    <groupId>com.amazon</groupId>
+    <groupId>software.amazon.randomcutforest</groupId>
     <version>${revision}</version>
   </parent>
 


### PR DESCRIPTION
Following AWS open source guidelines, include the project name as part
of the Maven group ID. Additionally, change the group ID namespace from
com.amazon to software.amazon, following current recommendations.

In all pom files, the group ID is changed from `com.amazon` to `software.amazon.randomcutforest`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
