### PR TITLE
Update GitHub workflow to use default branch name 'main'

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,7 @@ name: Java CI
 on:
   pull_request:
     branches: 
-      - master
+      - main
     paths:
       - Java/**
 


### PR DESCRIPTION
We recently updated our repository to change the name of the default branch to 'main' (#46). This change updates our GitHub build workflow accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
