### PR TITLE
Normalize constructors for state and mapper classes

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -428,6 +428,10 @@ public class RandomCutForest {
         return parallelExecutionEnabled;
     }
 
+    public boolean isBoundingBoxCachingEnabled() {
+        return boundingBoxCachingEnabled;
+    }
+
     /**
      * @return the number of threads in the thread pool if parallel execution is
      *         enabled, 0 otherwise.

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/PointStoreCoordinator.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/PointStoreCoordinator.java
@@ -20,7 +20,6 @@ import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 import java.util.List;
 
 import com.amazon.randomcutforest.store.IPointStore;
-import com.amazon.randomcutforest.store.PointStoreDouble;
 
 public class PointStoreCoordinator extends AbstractUpdateCoordinator<Integer> {
 
@@ -46,7 +45,7 @@ public class PointStoreCoordinator extends AbstractUpdateCoordinator<Integer> {
         totalUpdates++;
     }
 
-    public PointStoreDouble getStore() {
-        return (PointStoreDouble) store;
+    public IPointStore<?> getStore() {
+        return store;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
@@ -109,6 +109,7 @@ public class RandomCutForestMapper
         state.setStoreSequenceIndexesEnabled(forest.isStoreSequenceIndexesEnabled());
         state.setTotalUpdates(forest.getTotalUpdates());
         state.setCompactEnabled(forest.isCompactEnabled());
+        state.setBoundingBoxCachingEnabled(forest.isBoundingBoxCachingEnabled());
 
         if (saveExecutorContext) {
             ExecutorContext executorContext = new ExecutorContext();
@@ -120,7 +121,7 @@ public class RandomCutForestMapper
         if (forest.isCompactEnabled()) {
             PointStoreCoordinator pointStoreCoordinator = (PointStoreCoordinator) forest.getUpdateCoordinator();
             PointStoreDoubleState pointStoreState = new PointStoreDoubleMapper()
-                    .toState(pointStoreCoordinator.getStore());
+                    .toState((PointStoreDouble) pointStoreCoordinator.getStore());
             state.setPointStoreDoubleState(pointStoreState);
 
             List<CompactSamplerState> samplerStates = new ArrayList<>();
@@ -212,6 +213,7 @@ public class RandomCutForestMapper
 
             ComponentList<Integer> components = new ComponentList<>();
             CompactRandomCutTreeMapper treeMapper = new CompactRandomCutTreeMapper();
+            treeMapper.setBoundingBoxCacheEnabled(state.isBoundingBoxCachingEnabled());
 
             CompactRandomCutTreeContext context = new CompactRandomCutTreeContext();
             context.setMaxSize(state.getSampleSize());
@@ -227,7 +229,7 @@ public class RandomCutForestMapper
                             state.isStoreSequenceIndexesEnabled());
                 }
 
-                CompactSampler sampler = samplerMapper.toModel(samplerStates.get(i), state, rng.nextLong());
+                CompactSampler sampler = samplerMapper.toModel(samplerStates.get(i), rng.nextLong());
 
                 if (treeStates == null) {
                     sampler.getSample().forEach(s -> tree.addPoint(s.getValue(), s.getSequenceIndex()));
@@ -244,7 +246,7 @@ public class RandomCutForestMapper
             ComponentList<double[]> components = new ComponentList<>();
 
             for (int i = 0; i < state.getNumberOfTrees(); i++) {
-                CompactSampler compactData = samplerMapper.toModel(samplerStates.get(i), state);
+                CompactSampler compactData = samplerMapper.toModel(samplerStates.get(i));
                 RandomCutTree tree = RandomCutTree.builder()
                         .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled())
                         .centerOfMassEnabled(state.isCenterOfMassEnabled()).randomSeed(rng.nextLong()).build();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
@@ -79,6 +79,7 @@ public class ArraySamplersToCompactStateConverter {
         CompactSamplerState samplerState = new CompactSamplerState();
         samplerState.setSize(sampler.size());
         samplerState.setCapacity(sampler.getCapacity());
+        samplerState.setLambda(sampler.getLambda());
         samplerState.setPointIndex(pointIndex);
         samplerState.setWeight(weight);
         samplerState.setSequenceIndex(sequenceIndex);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
@@ -18,22 +18,25 @@ package com.amazon.randomcutforest.state.sampler;
 import java.util.Arrays;
 import java.util.Random;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.sampler.CompactSampler;
 import com.amazon.randomcutforest.state.IContextualStateMapper;
 import com.amazon.randomcutforest.state.RandomCutForestState;
 
+@Getter
+@Setter
 public class CompactSamplerMapper
         implements IContextualStateMapper<CompactSampler, CompactSamplerState, RandomCutForestState> {
 
+    /**
+     * This flag is passed to the constructor for {@code CompactSampler} when a new
+     * sampler is constructed in {@link #toModel}. If true, then the sampler will
+     * validate that the weight array in a {@code CompactSamplerState} instance
+     * satisfies the heap property.
+     */
     private boolean validateHeap;
