### PR TITLE
use spotless for license header

### DIFF
--- a/core/src/main/java/com/amazon/randomcutforest/AbstractForestTraversalExecutor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/AbstractForestTraversalExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/CommonUtils.java
+++ b/core/src/main/java/com/amazon/randomcutforest/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/DynamicScoringRandomCutForest.java
+++ b/core/src/main/java/com/amazon/randomcutforest/DynamicScoringRandomCutForest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/MultiVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/MultiVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/ParallelForestTraversalExecutor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/ParallelForestTraversalExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/SequentialForestTraversalExecutor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/SequentialForestTraversalExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/TreeUpdater.java
+++ b/core/src/main/java/com/amazon/randomcutforest/TreeUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/Visitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AbstractAttributionVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AbstractAttributionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AbstractScalarScoreVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AbstractScalarScoreVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AnomalyAttributionVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AnomalyAttributionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AnomalyScoreVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/AnomalyScoreVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/DynamicAttributionVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/DynamicAttributionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/DynamicScoreVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/DynamicScoreVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/SimulatedTransductiveScalarScoreVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/SimulatedTransductiveScalarScoreVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest.anomalydetection;
 
 import java.util.function.BiFunction;

--- a/core/src/main/java/com/amazon/randomcutforest/anomalydetection/TransductiveScalarScoreVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/anomalydetection/TransductiveScalarScoreVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest.anomalydetection;
 
 import java.util.function.BiFunction;

--- a/core/src/main/java/com/amazon/randomcutforest/imputation/ImputeVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/imputation/ImputeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/inspect/NearNeighborVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/inspect/NearNeighborVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/interpolation/SimpleInterpolationVisitor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/interpolation/SimpleInterpolationVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/ConvergingAccumulator.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/ConvergingAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/DensityOutput.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/DensityOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/DiVector.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/DiVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/InterpolationMeasure.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/InterpolationMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/Neighbor.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/Neighbor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDiVectorAccumulator.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDiVectorAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDoubleAccumulator.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDoubleAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedStDevAccumulator.java
+++ b/core/src/main/java/com/amazon/randomcutforest/returntypes/OneSidedStDevAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/AnomalyAttributionRunner.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/AnomalyAttributionRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/AnomalyScoreRunner.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/AnomalyScoreRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/ImputeRunner.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/ImputeRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/LineTransformer.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/LineTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/SimpleDensityRunner.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/SimpleDensityRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/SimpleRunner.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/SimpleRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/runner/UpdateOnlyTransformer.java
+++ b/core/src/main/java/com/amazon/randomcutforest/runner/UpdateOnlyTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/sampler/WeightedPoint.java
+++ b/core/src/main/java/com/amazon/randomcutforest/sampler/WeightedPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/tree/BoundingBox.java
+++ b/core/src/main/java/com/amazon/randomcutforest/tree/BoundingBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/tree/Cut.java
+++ b/core/src/main/java/com/amazon/randomcutforest/tree/Cut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
+++ b/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest.tree;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;

--- a/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
+++ b/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/main/java/com/amazon/randomcutforest/util/ShingleBuilder.java
+++ b/core/src/main/java/com/amazon/randomcutforest/util/ShingleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/DynamicPointSetFunctionalTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/DynamicPointSetFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/ForestTraversalExecutorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/ForestTraversalExecutorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest;
 
 import static com.amazon.randomcutforest.TestUtils.EPSILON;

--- a/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest;
 
 import static com.amazon.randomcutforest.TestUtils.EPSILON;

--- a/core/src/test/java/com/amazon/randomcutforest/TestUtils.java
+++ b/core/src/test/java/com/amazon/randomcutforest/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/TransductiveHyperForestFunctionalTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/TransductiveHyperForestFunctionalTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.randomcutforest;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;

--- a/core/src/test/java/com/amazon/randomcutforest/TreeUpdaterTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/TreeUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/anomalydetection/AnomalyAttributionVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/anomalydetection/AnomalyAttributionVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/anomalydetection/AnomalyScoreVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/anomalydetection/AnomalyScoreVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/anomalydetection/DynamicAttributionVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/anomalydetection/DynamicAttributionVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/anomalydetection/DynamicScoreVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/anomalydetection/DynamicScoreVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/imputation/ImputeVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/imputation/ImputeVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/inspect/NearNeighborVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/inspect/NearNeighborVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/interpolation/SimpleInterpolationVisitorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/interpolation/SimpleInterpolationVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/DensityOutputTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/DensityOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/DiVectorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/DiVectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/InterpolationMeasureTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/InterpolationMeasureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/NeighborTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/NeighborTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDiVectorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDiVectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDoubleAccumulatorTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/returntypes/OneSidedConvergingDoubleAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/AnomalyAttributionRunnerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/AnomalyAttributionRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/AnomalyScoreRunnerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/AnomalyScoreRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/ArgumentParserTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/ArgumentParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/ImputeRunnerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/ImputeRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/SimpleDensityRunnerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/SimpleDensityRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/runner/UpdateOnlyTransformerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/runner/UpdateOnlyTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/sampler/SimpleStreamSamplerTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/sampler/SimpleStreamSamplerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/sampler/WeightedPointTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/sampler/WeightedPointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/tree/BoundingBoxTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/tree/BoundingBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/tree/CutTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/tree/CutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/tree/NodeTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/tree/NodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/core/src/test/java/com/amazon/randomcutforest/util/ShingleBuilderTest.java
+++ b/core/src/test/java/com/amazon/randomcutforest/util/ShingleBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/license-header
+++ b/license-header
@@ -13,20 +13,4 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.randomcutforest.serialize;
 
-import java.lang.reflect.Type;
-
-import com.amazon.randomcutforest.RandomCutForest;
-import com.google.gson.InstanceCreator;
-
-/**
- * Adapter for customizing {@link RandomCutForest} serialization.
- */
-public class RandomCutForestAdapter implements InstanceCreator<RandomCutForest> {
-
-    @Override
-    public RandomCutForest createInstance(Type type) {
-        return RandomCutForest.defaultForest(1);
-    }
-}

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,9 @@
                 <version>1.31.0</version>
                 <configuration>
                     <java>
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/license-header</file>
+                        </licenseHeader>
                         <eclipse>
                             <file>${maven.multiModuleProjectDirectory}/spotless-eclipse.xml</file>
                         </eclipse>

--- a/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapter.java
+++ b/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/RandomAdapter.java
+++ b/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/RandomAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
+++ b/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/TreeUpdaterAdapter.java
+++ b/serialization-json/src/main/java/com/amazon/randomcutforest/serialize/TreeUpdaterAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapterTests.java
+++ b/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/AbstractForestTraversalExecutorAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
+++ b/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/testutils/src/main/java/com/amazon/randomcutforest/testutils/ExampleDataSets.java
+++ b/testutils/src/main/java/com/amazon/randomcutforest/testutils/ExampleDataSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/testutils/src/main/java/com/amazon/randomcutforest/testutils/NormalMixtureTestData.java
+++ b/testutils/src/main/java/com/amazon/randomcutforest/testutils/NormalMixtureTestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.


### PR DESCRIPTION
*Description of changes:* This pr uses spotless to update licence headers in source code files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
