### PR TITLE
Use floats instead of double in PointStore

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStore.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStore.java
@@ -21,7 +21,7 @@ import static com.amazon.randomcutforest.CommonUtils.checkState;
 import java.util.Arrays;
 
 /**
- * PointStore is a fixed size repository of points, where each point is a double
+ * PointStore is a fixed size repository of points, where each point is a float
  * array of a specified length. A PointStore counts references to points that
  * are added, and frees space internally when a given point is no longer in use.
  * The primary use of this store is to enable compression since the points in
@@ -33,7 +33,7 @@ import java.util.Arrays;
  */
 public class PointStore {
 
-    private final double[] store;
+    private final float[] store;
     private final int[] refCount;
     private final int[] freeBlockStack;
     private int freeBlockPointer;
@@ -52,7 +52,7 @@ public class PointStore {
 
         this.capacity = capacity;
         this.dimensions = dimensions;
-        store = new double[capacity * dimensions];
+        store = new float[capacity * dimensions];
         refCount = new int[capacity];
         freeBlockStack = new int[capacity];
 
@@ -102,7 +102,7 @@ public class PointStore {
      *                                  the point store's dimensions.
      * @throws IllegalStateException    if the point store is full.
      */
-    public int add(double[] point) {
+    public int add(float[] point) {
         checkArgument(point.length == dimensions, "point.length must be equal to dimensions");
         checkState(freeBlockPointer >= 0, "point store is full");
 
@@ -164,7 +164,7 @@ public class PointStore {
      * @throws IllegalArgumentException if the length of the point does not match
      *                                  the point store's dimensions.
      */
-    public boolean pointEquals(int index, double[] point) {
+    public boolean pointEquals(int index, float[] point) {
         checkValidIndex(index);
         checkArgument(point.length == dimensions, "point.length must be equal to dimensions");
 
@@ -187,7 +187,7 @@ public class PointStore {
      * @throws IllegalArgumentException if the current reference count for this
      *                                  index is nonpositive.
      */
-    public double[] get(int index) {
+    public float[] get(int index) {
         checkValidIndex(index);
         return Arrays.copyOfRange(store, index * dimensions, (index + 1) * dimensions);
     }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreTest.java
@@ -52,24 +52,24 @@ public class PointStoreTest {
 
     @Test
     public void testAdd() {
-        double[] point1 = { 1.2, -3.4 };
+        float[] point1 = { 1.2f, -3.4f };
         int offset1 = pointStore.add(point1);
         assertTrue(offset1 >= 0 && offset1 < capacity);
         assertEquals(1, pointStore.getRefCount(offset1));
         assertEquals(1, pointStore.size());
 
-        double[] retrievedPoint1 = pointStore.get(offset1);
+        float[] retrievedPoint1 = pointStore.get(offset1);
         assertNotSame(point1, retrievedPoint1);
         assertArrayEquals(point1, retrievedPoint1);
 
-        double[] point2 = { 111.2, -333.4 };
+        float[] point2 = { 111.2f, -333.4f };
         int offset2 = pointStore.add(point2);
         assertTrue(offset2 >= 0 && offset2 < capacity);
         assertEquals(1, pointStore.getRefCount(offset2));
         assertEquals(2, pointStore.size());
         assertNotEquals(offset1, offset2);
 
-        double[] retrievedPoint2 = pointStore.get(offset2);
+        float[] retrievedPoint2 = pointStore.get(offset2);
         assertNotSame(point2, retrievedPoint2);
         assertArrayEquals(point2, retrievedPoint2);
 
@@ -82,17 +82,17 @@ public class PointStoreTest {
     @Test
     public void testAddInvalid() {
         // invalid dimensions in point
-        assertThrows(IllegalArgumentException.class, () -> pointStore.add(new double[] { 1.1, -2.2, 3.3 }));
+        assertThrows(IllegalArgumentException.class, () -> pointStore.add(new float[] { 1.1f, -2.2f, 3.3f }));
 
         for (int i = 0; i < capacity; i++) {
-            double[] point = new double[dimensions];
-            point[0] = Math.random();
-            point[1] = Math.random();
+            float[] point = new float[dimensions];
+            point[0] = (float) Math.random();
+            point[1] = (float) Math.random();
             pointStore.add(point);
         }
 
         // point store is full
-        assertThrows(IllegalStateException.class, () -> pointStore.add(new double[] { 1.1, -2.2 }));
+        assertThrows(IllegalStateException.class, () -> pointStore.add(new float[] { 1.1f, -2.2f }));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class PointStoreTest {
 
     @Test
     public void testIncrementRefCount() {
-        double[] point = { 1.2, -3.4 };
+        float[] point = { 1.2f, -3.4f };
         int offset = pointStore.add(point);
         assertEquals(1, pointStore.getRefCount(offset));
 
@@ -119,7 +119,7 @@ public class PointStoreTest {
 
     @Test
     public void testDecrementRefCount() {
-        double[] point = { 1.2, -3.4 };
+        float[] point = { 1.2f, -3.4f };
         int offset = pointStore.add(point);
         pointStore.incrementRefCount(offset);
         assertEquals(2, pointStore.getRefCount(offset));
@@ -142,19 +142,19 @@ public class PointStoreTest {
 
     @Test
     public void testPointEquals() {
-        double[] point = { 1.2, -3.4 };
+        float[] point = { 1.2f, -3.4f };
         int offset = pointStore.add(point);
         assertTrue(pointStore.pointEquals(offset, point));
-        assertFalse(pointStore.pointEquals(offset, new double[] { 5.6, -7.8 }));
+        assertFalse(pointStore.pointEquals(offset, new float[] { 5.6f, -7.8f }));
     }
 
     @Test
     public void testPointEqualsInvalid() {
-        double[] point = { 1.2, -3.4 };
+        float[] point = { 1.2f, -3.4f };
         assertThrows(IllegalArgumentException.class, () -> pointStore.pointEquals(-1, point));
         assertThrows(IllegalArgumentException.class, () -> pointStore.pointEquals(0, point));
 
         int offset = pointStore.add(point);
-        assertThrows(IllegalArgumentException.class, () -> pointStore.pointEquals(offset, new double[] { 99.9 }));
+        assertThrows(IllegalArgumentException.class, () -> pointStore.pointEquals(offset, new float[] { 99.9f }));
     }
 }


### PR DESCRIPTION
*Description of changes:*

The PointStore will be used with as part of the new compact tree data structure. The purpose of creating compact trees is to save space, and storing floats instead of doubles will help with that. Moreover, we believe that typical uses for this algorithm should not depend on the additional precision provided by doubles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
