### PR TITLE
convertor to compact + compression

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -156,22 +156,32 @@ public class CompactSampler implements IStreamSampler<Integer> {
             --currentSize;
             weightArray[0] = weightArray[currentSize];
             referenceArray[0] = referenceArray[currentSize];
-            int current = 0;
-            while ((2 * current + 1) < currentSize) {
-                int maxIndex = 2 * current + 1;
-                if ((2 * current + 2 < currentSize) && (weightArray[2 * current + 2] > weightArray[maxIndex]))
-                    maxIndex = 2 * current + 2;
-                if (weightArray[maxIndex] > weightArray[current]) {
-                    swapWeights(current, maxIndex);
-                    current = maxIndex;
-                } else
-                    break;
-            }
+            swapDown(0);
             return Optional.of(weight);
         } else {
             return Optional.empty();
         }
 
+    }
+
+    private void swapDown(int startIndex) {
+        int current = startIndex;
+        while ((2 * current + 1) < currentSize) {
+            int maxIndex = 2 * current + 1;
+            if ((2 * current + 2 < currentSize) && (weightArray[2 * current + 2] > weightArray[maxIndex]))
+                maxIndex = 2 * current + 2;
+            if (weightArray[maxIndex] > weightArray[current]) {
+                swapWeights(current, maxIndex);
+                current = maxIndex;
+            } else
+                break;
+        }
+    }
+
+    private void reheap() {
+        for (int i = (currentSize + 1) / 2; i >= 0; i--) {
+            swapDown(i);
+        }
     }
 
     @Override
@@ -310,5 +320,6 @@ public class CompactSampler implements IStreamSampler<Integer> {
                 sequenceArray[i] = samplerData.sequenceArray[i];
             }
         }
+        reheap();
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSamplerData.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSamplerData.java
@@ -41,4 +41,15 @@ public class CompactSamplerData {
         }
     }
 
+    public CompactSamplerData(int currentSize, int maxSize, boolean storeSeq) {
+        this.currentSize = currentSize;
+        this.maxSize = maxSize;
+        weightArray = new double[currentSize];
+        referenceArray = new int[currentSize];
+        if (storeSeq) {
+            sequenceArray = new long[currentSize];
+        } else {
+            sequenceArray = null;
+        }
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/ConvertToCompact.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/ConvertToCompact.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.sampler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import com.amazon.randomcutforest.executor.Sequential;
+import com.amazon.randomcutforest.store.PointStoreDouble;
+
+/**
+ * This class converts a SimpleStreamSampler to the compact form; maintaining a
+ * pointstore.
+ */
+public class ConvertToCompact {
+
+    HashMap<double[], Integer> pointMap;
+    public PointStoreDouble pointStoreDouble;
+    public ArrayList<CompactSamplerData> dataList;
+    boolean storeSequences;
+
+    public ConvertToCompact(boolean storeSequences, int dimensions, int capacity) {
+        pointMap = new HashMap<>();
+        pointStoreDouble = new PointStoreDouble(dimensions, capacity);
+        dataList = new ArrayList<>();
+        this.storeSequences = storeSequences;
+    }
+
+    public void addSamples(ArrayList<List<Sequential<double[]>>> sampleList, int capacity) {
+
+        for (List<Sequential<double[]>> indivList : sampleList) {
+            CompactSamplerData compactData = new CompactSamplerData(indivList.size(), capacity, storeSequences);
+            for (int i = 0; i < indivList.size(); i++) {
+                double[] ref = indivList.get(i).getValue();
+
+                if (pointMap.containsKey(ref)) {
+                    compactData.referenceArray[i] = pointMap.get(ref);
+                    pointStoreDouble.incrementRefCount(compactData.referenceArray[i]);
+                } else {
+                    compactData.referenceArray[i] = pointStoreDouble.add(ref);
+                    pointMap.put(ref, compactData.referenceArray[i]);
+                }
+                compactData.weightArray[i] = indivList.get(i).getWeight();
+                if (storeSequences) {
+                    compactData.sequenceArray[i] = indivList.get(i).getSequenceIndex();
+                }
+            }
+            dataList.add(compactData);
+        }
+    }
+}

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
@@ -18,7 +18,6 @@ package com.amazon.randomcutforest.store;
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.checkState;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -168,32 +167,34 @@ public class PointStoreDouble extends IndexManager implements IPointStore<double
     }
 
     @Override
