### PR TITLE
handle signed zeros in data points

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/AbstractForestTraversalExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/AbstractForestTraversalExecutor.java
@@ -47,7 +47,7 @@ public abstract class AbstractForestTraversalExecutor {
      */
     public void update(double[] point) {
         totalUpdates++;
-        double[] pointCopy = Arrays.copyOf(point, point.length);
+        double[] pointCopy = cleanCopy(point);
         update(pointCopy, totalUpdates);
     }
 
@@ -192,4 +192,22 @@ public abstract class AbstractForestTraversalExecutor {
      */
     public abstract <R, S> S traverseForestMulti(double[] point,
             Function<RandomCutTree, MultiVisitor<R>> visitorFactory, Collector<R, ?, S> collector);
+
+    /**
+     * Returns a clean deep copy of the point.
+     *
+     * Current clean-ups include changing negative zero -0.0 to positive zero 0.0.
+     *
+     * @param point The original data point.
+     * @return a clean deep copy of the original point.
+     */
+    protected double[] cleanCopy(double[] point) {
+        double[] pointCopy = Arrays.copyOf(point, point.length);
+        for (int i = 0; i < point.length; i++) {
+            if (pointCopy[i] == 0.0) {
+                pointCopy[i] = 0.0;
+            }
+        }
+        return pointCopy;
+    }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/ForestTraversalExecutorTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/ForestTraversalExecutorTest.java
@@ -94,6 +94,23 @@ public class ForestTraversalExecutorTest {
 
     @ParameterizedTest
     @ArgumentsSource(TestExecutorProvider.class)
+    public void testUpdateWithSignedZero(AbstractForestTraversalExecutor executor) {
+        double[] negativeZero = new double[] { -0.0, 0.0, 5.0 };
+        double[] positiveZero = new double[] { 0.0, 0.0, 5.0 };
+
+        executor.update(negativeZero);
+        for (TreeUpdater updater : executor.treeUpdaters) {
+            verify(updater, times(1)).update(positiveZero, 1);
+        }
+
+        executor.update(positiveZero);
+        for (TreeUpdater updater : executor.treeUpdaters) {
+            verify(updater, times(1)).update(positiveZero, 2);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestExecutorProvider.class)
     public void testTraverseForestBinaryAccumulator(AbstractForestTraversalExecutor executor) {
         double[] point = new double[] { 1.2, -3.4 };
         double expectedResult = 0.0;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
@@ -418,6 +418,20 @@ public class RandomCutForestFunctionalTest {
     }
 
     @Test
+    public void testUpdateWithSignedZeros() {
+        RandomCutForest forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(2).dimensions(1)
+                .randomSeed(randomSeed).centerOfMassEnabled(true).storeSequenceIndexesEnabled(true).build();
+
+        forest.update(new double[] { 0.0 });
+        forest.getAnomalyScore(new double[] { 0.0 });
+        forest.getAnomalyScore(new double[] { -0.0 });
+
+        forest.update(new double[] { -0.0 });
+        forest.getAnomalyScore(new double[] { 0.0 });
+        forest.getAnomalyScore(new double[] { -0.0 });
+    }
+
+    @Test
     public void testShadowBuffer() {
         /**
          * This test checks that the attribution *DOES NOT* change as a ratio as more


### PR DESCRIPTION
*Issue #47* 

*Description of changes:* This is a fix for the issue caused by signed zeros described in the issue. This change maps negative zeros to positive zeros before passing them down for sampling and updating. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
