### PR TITLE
Use explicit versions in submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,11 @@ delimited data, and as such are **not intended for production use**. Instead,
 use these applications as example code and as a way to learn about the
 algorithms and their hyperparameters.
 
-Build a local archive of the core library by running the Maven package command in the randomcutforest-core module.
+After building the project (described in the previous section), you can invoke an example CLI application by adding the
+core jar file to your classpath. For example:
 
 ```text
-% cd core
-% mvn package -DexcludedGroups=functional
-```
-
-You can then invoke an example CLI application by adding the resulting jar file to your classpath. For example:
-
-```text
-% java -cp target/randomcutforest-core-1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
+% java -cp core/target/randomcutforest-core-1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
 Usage: java -cp RandomCutForest-1.0-super.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
 
 Compute scalar anomaly scores from the input rows and append them to the output rows.
@@ -155,7 +149,11 @@ The benchmark modules defines microbenchmarks using the [JMH](https://openjdk.ja
 framework. Build an executable jar containing the benchmark code by running
 
 ```text
-% cd benchmark
+% # (Optional) To benchmark the code in your local repository, build and install to your local Maven repository
+% # Otherwise, benchmark dependencies will be pulled from Maven central
+% mvn package install -DexcludedGroups=functional
+% 
+$ cd benchmark
 % mvn package assembly:single
 ```
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0-alpha</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0-alpha</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,10 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0-alpha</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.0-alpha</revision>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/serialization-json/pom.xml
+++ b/serialization-json/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>${revision}</version>
+    <version>1.0-alpha</version>
   </parent>
 
   <artifactId>randomcutforest-serialization-json</artifactId>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>${revision}</version>
+    <version>1.0-alpha</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION
In #26 we follewed the guidance to create CI friendly verions [1] in our
submodules, but we weren't able to build the project locally with this
setup. This change reverts to using explicit version numbers in
submodules.

[1] http://maven.apache.org/maven-ci-friendly.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
