### PR TITLE
Add maven release workflow

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,37 @@
+# This workflow will build a package using Maven and then publish it to
+# Maven central each time a release is created on github.
+
+name: Publish Maven Package
+
+defaults:
+  run:
+    working-directory: Java/
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: ossrh
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to Maven central
+      run: mvn deploy --file pom.xml
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+


### PR DESCRIPTION
This workflow will build a package using Maven and then publish it to Maven central each time a github release is created.

For the worflow to be successful, we need to store the maven credentials inside two github secret entries: `OSSRH_USERNAME` and `OSSRH_TOKEN`. I plan to create these entries after addressing comments on this PR.

To launch a new release (say x.y.z), we will roughly follow these steps:

```
git checkout -b x.y.z                   # create x.y.z branch
mvn versions:set -DnewVersion=x.y.z     # update all pom files to x.y.z
mvn package -DexcludedGroups=functional # make sure build is successful
git add .                               # keep track of changed pom files
git commit -m "Release RCF x.y.z"
git push -u origin x.y.z
```
Finally, we will create a new release using github's UX which will eventually trigger the maven release workflow and if all goes well publish the latest artifacts to maven central.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
