### PR TITLE
Update executors to use ComponentList

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
@@ -15,7 +15,6 @@
 
 package com.amazon.randomcutforest;
 
-import java.util.ArrayList;
 import java.util.Random;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -31,7 +30,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import com.amazon.randomcutforest.executor.AbstractForestUpdateExecutor;
-import com.amazon.randomcutforest.executor.IUpdatable;
 import com.amazon.randomcutforest.executor.IUpdateCoordinator;
 import com.amazon.randomcutforest.executor.ParallelForestUpdateExecutor;
 import com.amazon.randomcutforest.executor.PassThroughCoordinator;
@@ -85,37 +83,37 @@ public class ForestUpdateExecutorBenchmark {
 
             if (!compactEnabled) {
                 IUpdateCoordinator<double[]> updateCoordinator = new PassThroughCoordinator();
-                ArrayList<IUpdatable<double[]>> trees = new ArrayList<>();
+                ComponentList<double[]> components = new ComponentList<>();
                 for (int i = 0; i < numberOfTrees; i++) {
                     RandomCutTree tree = RandomCutTree.builder().build();
                     SimpleStreamSampler<double[]> sampler = new SimpleStreamSampler<>(sampleSize, lambda,
                             random.nextLong(), false);
                     SamplerPlusTree<double[]> samplingTree = new SamplerPlusTree<>(sampler, tree);
-                    trees.add(samplingTree);
+                    components.add(samplingTree);
                 }
 
                 if (parallelExecutionEnabled) {
-                    executor = new ParallelForestUpdateExecutor<>(updateCoordinator, trees, threadPoolSize);
+                    executor = new ParallelForestUpdateExecutor<>(updateCoordinator, components, threadPoolSize);
                 } else {
-                    executor = new SequentialForestUpdateExecutor<>(updateCoordinator, trees);
+                    executor = new SequentialForestUpdateExecutor<>(updateCoordinator, components);
                 }
             } else {
                 PointStoreDouble store = new PointStoreDouble(dimensions, numberOfTrees * sampleSize);
                 IUpdateCoordinator<Integer> updateCoordinator = new PointStoreCoordinator(store);
-                ArrayList<IUpdatable<Integer>> trees = new ArrayList<>();
+                ComponentList<Integer> components = new ComponentList<>();
                 for (int i = 0; i < numberOfTrees; i++) {
                     CompactRandomCutTreeDouble tree = new CompactRandomCutTreeDouble(sampleSize, random.nextLong(),
                             store);
-                    SimpleStreamSampler<Integer> sampler = new SimpleStreamSampler(sampleSize, lambda,
+                    SimpleStreamSampler<Integer> sampler = new SimpleStreamSampler<>(sampleSize, lambda,
                             random.nextLong(), false);
-                    SamplerPlusTree<Integer> samplerTree = new SamplerPlusTree(sampler, tree);
-                    trees.add(samplerTree);
+                    SamplerPlusTree<Integer> samplerTree = new SamplerPlusTree<>(sampler, tree);
+                    components.add(samplerTree);
                 }
 
                 if (parallelExecutionEnabled) {
-                    executor = new ParallelForestUpdateExecutor<>(updateCoordinator, trees, threadPoolSize);
+                    executor = new ParallelForestUpdateExecutor<>(updateCoordinator, components, threadPoolSize);
                 } else {
-                    executor = new SequentialForestUpdateExecutor<>(updateCoordinator, trees);
+                    executor = new SequentialForestUpdateExecutor<>(updateCoordinator, components);
                 }
             }
         }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestTraversalExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestTraversalExecutor.java
@@ -15,11 +15,11 @@
 
 package com.amazon.randomcutforest.executor;
 
-import java.util.ArrayList;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
+import com.amazon.randomcutforest.ComponentList;
 import com.amazon.randomcutforest.MultiVisitor;
 import com.amazon.randomcutforest.Visitor;
 import com.amazon.randomcutforest.returntypes.ConvergingAccumulator;
@@ -28,10 +28,10 @@ import com.amazon.randomcutforest.tree.RandomCutTree;
 
 public abstract class AbstractForestTraversalExecutor {
 
-    protected final ArrayList<SamplerPlusTree> components;
+    protected final ComponentList<?> components;
 
-    protected AbstractForestTraversalExecutor(ArrayList<SamplerPlusTree> treeExecutors) {
-        this.components = treeExecutors;
+    protected AbstractForestTraversalExecutor(ComponentList<?> components) {
+        this.components = components;
     }
 
     /**
@@ -62,7 +62,7 @@ public abstract class AbstractForestTraversalExecutor {
      * Visit each of the trees in the forest and combine the individual results into
      * an aggregate result. A visitor is constructed for each tree using the visitor
      * factory, and then submitted to
-     * {@link RandomCutTree#traverse(double[], Visitor)}. The results from
+     * {@link RandomCutTree#traverse(double[], Function)}. The results from
      * individual trees are collected using the {@link java.util.stream.Collector}
      * and returned. Trees are visited in parallel using
      * {@link java.util.Collection#parallelStream()}.
@@ -86,7 +86,7 @@ public abstract class AbstractForestTraversalExecutor {
      * Visit each of the trees in the forest sequentially and combine the individual
      * results into an aggregate result. A visitor is constructed for each tree
      * using the visitor factory, and then submitted to
-     * {@link RandomCutTree#traverse(double[], Visitor)}. The results from all the
+     * {@link RandomCutTree#traverse(double[], Function)}. The results from all the
      * trees are combined using the {@link ConvergingAccumulator}, and the method
      * stops visiting trees after convergence is reached. The result is transformed
      * using the finisher before being returned.

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
@@ -15,11 +15,14 @@
 
 package com.amazon.randomcutforest.executor;
 
+import java.util.function.Function;
+
 import com.amazon.randomcutforest.MultiVisitor;
 import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.tree.ITree;
 
 public interface ITraversable {
-    <R> R traverse(double[] point, Visitor<R> visitor);
+    <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory);
 
-    <R> R traverseMulti(double[] point, MultiVisitor<R> visitor);
+    <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory);
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/ParallelForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/ParallelForestUpdateExecutor.java
@@ -15,12 +15,13 @@
 
 package com.amazon.randomcutforest.executor;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
+
+import com.amazon.randomcutforest.ComponentList;
 
 /**
  * An implementation of forest traversal methods that uses a private thread pool
@@ -31,9 +32,9 @@ public class ParallelForestUpdateExecutor<P> extends AbstractForestUpdateExecuto
     private ForkJoinPool forkJoinPool;
     private final int threadPoolSize;
 
-    public ParallelForestUpdateExecutor(IUpdateCoordinator<P> updateCoordinator, ArrayList<IUpdatable<P>> models,
+    public ParallelForestUpdateExecutor(IUpdateCoordinator<P> updateCoordinator, ComponentList<P> components,
             int threadPoolSize) {
-        super(updateCoordinator, models);
+        super(updateCoordinator, components);
         this.threadPoolSize = threadPoolSize;
         forkJoinPool = new ForkJoinPool(threadPoolSize);
     }
@@ -41,7 +42,7 @@ public class ParallelForestUpdateExecutor<P> extends AbstractForestUpdateExecuto
     @Override
     protected List<Optional<UpdateReturn<P>>> update(P point, long seqNum) {
         return submitAndJoin(
-                () -> models.parallelStream().map(t -> t.update(point, seqNum)).collect(Collectors.toList()));
+                () -> components.parallelStream().map(t -> t.update(point, seqNum)).collect(Collectors.toList()));
     }
 
     private <T> T submitAndJoin(Callable<T> callable) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
@@ -20,6 +20,7 @@ import static com.amazon.randomcutforest.CommonUtils.checkState;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import com.amazon.randomcutforest.IComponentModel;
 import com.amazon.randomcutforest.MultiVisitor;
@@ -176,27 +177,27 @@ public class SamplerPlusTree<P> implements IComponentModel<P> {
     /**
      * traversal methods
      * 
-     * @param point   to be evaluated
-     * @param visitor the visitor implementation that corresponds to the function
-     *                being evaluated
-     * @param <R>     return type
+     * @param point          to be evaluated
+     * @param visitorFactory the visitor implementation that corresponds to the
+     *                       function being evaluated
+     * @param <R>            return type
      * @return
      */
     @Override
-    public <R> R traverse(double[] point, Visitor<R> visitor) {
-        return tree.traverse(point, visitor);
+    public <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory) {
+        return tree.traverse(point, visitorFactory);
     }
 
     /**
      *
-     * @param point   to be evaluated
-     * @param visitor MultiVisitor, used in extrapolation
-     * @param <R>     return type
+     * @param point          to be evaluated
+     * @param visitorFactory MultiVisitor, used in extrapolation
+     * @param <R>            return type
      * @return
      */
     @Override
-    public <R> R traverseMulti(double[] point, MultiVisitor<R> visitor) {
-        return tree.traverseMulti(point, visitor);
+    public <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory) {
+        return tree.traverseMulti(point, visitorFactory);
     }
 
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SequentialForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SequentialForestUpdateExecutor.java
@@ -15,22 +15,23 @@
 
 package com.amazon.randomcutforest.executor;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.amazon.randomcutforest.ComponentList;
 
 /**
  * Traverse the trees in a forest sequentially.
  */
 public class SequentialForestUpdateExecutor<P> extends AbstractForestUpdateExecutor<P> {
 
-    public SequentialForestUpdateExecutor(IUpdateCoordinator<P> updateCoordinator, ArrayList<IUpdatable<P>> models) {
-        super(updateCoordinator, models);
+    public SequentialForestUpdateExecutor(IUpdateCoordinator<P> updateCoordinator, ComponentList<P> components) {
+        super(updateCoordinator, components);
     }
 
     @Override
     protected List<Optional<UpdateReturn<P>>> update(P point, long seqNum) {
-        return models.stream().map(t -> t.update(point, seqNum)).collect(Collectors.toList());
+        return components.stream().map(t -> t.update(point, seqNum)).collect(Collectors.toList());
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTree.java
@@ -19,6 +19,7 @@ import static com.amazon.randomcutforest.CommonUtils.*;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Function;
 
 import com.amazon.randomcutforest.CommonUtils;
 import com.amazon.randomcutforest.MultiVisitor;
@@ -420,15 +421,17 @@ public class CompactRandomCutTree implements ITree<Integer> {
      * then we will invoke visitor::accept on the remaining nodes in the following
      * order: nodeN, node(N-1), ..., node2, node1, and root.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     @Override
-    public <R> R traverse(double[] point, Visitor<R> visitor) {
+    public <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory) {
         checkState(rootIndex != NULL, "this tree doesn't contain any nodes");
+        Visitor<R> visitor = visitorFactory.apply(this);
         traversePathToLeafAndVisitNodes(point, visitor, rootIndex, 0);
         return visitor.getResult();
     }
@@ -447,15 +450,16 @@ public class CompactRandomCutTree implements ITree<Integer> {
 
     /**
      * This is a traversal method which follows the standard traveral path (defined
-     * in {@link #traverse(double[], Visitor)}) but at Node in checks to see whether
-     * the visitor should split. If a split is triggered, then independent copies of
-     * the visitor are sent down each branch of the tree and then merged before
-     * propogating the result.
+     * in {@link #traverse(double[], Function)}) but at Node in checks to see
+     * whether the visitor should split. If a split is triggered, then independent
+     * copies of the visitor are sent down each branch of the tree and then merged
+     * before propogating the result.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     /*
@@ -467,10 +471,11 @@ public class CompactRandomCutTree implements ITree<Integer> {
      */
 
     @Override
-    public <R> R traverseMulti(double[] point, MultiVisitor<R> visitor) {
+    public <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory) {
         checkNotNull(point, "point must not be null");
-        checkNotNull(visitor, "visitor must not be null");
+        checkNotNull(visitorFactory, "visitorFactory must not be null");
         checkState(rootIndex != NULL, "this tree doesn't contain any nodes");
+        MultiVisitor<R> visitor = visitorFactory.apply(this);
         traverseTreeMulti(point, visitor, rootIndex, 0);
         return visitor.getResult();
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -19,6 +19,7 @@ import static com.amazon.randomcutforest.CommonUtils.*;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Function;
 
 import com.amazon.randomcutforest.CommonUtils;
 import com.amazon.randomcutforest.MultiVisitor;
@@ -468,15 +469,17 @@ public class CompactRandomCutTreeDouble implements ITree<Integer> {
      * then we will invoke visitor::accept on the remaining nodes in the following
      * order: nodeN, node(N-1), ..., node2, node1, and root.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     @Override
-    public <R> R traverse(double[] point, Visitor<R> visitor) {
+    public <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory) {
         checkState(rootIndex != NULL, "this tree doesn't contain any nodes");
+        Visitor<R> visitor = visitorFactory.apply(this);
         traversePathToLeafAndVisitNodes(point, visitor, rootIndex, 0);
         return visitor.getResult();
     }
@@ -510,15 +513,16 @@ public class CompactRandomCutTreeDouble implements ITree<Integer> {
 
     /**
      * This is a traversal method which follows the standard traveral path (defined
-     * in {@link #traverse(double[], Visitor)}) but at Node in checks to see whether
-     * the visitor should split. If a split is triggered, then independent copies of
-     * the visitor are sent down each branch of the tree and then merged before
-     * propogating the result.
+     * in {@link #traverse(double[], Function)}) but at Node in checks to see
+     * whether the visitor should split. If a split is triggered, then independent
+     * copies of the visitor are sent down each branch of the tree and then merged
+     * before propogating the result.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     /*
@@ -530,10 +534,11 @@ public class CompactRandomCutTreeDouble implements ITree<Integer> {
      */
 
     @Override
-    public <R> R traverseMulti(double[] point, MultiVisitor<R> visitor) {
+    public <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory) {
         checkNotNull(point, "point must not be null");
-        checkNotNull(visitor, "visitor must not be null");
+        checkNotNull(visitorFactory, "visitor must not be null");
         checkState(rootIndex != NULL, "this tree doesn't contain any nodes");
+        MultiVisitor<R> visitor = visitorFactory.apply(this);
         traverseTreeMulti(point, visitor, rootIndex, 0);
         return visitor.getResult();
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -20,6 +20,7 @@ import static com.amazon.randomcutforest.tree.Node.isLeftOf;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.function.Function;
 
 import com.amazon.randomcutforest.MultiVisitor;
 import com.amazon.randomcutforest.Visitor;
@@ -399,15 +400,17 @@ public class RandomCutTree implements ITree<double[]> {
      * then we will invoke visitor::accept on the remaining nodes in the following
      * order: nodeN, node(N-1), ..., node2, node1, and root.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     @Override
-    public <R> R traverse(double[] point, Visitor<R> visitor) {
+    public <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory) {
         checkState(root != null, "this tree doesn't contain any nodes");
+        Visitor<R> visitor = visitorFactory.apply(this);
         traversePathToLeafAndVisitNodes(point, visitor, root, 0);
         return visitor.getResult();
     }
@@ -425,22 +428,24 @@ public class RandomCutTree implements ITree<double[]> {
 
     /**
      * This is a traversal method which follows the standard traveral path (defined
-     * in {@link #traverse(double[], Visitor)}) but at Node in checks to see whether
-     * the visitor should split. If a split is triggered, then independent copies of
-     * the visitor are sent down each branch of the tree and then merged before
-     * propogating the result.
+     * in {@link #traverse(double[], Function)}) but at Node in checks to see
+     * whether the visitor should split. If a split is triggered, then independent
+     * copies of the visitor are sent down each branch of the tree and then merged
+     * before propogating the result.
      *
-     * @param point   A point which determines the traversal path from the root to a
-     *                leaf node.
-     * @param visitor A visitor that will be invoked for each node on the path.
-     * @param <R>     The return type of the Visitor.
+     * @param point          A point which determines the traversal path from the
+     *                       root to a leaf node.
+     * @param visitorFactory A visitor that will be invoked for each node on the
+     *                       path.
+     * @param <R>            The return type of the Visitor.
      * @return the value of {@link Visitor#getResult()}} after the traversal.
      */
     @Override
-    public <R> R traverseMulti(double[] point, MultiVisitor<R> visitor) {
+    public <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory) {
         checkNotNull(point, "point must not be null");
-        checkNotNull(visitor, "visitor must not be null");
+        checkNotNull(visitorFactory, "visitor must not be null");
         checkState(root != null, "this tree doesn't contain any nodes");
+        MultiVisitor<R> visitor = visitorFactory.apply(this);
         traverseTreeMulti(point, visitor, root, 0);
         return visitor.getResult();
     }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/executor/ForestUpdateExecutorTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/executor/ForestUpdateExecutorTest.java
@@ -17,7 +17,6 @@ package com.amazon.randomcutforest.executor;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +26,9 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazon.randomcutforest.ComponentList;
+import com.amazon.randomcutforest.IComponentModel;
 
 @ExtendWith(MockitoExtension.class)
 public class ForestUpdateExecutorTest {
@@ -41,24 +43,23 @@ public class ForestUpdateExecutorTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
 
-            ArrayList<IUpdatable<Sequential<double[]>>> sequentialTrees = new ArrayList<>();
-            ArrayList<IUpdatable<Sequential<double[]>>> parallelTrees = new ArrayList<>();
+            ComponentList<double[]> sequentialComponents = new ComponentList<>();
+            ComponentList<double[]> parallelComponents = new ComponentList<>();
 
             for (int i = 0; i < numberOfTrees; i++) {
-                sequentialTrees.add(mock(IUpdatable.class));
-                parallelTrees.add(mock(IUpdatable.class));
+                sequentialComponents.add(mock(IComponentModel.class));
+                parallelComponents.add(mock(IComponentModel.class));
             }
 
             IUpdateCoordinator<double[]> sequentialUpdateCoordinator = new PassThroughCoordinator();
-            AbstractForestUpdateExecutor<Sequential<double[]>> sequentialExecutor = new SequentialForestUpdateExecutor(
-                    sequentialUpdateCoordinator, sequentialTrees);
+            AbstractForestUpdateExecutor<double[]> sequentialExecutor = new SequentialForestUpdateExecutor<>(
+                    sequentialUpdateCoordinator, sequentialComponents);
 
             IUpdateCoordinator<double[]> parallelUpdateCoordinator = new PassThroughCoordinator();
-            AbstractForestUpdateExecutor<Sequential<double[]>> parallelExecutor = new ParallelForestUpdateExecutor(
-                    parallelUpdateCoordinator, parallelTrees, threadPoolSize);
+            AbstractForestUpdateExecutor<double[]> parallelExecutor = new ParallelForestUpdateExecutor<>(
+                    parallelUpdateCoordinator, parallelComponents, threadPoolSize);
 
             return Stream.of(sequentialExecutor, parallelExecutor).map(Arguments::of);
         }
     }
-
 }


### PR DESCRIPTION
Update the executor classes to operate on the generic ComponentList
class instead of a list of SamplerPlusTree.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