+    public List<?> getData() {
+        return null;
+    }
+
+    @Override
+    public List<Short> getRef() {
+        return null;
+    }
+
+    @Override
     protected void checkValidIndex(int index) {
         super.checkValidIndex(index);
         checkState(refCount[index] > 0, "ref count at occupied index is 0");
     }
 
-    @Override
-    public List<Double> getData() {
-        List<Double> result = new ArrayList<>(store.length);
-        for (int j = 0; j < capacity * dimensions; j++) {
-            result.add(store[j]);
-        }
-        return result;
-    }
-
-    @Override
-    public List<Short> getRef() {
-        List<Short> result = new ArrayList<>(capacity);
-        for (int j = 0; j < super.capacity; j++) {
-            result.add(refCount[j]);
-        }
-        return result;
-    }
-
+    /*
+     * @Override public List<Double> getData() { List<Double> result = new
+     * ArrayList<>(store.length); for (int j = 0; j < capacity * dimensions; j++) {
+     * result.add(store[j]); } return result; }
+     * 
+     * @Override public List<Short> getRef() { List<Short> result = new
+     * ArrayList<>(capacity); for (int j = 0; j < super.capacity; j++) {
+     * result.add(refCount[j]); } return result; }
+     */
     public void reInitialize(PointStoreDoubleData pointStoreData) {
         int debug = 0;
         for (int i = 0; i < getCapacity(); i++) {
+            occupied.clear(i);
             refCount[i] = pointStoreData.refCount[i];
             if (refCount[i] > 0) {
                 occupied.set(i);
@@ -201,15 +202,19 @@ public class PointStoreDouble extends IndexManager implements IPointStore<double
             // sets everything
         }
 
-        for (int i = 0; i < pointStoreData.freeIndexes.length; i++) {
-            freeIndexes[i] = pointStoreData.freeIndexes[i];
-            occupied.clear(freeIndexes[i]);
-            // resets index for free entries
+        freeIndexPointer = -1;
+        for (int i = getCapacity() - 1; i >= 0; i--) {
+            if (!occupied.get(i)) {
+                freeIndexes[++freeIndexPointer] = i;
+            }
         }
-        // note that freeIndexPointer can be -1; when everything is occupied
-        // otherwise it indexes to last free position in [0:capacity-1]
-        freeIndexPointer = pointStoreData.freeIndexes.length - 1;
-
+        /*
+         * for (int i = 0; i < pointStoreData.freeIndexes.length; i++) { freeIndexes[i]
+         * = pointStoreData.freeIndexes[i]; occupied.clear(freeIndexes[i]); // resets
+         * index for free entries } // note that freeIndexPointer can be -1; when
+         * everything is occupied // otherwise it indexes to last free position in
+         * [0:capacity-1] freeIndexPointer = pointStoreData.freeIndexes.length - 1;
+         */
         for (int i = 0; i < pointStoreData.store.length; i++) {
             store[i] = pointStoreData.store[i];
         }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDoubleData.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDoubleData.java
@@ -21,7 +21,7 @@ public class PointStoreDoubleData {
 
     public final double[] store;
     public final short[] refCount;
-    public final int[] freeIndexes;
+    public int[] freeIndexes;
 
     /**
      * Takes a PointStoreDouble and stores the information. Note that
@@ -33,7 +33,8 @@ public class PointStoreDoubleData {
     public PointStoreDoubleData(PointStoreDouble pointStoreDouble) {
         store = Arrays.copyOf(pointStoreDouble.store, pointStoreDouble.store.length);
         refCount = Arrays.copyOf(pointStoreDouble.refCount, pointStoreDouble.refCount.length);
-        freeIndexes = Arrays.copyOf(pointStoreDouble.freeIndexes, pointStoreDouble.freeIndexPointer + 1);
+        // freeIndexes = Arrays.copyOf(pointStoreDouble.freeIndexes,
+        // pointStoreDouble.freeIndexPointer + 1);
     }
 
 }

--- a/Java/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
+++ b/Java/serialization-json/src/test/java/com/amazon/randomcutforest/serialize/RandomCutForestSerDeTests.java
@@ -37,13 +37,13 @@ public class RandomCutForestSerDeTests {
             "1, 100, 256, 1024, 1024, 0, 0", "10, 100, 256, 32, 1024, 0, 0", "10, 100, 256, 256, 1024, 0, 0",
             "10, 100, 256, 512, 1024, 0, 0", "10, 100, 256, 1024, 1024, 0, 0", "1, 100, 256, 32, 1024, 1, 0",
             "1, 100, 256, 256, 1024, 1, 1", "1, 100, 256, 512, 1024, 1, 2", "1, 100, 256, 1024, 1024, 1, 4",
-            "10, 100, 256, 32, 1024, 1, 0", "10, 100, 256, 1024, 1024, 1, 1", "4, 10, 256, 1024, 1024, 1, 2",
+            "10, 100, 256, 32, 1024, 1, 0", "10, 100, 256, 1024, 1024, 1, 1", "4, 100, 256, 1024, 1024, 1, 2",
             "10, 100, 256, 1024, 10240, 1, 6" })
 
     public void toJsonString(int numDims, int numTrees, int numSamples, int numTrainSamples, int numTestSamples,
             int enableParallel, int numThreads) {
         RandomCutForest.Builder forestBuilder = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).compactEnabled(true).saveTreeData(true);
+                .sampleSize(numSamples).randomSeed(0).compactEnabled(false);
         if (enableParallel == 0) {
             forestBuilder.parallelExecutionEnabled(false);
         }
@@ -62,7 +62,7 @@ public class RandomCutForestSerDeTests {
         ForestState reForestState = serializer.fromJson(json);
         System.out.println(" Size " + json.length());
 
-        RandomCutForest reForest = RandomCutForest.getForest(reForestState);
+        RandomCutForest reForest = RandomCutForest.createForest(reForestState);
 
         int num = 0;
         int numForDimOne = 0;
@@ -72,7 +72,7 @@ public class RandomCutForestSerDeTests {
             double newScore = reForest.getAnomalyScore(point);
             if (numDims > 1) {
                 assertTrue(Math.abs(score - newScore) < delta);
-                if ((score > 1) && (Math.abs(score - newScore) > 0.05 * score))
+                if (((score > 1) || (newScore > 1)) && (Math.abs(score - newScore) > 0.05 * score))
                     num++;
             } else {
                 if (((score > 1) || (newScore > 1)) && (Math.abs(score - newScore) > delta))
@@ -124,7 +124,7 @@ public class RandomCutForestSerDeTests {
 
         for (int i = 0; i < numTestSamples; i++) {
             reForestState = serializer.fromJson(json);
-            RandomCutForest reForest = RandomCutForest.getForest(reForestState);
+            RandomCutForest reForest = RandomCutForest.createForest(reForestState);
             double[] point = generate(1, numDims)[0];
             assertTrue(Math.abs(forest.getAnomalyScore(point) - reForest.getAnomalyScore(point)) < delta);
             reForest.update(point);


### PR DESCRIPTION
Adds a convertor for old samplers to compact samplers. The Forest State can be now simplified to only have compact sampler representation. Also cleans up PointStoreData in not needing to store the free locations. 
