### PR TITLE
use fixed test data for serialization test

### DIFF
--- a/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
+++ b/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
@@ -65,7 +65,7 @@ public class RandomCutForestSerDeTests {
     }
 
     private double[][] generate(int numSamples, int numDimensions) {
-        return IntStream.range(0, numSamples).mapToObj(i -> new Random().doubles(numDimensions).toArray())
+        return IntStream.range(0, numSamples).mapToObj(i -> new Random(0L).doubles(numDimensions).toArray())
                 .toArray(double[][]::new);
     }
 }


### PR DESCRIPTION
#20 : Intermittent failure in RandomCutForestSerDeTests

This pr fixes the random seed used to generate test data so the test results are less randomized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
