### PR TITLE
Updates to forest/builder configuration

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.config;
+
+/**
+ * Options for floating-point precision.
+ */
+public enum Precision {
+    SINGLE, DOUBLE
+}

--- a/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFloatFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFloatFunctionalTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.returntypes.DensityOutput;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
@@ -68,11 +69,11 @@ public class CompactRandomCutForestFloatFunctionalTest {
 
         parallelExecutionForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
-                .singlePrecisionEnabled(true).boundingBoxCachingEnabled(false).build();
+                .precision(Precision.SINGLE).boundingBoxCachingEnabled(false).build();
 
         singleThreadedForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
-                .singlePrecisionEnabled(true).boundingBoxCachingEnabled(true).parallelExecutionEnabled(false).build();
+                .precision(Precision.SINGLE).boundingBoxCachingEnabled(true).parallelExecutionEnabled(false).build();
 
         dataSize = 10_000;
 


### PR DESCRIPTION
* Change the singlePrecisionEnabled flag to use a new Precision enum
* Remove logic from the builder that overrides user options. Instead
  we will fail fast in the constructor.

Closes #77 #82

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
