### PR TITLE
Support mapping CompactSampler to state class without copy

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -181,6 +181,7 @@ public class CompactSampler implements IStreamSampler<Integer> {
      * determining the heap structure.
      *
      * @param sampleSize    The number of points in the sampler when full.
+     * @param size          The number of points currently stored in the sample.
      * @param lambda        The decay factor used for generating the weight of the
      *                      point. For greater values of lambda the sampler is more
      *                      biased in favor of recent points.
@@ -195,19 +196,20 @@ public class CompactSampler implements IStreamSampler<Integer> {
      *                      IllegalArgumentException if the weight array doesn't
      *                      satisfy the heap property.
      */
-    public CompactSampler(int sampleSize, double lambda, Random random, float[] weight, int[] pointIndex,
+    public CompactSampler(int sampleSize, int size, double lambda, Random random, float[] weight, int[] pointIndex,
             long[] sequenceIndex, boolean validateHeap) {
-        this(sampleSize, lambda, random, sequenceIndex != null);
+
         checkNotNull(weight, "weight must not be null");
         checkNotNull(pointIndex, "pointIndex must not be null");
 
-        size = weight.length;
-        System.arraycopy(weight, 0, this.weight, 0, size);
-        System.arraycopy(pointIndex, 0, this.pointIndex, 0, size);
-
-        if (sequenceIndex != null) {
-            System.arraycopy(sequenceIndex, 0, this.sequenceIndex, 0, size);
-        }
+        this.capacity = sampleSize;
+        this.size = size;
+        storeSequenceIndexesEnabled = (sequenceIndex != null);
+        this.random = random;
+        this.lambda = lambda;
+        this.weight = weight;
+        this.pointIndex = pointIndex;
+        this.sequenceIndex = sequenceIndex;
 
         reheap(validateHeap);
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
@@ -67,24 +67,24 @@ public class RandomCutForestMapper
      * A flag indicating whether the structure of the trees in the forest should be
      * included in the state object. If true, then data describing the bounding
      * boxes and cuts defining each tree will be written to the
-     * {@link RandomCutForestState} object produced by the mapper.
+     * {@link RandomCutForestState} object produced by the mapper. Tree state is not
+     * saved by default.
      */
-    private boolean saveTreeState;
+    private boolean saveTreeState = false;
 
     /**
      * A flag indicating whether the executor context should be included in the
-     * {@link RandomCutForestState} object produced by the mapper.
+     * {@link RandomCutForestState} object produced by the mapper. Executor context
+     * is not saved by defalt.
      */
-    private boolean saveExecutorContext;
+    private boolean saveExecutorContext = false;
 
     /**
-     * Crate a new mapper with {@code saveTreeState} and {@code saveExecutorContext}
-     * set to false.
+     * If true, then model data will be copied (i.e., the state class will not share
+     * any data with the model). If false, some model data may be shared with the
+     * state class. Copying is enabled by default.
      */
-    public RandomCutForestMapper() {
-        saveTreeState = false;
-        saveExecutorContext = false;
-    }
+    private boolean copy = true;
 
     /**
      * Create a {@link RandomCutForestState} object representing the state of the

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/LeafStoreMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/LeafStoreMapper.java
@@ -17,10 +17,22 @@ package com.amazon.randomcutforest.state.store;
 
 import java.util.Arrays;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.store.LeafStore;
 
+@Getter
+@Setter
 public class LeafStoreMapper implements IStateMapper<LeafStore, LeafStoreState> {
+    /**
+     * If true, then model data will be copied (i.e., the state class will not share
+     * any data with the model). If false, some model data may be shared with the
+     * state class. Copying is enabled by default.
+     */
+    private boolean copy = true;
+
     @Override
     public LeafStore toModel(LeafStoreState state, long seed) {
         int capacity = state.getPointIndex().length;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
@@ -17,10 +17,22 @@ package com.amazon.randomcutforest.state.store;
 
 import java.util.Arrays;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.store.NodeStore;
 
+@Getter
+@Setter
 public class NodeStoreMapper implements IStateMapper<NodeStore, NodeStoreState> {
+    /**
+     * If true, then model data will be copied (i.e., the state class will not share
+     * any data with the model). If false, some model data may be shared with the
+     * state class. Copying is enabled by default.
+     */
+    private boolean copy = true;
+
     @Override
     public NodeStore toModel(NodeStoreState state, long seed) {
         int capacity = state.getLeftIndex().length;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
@@ -19,10 +19,21 @@ import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 
 import java.util.Arrays;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.store.PointStoreDouble;
 
+@Getter
+@Setter
 public class PointStoreDoubleMapper implements IStateMapper<PointStoreDouble, PointStoreState> {
+    /**
+     * If true, then model data will be copied (i.e., the state class will not share
+     * any data with the model). If false, some model data may be shared with the
+     * state class. Copying is enabled by default.
+     */
+    private boolean copy = true;
 
     @Override
     public PointStoreDouble toModel(PointStoreState state, long seed) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
@@ -19,10 +19,21 @@ import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 
 import java.util.Arrays;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.store.PointStoreFloat;
 
+@Getter
+@Setter
 public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, PointStoreState> {
+    /**
+     * If true, then model data will be copied (i.e., the state class will not share
+     * any data with the model). If false, some model data may be shared with the
+     * state class. Copying is enabled by default.
+     */
+    private boolean copy = true;
 
     @Override
     public PointStoreFloat toModel(PointStoreState state, long seed) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
@@ -83,7 +83,8 @@ public class CompactSamplerTest {
         // weight array is valid heap
         float[] weight = { 0.4f, 0.3f, 0.2f };
         int[] pointIndex = { 1, 2, 3 };
-        CompactSampler sampler = new CompactSampler(sampleSize, lambda, new Random(), weight, pointIndex, null, true);
+        CompactSampler sampler = new CompactSampler(sampleSize, weight.length, lambda, new Random(), weight, pointIndex,
+                null, true);
 
         assertFalse(sampler.getEvictedPoint().isPresent());
         assertFalse(sampler.isStoreSequenceIndexesEnabled());
@@ -231,7 +232,7 @@ public class CompactSamplerTest {
         weightArray[i] = weightArray[2 * i + 1];
         weightArray[2 * i + 1] = f;
 
-        assertThrows(IllegalStateException.class, () -> new CompactSampler(sampleSize, lambda, random, weightArray,
-                sampler.getPointIndexArray(), sampler.getSequenceIndexArray(), true));
+        assertThrows(IllegalStateException.class, () -> new CompactSampler(sampleSize, sampleSize, lambda, random,
+                weightArray, sampler.getPointIndexArray(), sampler.getSequenceIndexArray(), true));
     }
 }


### PR DESCRIPTION
In addition, the copy flag is added to other applicable mapper classes,
but the behavior (mapping without copy) is only implemented for
CompactSamplerMapper in this commit.

Partially implements #79 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