-
-    public CompactSamplerMapper(boolean validateHeap) {
-        this.validateHeap = validateHeap;
-    }
-
-    public CompactSamplerMapper() {
-        this(false);
-    }
 
     @Override
     public CompactSampler toModel(CompactSamplerState state, RandomCutForestState forestState, long seed) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
@@ -22,13 +22,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import com.amazon.randomcutforest.sampler.CompactSampler;
-import com.amazon.randomcutforest.state.IContextualStateMapper;
-import com.amazon.randomcutforest.state.RandomCutForestState;
+import com.amazon.randomcutforest.state.IStateMapper;
 
 @Getter
 @Setter
-public class CompactSamplerMapper
-        implements IContextualStateMapper<CompactSampler, CompactSamplerState, RandomCutForestState> {
+public class CompactSamplerMapper implements IStateMapper<CompactSampler, CompactSamplerState> {
 
     /**
      * This flag is passed to the constructor for {@code CompactSampler} when a new
@@ -39,9 +37,9 @@ public class CompactSamplerMapper
     private boolean validateHeap;
 
     @Override
-    public CompactSampler toModel(CompactSamplerState state, RandomCutForestState forestState, long seed) {
-        return new CompactSampler(forestState.getSampleSize(), forestState.getLambda(), new Random(seed),
-                state.getWeight(), state.getPointIndex(), state.getSequenceIndex(), validateHeap);
+    public CompactSampler toModel(CompactSamplerState state, long seed) {
+        return new CompactSampler(state.getCapacity(), state.getLambda(), new Random(seed), state.getWeight(),
+                state.getPointIndex(), state.getSequenceIndex(), validateHeap);
     }
 
     @Override
@@ -49,6 +47,7 @@ public class CompactSamplerMapper
         CompactSamplerState state = new CompactSamplerState();
         state.setSize(model.size());
         state.setCapacity(model.getCapacity());
+        state.setLambda(model.getLambda());
         state.setWeight(Arrays.copyOf(model.getWeightArray(), model.size()));
         state.setPointIndex(Arrays.copyOf(model.getPointIndexArray(), model.size()));
         if (model.isStoreSequenceIndexesEnabled()) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
@@ -17,15 +17,31 @@ package com.amazon.randomcutforest.state.sampler;
 
 import lombok.Data;
 
+/**
+ * A data object representing the state of a
+ * {@link com.amazon.randomcutforest.sampler.CompactSampler}.
+ */
 @Data
 public class CompactSamplerState {
+    /**
+     * An array of sampler weights.
+     */
     private float[] weight;
-
+    /**
+     * An array of index values identifying the points in the sample. These indexes
+     * will correspond to a {@link com.amazon.randomcutforest.store.PointStore}.
+     */
     private int[] pointIndex;
-
+    /**
+     * The sequence indexes of points in the sample.
+     */
     private long[] sequenceIndex;
-
+    /**
+     * The number of points in the sample.
+     */
     private int size;
-
+    /**
+     * The maximum number of points taht the sampler can contain.
+     */
     private int capacity;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
@@ -41,7 +41,11 @@ public class CompactSamplerState {
      */
     private int size;
     /**
-     * The maximum number of points taht the sampler can contain.
+     * The maximum number of points that the sampler can contain.
      */
     private int capacity;
+    /**
+     * The lambda time-decay parameter for this sampler
+     */
+    private double lambda;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/LeafStoreState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/LeafStoreState.java
@@ -15,27 +15,12 @@
 
 package com.amazon.randomcutforest.state.store;
 
-import java.util.Arrays;
-
 import lombok.Data;
-
-import com.amazon.randomcutforest.store.LeafStore;
 
 @Data
 public class LeafStoreState {
-
     public int[] pointIndex;
     public short[] parentIndex;
     public short[] mass;
     public short[] freeIndexes;
-
-    public LeafStoreState() {
-    }
-
-    public LeafStoreState(LeafStore leafStore) {
-        pointIndex = Arrays.copyOf(leafStore.pointIndex, leafStore.pointIndex.length);
-        parentIndex = Arrays.copyOf(leafStore.parentIndex, leafStore.parentIndex.length);
-        mass = Arrays.copyOf(leafStore.mass, leafStore.mass.length);
-        freeIndexes = Arrays.copyOf(leafStore.getFreeIndexes(), leafStore.getFreeIndexPointer() + 1);
-    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreState.java
@@ -15,11 +15,7 @@
 
 package com.amazon.randomcutforest.state.store;
 
-import java.util.Arrays;
-
 import lombok.Data;
-
-import com.amazon.randomcutforest.store.NodeStore;
 
 @Data
 public class NodeStoreState {
@@ -30,18 +26,4 @@ public class NodeStoreState {
     public double[] cutValue;
     public short[] mass;
     public short[] freeIndexes;
-
-    public NodeStoreState() {
-    }
-
-    public NodeStoreState(NodeStore nodeStore) {
-        leftIndex = Arrays.copyOf(nodeStore.leftIndex, nodeStore.leftIndex.length);
-        rightIndex = Arrays.copyOf(nodeStore.rightIndex, nodeStore.rightIndex.length);
-        parentIndex = Arrays.copyOf(nodeStore.parentIndex, nodeStore.parentIndex.length);
-        mass = Arrays.copyOf(nodeStore.mass, nodeStore.mass.length);
-        cutDimension = Arrays.copyOf(nodeStore.cutDimension, nodeStore.cutDimension.length);
-        cutValue = Arrays.copyOf(nodeStore.cutValue, nodeStore.cutValue.length);
-        freeIndexes = Arrays.copyOf(nodeStore.getFreeIndexes(), nodeStore.getFreeIndexPointer() + 1);
-    }
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleState.java
@@ -15,33 +15,11 @@
 
 package com.amazon.randomcutforest.state.store;
 
-import java.util.Arrays;
-
 import lombok.Data;
-
-import com.amazon.randomcutforest.store.PointStoreDouble;
 
 @Data
 public class PointStoreDoubleState {
-
-    public double[] store;
-    public short[] refCount;
-    public int[] freeIndexes;
-
-    public PointStoreDoubleState() {
-
-    }
-
-    /**
-     * Takes a PointStoreDouble and stores the information. Note that
-     * freeIndexPointer is an index into an array [0:capacity-1] and can be -1 when
-     * everything is occupied.
-     *
-     * @param pointStoreDouble A point store.
-     */
-    public PointStoreDoubleState(PointStoreDouble pointStoreDouble) {
-        store = Arrays.copyOf(pointStoreDouble.getStore(), pointStoreDouble.getStore().length);
-        refCount = Arrays.copyOf(pointStoreDouble.getRefCount(), pointStoreDouble.getRefCount().length);
-    }
-
+    private double[] store;
+    private short[] refCount;
+    private int[] freeIndexes;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.state.tree;
+
+import com.amazon.randomcutforest.state.IStateMapper;
+import com.amazon.randomcutforest.state.store.LeafStoreMapper;
+import com.amazon.randomcutforest.state.store.NodeStoreMapper;
+import com.amazon.randomcutforest.store.LeafStore;
+import com.amazon.randomcutforest.store.NodeStore;
+import com.amazon.randomcutforest.tree.CompactNodeManager;
+
+public class CompactNodeManagerMapper implements IStateMapper<CompactNodeManager, CompactNodeManagerState> {
+    @Override
+    public CompactNodeManagerState toState(CompactNodeManager manager) {
+        CompactNodeManagerState state = new CompactNodeManagerState();
+
+        LeafStoreMapper leafStoreMapper = new LeafStoreMapper();
+        state.setLeafStoreState(leafStoreMapper.toState((LeafStore) manager.getLeafStore()));
+
+        NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
+        state.setNodeStoreState(nodeStoreMapper.toState((NodeStore) manager.getNodeStore()));
+
+        return state;
+    }
+
+    @Override
+    public CompactNodeManager toModel(CompactNodeManagerState state, long seed) {
+        LeafStoreMapper leafStoreMapper = new LeafStoreMapper();
+        LeafStore leafStore = leafStoreMapper.toModel(state.getLeafStoreState());
+
+        NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
+        NodeStore nodeStore = nodeStoreMapper.toModel(state.getNodeStoreState());
+
+        return new CompactNodeManager(leafStore.getCapacity(), nodeStore, leafStore);
+    }
+}

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerState.java
@@ -17,8 +17,11 @@ package com.amazon.randomcutforest.state.tree;
 
 import lombok.Data;
 
+import com.amazon.randomcutforest.state.store.LeafStoreState;
+import com.amazon.randomcutforest.state.store.NodeStoreState;
+
 @Data
-public class CompactRandomCutTreeState {
-    private int rootIndex;
-    private CompactNodeManagerState compactNodeManagerState;
+public class CompactNodeManagerState {
+    private LeafStoreState leafStoreState;
+    private NodeStoreState nodeStoreState;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeMapper.java
@@ -15,24 +15,28 @@
 
 package com.amazon.randomcutforest.state.tree;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.state.IContextualStateMapper;
-import com.amazon.randomcutforest.state.store.LeafStoreMapper;
-import com.amazon.randomcutforest.state.store.NodeStoreMapper;
-import com.amazon.randomcutforest.store.LeafStore;
-import com.amazon.randomcutforest.store.NodeStore;
 import com.amazon.randomcutforest.tree.CompactNodeManager;
 import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 
+@Getter
+@Setter
 public class CompactRandomCutTreeMapper implements
         IContextualStateMapper<CompactRandomCutTreeDouble, CompactRandomCutTreeState, CompactRandomCutTreeContext> {
+
+    private boolean boundingBoxCacheEnabled;
 
     @Override
     public CompactRandomCutTreeDouble toModel(CompactRandomCutTreeState state, CompactRandomCutTreeContext context,
             long seed) {
-        NodeStore nodeStore = new NodeStoreMapper().toModel(state.nodeStoreState);
-        LeafStore leafStore = new LeafStoreMapper().toModel(state.leafStoreState);
-        return new CompactRandomCutTreeDouble(context.getMaxSize(), seed, context.getPointStore(), leafStore, nodeStore,
-                state.rootIndex);
+        CompactNodeManagerMapper compactNodeManagerMapper = new CompactNodeManagerMapper();
+        CompactNodeManager nodeManager = compactNodeManagerMapper.toModel(state.getCompactNodeManagerState());
+
+        return new CompactRandomCutTreeDouble(context.getMaxSize(), seed, context.getPointStore(), nodeManager,
+                state.getRootIndex(), boundingBoxCacheEnabled);
     }
 
     @Override
@@ -40,13 +44,8 @@ public class CompactRandomCutTreeMapper implements
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
         state.setRootIndex(model.getRootIndex());
 
-        CompactNodeManager nodeManager = model.getNodeManager();
-
-        LeafStoreMapper leafStoreMapper = new LeafStoreMapper();
-        state.setLeafStoreState(leafStoreMapper.toState(nodeManager.getLeafStore()));
-
-        NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
-        state.setNodeStoreState(nodeStoreMapper.toState(nodeManager.getNodeStore()));
+        CompactNodeManagerMapper compactNodeManagerMapper = new CompactNodeManagerMapper();
+        state.setCompactNodeManagerState(compactNodeManagerMapper.toState(model.getNodeManager()));
 
         return state;
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeMapper.java
@@ -20,6 +20,7 @@ import com.amazon.randomcutforest.state.store.LeafStoreMapper;
 import com.amazon.randomcutforest.state.store.NodeStoreMapper;
 import com.amazon.randomcutforest.store.LeafStore;
 import com.amazon.randomcutforest.store.NodeStore;
+import com.amazon.randomcutforest.tree.CompactNodeManager;
 import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 
 public class CompactRandomCutTreeMapper implements
@@ -37,9 +38,16 @@ public class CompactRandomCutTreeMapper implements
     @Override
     public CompactRandomCutTreeState toState(CompactRandomCutTreeDouble model) {
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
-        state.setLeafStoreState(model.getLeaves());
-        state.setNodeStoreState(model.getNodes());
         state.setRootIndex(model.getRootIndex());
+
+        CompactNodeManager nodeManager = model.getNodeManager();
+
+        LeafStoreMapper leafStoreMapper = new LeafStoreMapper();
+        state.setLeafStoreState(leafStoreMapper.toState(nodeManager.getLeafStore()));
+
+        NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
+        state.setNodeStoreState(nodeStoreMapper.toState(nodeManager.getNodeStore()));
+
         return state;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
@@ -19,21 +19,10 @@ import lombok.Data;
 
 import com.amazon.randomcutforest.state.store.LeafStoreState;
 import com.amazon.randomcutforest.state.store.NodeStoreState;
-import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 
 @Data
 public class CompactRandomCutTreeState {
     public LeafStoreState leafStoreState;
     public NodeStoreState nodeStoreState;
     public int rootIndex;
-
-    public CompactRandomCutTreeState() {
-
-    }
-
-    public CompactRandomCutTreeState(CompactRandomCutTreeDouble tree) {
-        leafStoreState = tree.getLeaves();
-        nodeStoreState = tree.getNodes();
-        rootIndex = tree.getRootIndex();
-    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
  * point values and increment and decrement reference counts. Valid index values
  * are between 0 (inclusive) and capacity (exclusive).
  */
-public class PointStoreDouble extends PointStore<double[]> implements IPointStore<double[]> {
+public class PointStoreDouble extends PointStore<double[]> {
 
     protected final double[] store;
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -21,8 +21,6 @@ import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 import java.util.HashSet;
 
 import com.amazon.randomcutforest.Visitor;
-import com.amazon.randomcutforest.state.store.LeafStoreState;
-import com.amazon.randomcutforest.state.store.NodeStoreState;
 import com.amazon.randomcutforest.store.IPointStoreView;
 import com.amazon.randomcutforest.store.LeafStore;
 import com.amazon.randomcutforest.store.NodeStore;
@@ -150,12 +148,8 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         }
     }
 
-    public NodeStoreState getNodes() {
-        return new NodeStoreState((NodeStore) nodeManager.getNodeStore());
-    }
-
-    public LeafStoreState getLeaves() {
-        return new LeafStoreState((LeafStore) nodeManager.getLeafStore());
+    public CompactNodeManager getNodeManager() {
+        return nodeManager;
     }
 
     public int getRootIndex() {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -22,8 +22,6 @@ import java.util.HashSet;
 
 import com.amazon.randomcutforest.Visitor;
 import com.amazon.randomcutforest.store.IPointStoreView;
-import com.amazon.randomcutforest.store.LeafStore;
-import com.amazon.randomcutforest.store.NodeStore;
 
 /**
  * A Compact Random Cut Tree is a tree data structure whose leaves represent
@@ -63,9 +61,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         super(seed, enableCache, enableCenterOfMass, enableSequenceIndices);
         checkArgument(maxSize > 0, "maxSize must be greater than 0");
         this.maxSize = maxSize;
-        nodeManager = new CompactNodeManager(new NodeStore((short) (this.maxSize - 1)),
-                new LeafStore((short) this.maxSize), this.maxSize);
-        // random = new Random(seed);
+        nodeManager = new CompactNodeManager(maxSize);
         rootIndex = null;
         this.enableCache = enableCache;
         if (enableSequenceIndices) {
@@ -73,17 +69,15 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         }
     }
 
-    public AbstractCompactRandomCutTree(int maxSize, long seed, LeafStore leafStore, NodeStore nodeStore, int rootIndex,
+    public AbstractCompactRandomCutTree(int maxSize, long seed, CompactNodeManager nodeManager, int rootIndex,
             boolean enableCache) {
         super(seed, enableCache, false, false);
         checkArgument(maxSize > 0, "maxSize must be greater than 0");
-        checkNotNull(leafStore, "leafStore must not be null");
-        checkNotNull(nodeStore, "nodeStore must not be null");
+        checkNotNull(nodeManager, "nodeManager must not be null");
 
         this.maxSize = maxSize;
         this.rootIndex = rootIndex;
-        // random = new Random(seed);
-        nodeManager = new CompactNodeManager(nodeStore, leafStore, maxSize);
+        this.nodeManager = nodeManager;
         this.enableCache = enableCache;
     }
 
@@ -264,5 +258,4 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
     protected int getMass(Integer node) {
         return nodeManager.getMass(node);
     }
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeManager.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeManager.java
@@ -17,8 +17,6 @@ package com.amazon.randomcutforest.tree;
 
 import static com.amazon.randomcutforest.CommonUtils.checkState;
 
-import com.amazon.randomcutforest.store.ILeafStore;
-import com.amazon.randomcutforest.store.INodeStore;
 import com.amazon.randomcutforest.store.LeafStore;
 import com.amazon.randomcutforest.store.NodeStore;
 
@@ -28,8 +26,8 @@ import com.amazon.randomcutforest.store.NodeStore;
  */
 public class CompactNodeManager {
 
-    private final ILeafStore leafstore;
-    private final INodeStore nodeStore;
+    private final LeafStore leafstore;
+    private final NodeStore nodeStore;
     private final int capacity;
     private final short NULL = -1;
 
@@ -161,11 +159,11 @@ public class CompactNodeManager {
         return leafstore.addLeaf(parentIndex, pointIndex, mass);
     }
 
-    public INodeStore getNodeStore() {
+    public NodeStore getNodeStore() {
         return nodeStore;
     }
 
-    public ILeafStore getLeafStore() {
+    public LeafStore getLeafStore() {
         return leafstore;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeManager.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeManager.java
@@ -17,6 +17,8 @@ package com.amazon.randomcutforest.tree;
 
 import static com.amazon.randomcutforest.CommonUtils.checkState;
 
+import com.amazon.randomcutforest.store.ILeafStore;
+import com.amazon.randomcutforest.store.INodeStore;
 import com.amazon.randomcutforest.store.LeafStore;
 import com.amazon.randomcutforest.store.NodeStore;
 
@@ -26,15 +28,21 @@ import com.amazon.randomcutforest.store.NodeStore;
  */
 public class CompactNodeManager {
 
-    private final LeafStore leafstore;
-    private final NodeStore nodeStore;
+    private final ILeafStore leafstore;
+    private final INodeStore nodeStore;
     private final int capacity;
     private final short NULL = -1;
 
-    CompactNodeManager(NodeStore nodeStore, LeafStore leafStore, int capacity) {
+    public CompactNodeManager(int treeCapacity) {
+        leafstore = new LeafStore((short) treeCapacity);
+        nodeStore = new NodeStore((short) (treeCapacity - 1));
+        capacity = treeCapacity;
+    }
+
+    public CompactNodeManager(int treeCapacity, INodeStore nodeStore, ILeafStore leafStore) {
         this.leafstore = leafStore;
         this.nodeStore = nodeStore;
-        this.capacity = capacity;
+        this.capacity = treeCapacity;
     }
 
     protected int intValue(Integer ref) {
@@ -159,11 +167,15 @@ public class CompactNodeManager {
         return leafstore.addLeaf(parentIndex, pointIndex, mass);
     }
 
-    public NodeStore getNodeStore() {
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public INodeStore getNodeStore() {
         return nodeStore;
     }
 
-    public LeafStore getLeafStore() {
+    public ILeafStore getLeafStore() {
         return leafstore;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -133,5 +133,4 @@ public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<dou
         }
         return cachedBoxes[nodeReference];
     }
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -20,8 +20,6 @@ import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 import java.util.Arrays;
 
 import com.amazon.randomcutforest.store.IPointStore;
-import com.amazon.randomcutforest.store.LeafStore;
-import com.amazon.randomcutforest.store.NodeStore;
 
 public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<double[]> {
 
@@ -38,12 +36,14 @@ public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<dou
         }
     }
 
-    public CompactRandomCutTreeDouble(int maxSize, long seed, IPointStore<double[]> pointStore, LeafStore leafStore,
-            NodeStore nodeStore, int rootIndex) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, true);
+    public CompactRandomCutTreeDouble(int maxSize, long seed, IPointStore<double[]> pointStore,
+            CompactNodeManager nodeManager, int rootIndex, boolean cacheEnabled) {
+        super(maxSize, seed, nodeManager, rootIndex, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
-        cachedBoxes = new BoundingBox[maxSize - 1];
+        if (cacheEnabled) {
+            cachedBoxes = new BoundingBox[maxSize - 1];
+        }
     }
 
     @Override

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
@@ -21,8 +21,6 @@ import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
 import java.util.Arrays;
 
 import com.amazon.randomcutforest.store.IPointStore;
-import com.amazon.randomcutforest.store.LeafStore;
-import com.amazon.randomcutforest.store.NodeStore;
 
 public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<float[]> {
 
@@ -39,12 +37,14 @@ public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<floa
         }
     }
 
-    public CompactRandomCutTreeFloat(int maxSize, long seed, IPointStore<float[]> pointStore, LeafStore leafStore,
-            NodeStore nodeStore, int rootIndex, boolean cacheEnabled) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, cacheEnabled);
+    public CompactRandomCutTreeFloat(int maxSize, long seed, IPointStore<float[]> pointStore,
+            CompactNodeManager nodeManager, int rootIndex, boolean cacheEnabled) {
+        super(maxSize, seed, nodeManager, rootIndex, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
-        cachedBoxes = new BoundingBoxFloat[maxSize - 1];
+        if (cacheEnabled) {
+            cachedBoxes = new BoundingBoxFloat[maxSize - 1];
+        }
     }
 
     @Override

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.state.sampler;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Random;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import com.amazon.randomcutforest.sampler.CompactSampler;
+import com.amazon.randomcutforest.state.RandomCutForestState;
+
+public class CompactSamplerMapperTest {
+    private CompactSamplerMapper mapper;
+    private RandomCutForestState forestState;
+
+    private static int sampleSize = 20;
+    private static double lambda = 0.01;
+
+    private static class SamplerProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            int sampleSize = 20;
+            double lambda = 0.01;
+            long seed = 4444;
+            CompactSampler sampler1 = new CompactSampler(sampleSize, lambda, seed, false);
+            CompactSampler sampler2 = new CompactSampler(sampleSize, lambda, seed, true);
+
+            Random random = new Random();
+            long baseIndex = 10_000;
+            for (int i = 0; i < 100; i++) {
+                int pointReference = random.nextInt();
+                sampler1.update(pointReference, baseIndex + i);
+                sampler2.update(pointReference, baseIndex + i);
+            }
+
+            return Stream.of(sampler1, sampler2).map(Arguments::of);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new CompactSamplerMapper();
+        mapper.setValidateHeap(true);
+        forestState = new RandomCutForestState();
+        forestState.setSampleSize(sampleSize);
+        forestState.setLambda(lambda);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SamplerProvider.class)
+    public void testRoundTrip(CompactSampler sampler) {
+        CompactSampler sampler2 = mapper.toModel(mapper.toState(sampler), forestState);
+        assertArrayEquals(sampler.getWeightArray(), sampler2.getWeightArray());
+        assertArrayEquals(sampler.getPointIndexArray(), sampler2.getPointIndexArray());
+        assertEquals(sampler.getCapacity(), sampler2.getCapacity());
+        assertEquals(sampler.size(), sampler2.size());
+        assertEquals(sampler.getLambda(), sampler2.getLambda());
+        assertFalse(sampler2.getEvictedPoint().isPresent());
+
+        if (sampler.isStoreSequenceIndexesEnabled()) {
+            assertTrue(sampler2.isStoreSequenceIndexesEnabled());
+            assertArrayEquals(sampler.getSequenceIndexArray(), sampler2.getSequenceIndexArray());
+        } else {
+            assertFalse(sampler2.isStoreSequenceIndexesEnabled());
+            assertNull(sampler2.getSequenceIndexArray());
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(SamplerProvider.class)
+    public void testRoundTripInvalidHeap(CompactSampler sampler) {
+        mapper.setValidateHeap(true);
+        CompactSamplerState state = mapper.toState(sampler);
+
+        // swap to weights in the weight array in order to violate the heap property
+        float[] weights = state.getWeight();
+        int index = weights.length / 4;
+        float temp = weights[index];
+        weights[index] = weights[2 * index + 1];
+        weights[2 * index + 1] = temp;
+
+        assertThrows(IllegalStateException.class, () -> mapper.toModel(state, forestState));
+
+        mapper.setValidateHeap(false);
+        CompactSampler sampler2 = mapper.toModel(state, forestState);
+        assertArrayEquals(sampler.getWeightArray(), sampler2.getWeightArray());
+    }
+}

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
@@ -33,14 +33,9 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.amazon.randomcutforest.sampler.CompactSampler;
-import com.amazon.randomcutforest.state.RandomCutForestState;
 
 public class CompactSamplerMapperTest {
     private CompactSamplerMapper mapper;
-    private RandomCutForestState forestState;
-
-    private static int sampleSize = 20;
-    private static double lambda = 0.01;
 
     private static class SamplerProvider implements ArgumentsProvider {
         @Override
@@ -67,15 +62,12 @@ public class CompactSamplerMapperTest {
     public void setUp() {
         mapper = new CompactSamplerMapper();
         mapper.setValidateHeap(true);
-        forestState = new RandomCutForestState();
-        forestState.setSampleSize(sampleSize);
-        forestState.setLambda(lambda);
     }
 
     @ParameterizedTest
     @ArgumentsSource(SamplerProvider.class)
     public void testRoundTrip(CompactSampler sampler) {
-        CompactSampler sampler2 = mapper.toModel(mapper.toState(sampler), forestState);
+        CompactSampler sampler2 = mapper.toModel(mapper.toState(sampler));
         assertArrayEquals(sampler.getWeightArray(), sampler2.getWeightArray());
         assertArrayEquals(sampler.getPointIndexArray(), sampler2.getPointIndexArray());
         assertEquals(sampler.getCapacity(), sampler2.getCapacity());
@@ -105,10 +97,10 @@ public class CompactSamplerMapperTest {
         weights[index] = weights[2 * index + 1];
         weights[2 * index + 1] = temp;
 
-        assertThrows(IllegalStateException.class, () -> mapper.toModel(state, forestState));
+        assertThrows(IllegalStateException.class, () -> mapper.toModel(state));
 
         mapper.setValidateHeap(false);
-        CompactSampler sampler2 = mapper.toModel(state, forestState);
+        CompactSampler sampler2 = mapper.toModel(state);
         assertArrayEquals(sampler.getWeightArray(), sampler2.getWeightArray());
     }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/store/LeafStoreMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/store/LeafStoreMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.state.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.store.LeafStore;
+
+public class LeafStoreMapperTest {
+    private LeafStoreMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new LeafStoreMapper();
+    }
+
+    @Test
+    public void testRoundTrip() {
+        LeafStore store = new LeafStore((short) 10);
+        int index1 = store.addLeaf(1, 2, 1);
+        int index2 = store.addLeaf(1, 3, 2);
+        int index3 = store.addLeaf(4, 5, 1);
+        int index4 = store.addLeaf(4, 6, 3);
+
+        LeafStore store2 = mapper.toModel(mapper.toState(store));
+        assertEquals(store.getCapacity(), store2.getCapacity());
+        assertEquals(store.size(), store2.size());
+
+        IntStream.of(index1, index2, index3, index4).forEach(i -> {
+            assertEquals(store.getParent(i), store2.getParent(i));
+            assertEquals(store.getPointIndex(i), store2.getPointIndex(i));
+            assertEquals(store.getMass(i), store2.getMass(i));
+        });
+    }
+}

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/store/NodeStoreMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/store/NodeStoreMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.state.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.store.NodeStore;
+
+public class NodeStoreMapperTest {
+    private NodeStoreMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new NodeStoreMapper();
+    }
+
+    @Test
+    public void testRoundTrip() {
+        NodeStore store = new NodeStore((short) 10);
+        int index1 = store.addNode(1, 2, 3, 1, 6.6, 1);
+        int index2 = store.addNode(1, 4, 5, 2, -14.8, 2);
+        int index3 = store.addNode(6, 7, 8, 1, 9.8, 4);
+        int index4 = store.addNode(6, 10, 11, 4, -1000.01, 1);
+
+        NodeStore store2 = mapper.toModel(mapper.toState(store));
+        assertEquals(store.getCapacity(), store2.getCapacity());
+        assertEquals(store.size(), store2.size());
+
+        IntStream.of(index1, index2, index3, index4).forEach(i -> {
+            assertEquals(store.getParent(i), store2.getParent(i));
+            assertEquals(store.getLeftIndex(i), store2.getLeftIndex(i));
+            assertEquals(store.getRightIndex(i), store2.getRightIndex(i));
+            assertEquals(store.getCutDimension(i), store2.getCutDimension(i));
+            assertEquals(store.getCutValue(i), store2.getCutValue(i));
+            assertEquals(store.getMass(i), store2.getMass(i));
+        });
+    }
+}

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapperTest.java
@@ -49,9 +49,6 @@ public class PointStoreDoubleMapperTest {
         assertEquals(capacity, store2.getCapacity());
         assertEquals(3, store2.size());
         assertEquals(dimensions, store2.getDimensions());
-
-        assertArrayEquals(point1, store2.get(index1));
-        assertArrayEquals(point2, store2.get(index2));
-        assertArrayEquals(point3, store2.get(index3));
+        assertArrayEquals(store.getStore(), store2.getStore());
     }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactNodeManagerMapperTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.state.tree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.tree.CompactNodeManager;
+
+public class CompactNodeManagerMapperTest {
+    private CompactNodeManagerMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        mapper = new CompactNodeManagerMapper();
+    }
+
+    @Test
+    public void testRoundTrip() {
+        CompactNodeManager manager = new CompactNodeManager(10);
+
+        int nodeIndex1 = manager.addNode(1, 2, 3, 0, 1.0, 1);
+        int nodeIndex2 = manager.addNode(1, 4, 5, 1, -1.0, 1);
+        int nodeIndex3 = manager.addNode(6, 7, 8, 3, 2.0, 3);
+        int nodeIndex4 = manager.addNode(6, 9, 10, 2, -1.0, 1);
+
+        int leafIndex1 = manager.addLeaf(2, 5, 3);
+        int leafIndex2 = manager.addLeaf(3, 40, 1);
+        int leafIndex3 = manager.addLeaf(10, 2, 2);
+
+        CompactNodeManager manager2 = mapper.toModel(mapper.toState(manager));
+        assertEquals(manager.getCapacity(), manager2.getCapacity());
+
+        IntStream.of(nodeIndex1, nodeIndex2, nodeIndex3, nodeIndex4).forEach(i -> {
+            assertFalse(manager2.isLeaf(i));
+            assertEquals(manager.getParent(i), manager2.getParent(i));
+            assertEquals(manager.getLeftChild(i), manager2.getLeftChild(i));
+            assertEquals(manager.getRightChild(i), manager2.getRightChild(i));
+            assertEquals(manager.getCutDimension(i), manager2.getCutDimension(i));
+            assertEquals(manager.getCutValue(i), manager2.getCutValue(i));
+            assertEquals(manager.getMass(i), manager2.getMass(i));
+        });
+
+        IntStream.of(leafIndex1, leafIndex2, leafIndex3).forEach(i -> {
+            assertTrue(manager2.isLeaf(i));
+            assertEquals(manager.getParent(i), manager2.getParent(i));
+            assertEquals(manager.getPointIndex(i), manager2.getPointIndex(i));
+            assertEquals(manager.getMass(i), manager2.getMass(i));
+        });
+    }
+}


### PR DESCRIPTION
This change makes it so that all state and mapper classes have a single
no-argument constructor and settable fields. Additionally, new test
cases are added to improve test coverage in the state package.

Closes #90


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
