### PR TITLE
Upgrade to powermock-api-easymock 2.0.7

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-easymock</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Closes #22

Upgrade to powermock-api-easymock 2.0.7 in order to fix failing tests occurring on OpenJDK13+ platform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
