### PR TITLE
Add new examples module

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -158,13 +158,13 @@ Test dependencies will be downloaded automatically when invoking `mvn test` or `
 
 ## Benchmarks
 
-The benchmark modules defines microbenchmarks using the [JMH](https://openjdk.java.net/projects/code-tools/jmh/) 
+The benchmark module defines microbenchmarks using the [JMH](https://openjdk.java.net/projects/code-tools/jmh/) 
 framework. Build an executable jar containing the benchmark code by running
 
 ```text
 % # (Optional) To benchmark the code in your local repository, build and install to your local Maven repository
 % # Otherwise, benchmark dependencies will be pulled from Maven central
-% mvn package install -DexcludedGroups=functional
+% mvn package install -DexcludedGroups=functional -Dgpg.skip
 % 
 % mvn -pl benchmark package assembly:single
 ```
@@ -187,4 +187,36 @@ different configurations, then you'll need to enable the `StringSizeProfiler` in
 
 ```text
 % java -jar benchmark/target/randomcutforest-benchmark-1.0-jar-with-dependencies.jar SerDeOutputLengthBenchmark -prof com.amazon.randomcutforest.profilers.StringSizeProfiler
+```
+
+## Examples
+
+The examples module provides runnable code examples using the library. Build an executable jar containing the
+examples by running:
+
+```text
+% # (Optional) To run examples using code in your local repository, build and install to your local Maven repository
+% # Otherwise, dependencies will be pulled from Maven central
+% mvn package install -DexcludedGroups=functional -Dgpg.skip
+% 
+% mvn -pl examples package assembly:single
+```
+
+To see a list of examples:
+
+```text
+% java -jar examples/target/randomcutforest-examples-1.0-jar-with-dependencies.jar
+Usage: java -cp randomcutforest-examples-1.0.jar [example]
+Examples:
+               json - serialize a Random Cut Forest as a JSON string
+         protostuff - serialize a Random Cut Forest with the protostuff library
+```
+
+To run an example, provide the example name:
+
+```text
+% java -jar examples/target/randomcutforest-examples-1.0-alpha-jar-with-dependencies.jar json
+dimensions = 4, numberOfTrees = 50, sampleSize = 256, precision = DOUBLE
+JSON size = 550295 bytes
+Looks good!
 ```

--- a/Java/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
  */
 public class ArgumentParser {
 
-    public static final String ARCHIVE_NAME = "target/random-cut-forest-1.0.jar";
+    public static final String ARCHIVE_NAME = "randomcutforest-core-1.0.jar";
     private final String runnerClass;
     private final String runnerDescription;
     private final Map<String, Argument<?>> shortFlags;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
@@ -18,6 +18,7 @@ package com.amazon.randomcutforest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.amazon.randomcutforest.config.Precision;
@@ -28,6 +29,7 @@ import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
  * (sequential or parallel) or different internal data representations are
  * executing the algorithm steps in the same way.
  */
+@Tag("functional")
 public class RandomCutForestConsistencyFunctionalTest {
 
     private int dimensions = 5;

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>software.amazon.randomcutforest</groupId>
+        <artifactId>randomcutforest-parent</artifactId>
+        <version>1.0-alpha</version>
+    </parent>
+
+    <artifactId>randomcutforest-examples</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.randomcutforest</groupId>
+            <artifactId>randomcutforest-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.randomcutforest</groupId>
+            <artifactId>randomcutforest-testutils</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.protostuff</groupId>
+            <artifactId>protostuff-core</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.protostuff</groupId>
+            <artifactId>protostuff-runtime</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.amazon.randomcutforest.examples.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/Example.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/Example.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples;
+
+public interface Example {
+    String command();
+
+    String description();
+
+    void run() throws Exception;
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/Main.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/Main.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.amazon.randomcutforest.examples.serialization.JsonExample;
+import com.amazon.randomcutforest.examples.serialization.ProtostuffExample;
+
+public class Main {
+
+    public static final String ARCHIVE_NAME = "randomcutforest-examples-1.0.jar";
+
+    public static void main(String[] args) throws Exception {
+        new Main().run(args);
+    }
+
+    private final Map<String, Example> examples;
+    private int maxCommandLength;
+
+    public Main() {
+        examples = new TreeMap<>();
+        maxCommandLength = 0;
+        add(new JsonExample());
+        add(new ProtostuffExample());
+    }
+
+    private void add(Example example) {
+        examples.put(example.command(), example);
+        if (maxCommandLength < example.command().length()) {
+            maxCommandLength = example.command().length();
+        }
+    }
+
+    public void run(String[] args) throws Exception {
+        if (args == null || args.length < 1 || args[0].equals("-h") || args[0].equals("--help")) {
+            printUsage();
+            return;
+        }
+
+        String command = args[0];
+        if (!examples.containsKey(command)) {
+            throw new IllegalArgumentException("No such example: " + command);
+        }
+
+        examples.get(command).run();
+    }
+
+    public void printUsage() {
+        System.out.printf("Usage: java -cp %s [example]%n", ARCHIVE_NAME);
+        System.out.println("Examples:");
+        String formatString = String.format("\t %%%ds - %%s%%n", maxCommandLength);
+        for (Example example : examples.values()) {
+            System.out.printf(formatString, example.command(), example.description());
+        }
+    }
+
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
@@ -28,6 +28,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * <a href="https://github.com/FasterXML/jackson">Jackson</a>.
  */
 public class JsonExample implements Example {
+
+    public static void main(String[] args) throws Exception {
+        new JsonExample().run();
+    }
+
     @Override
     public String command() {
         return "json";

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.serialization;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.state.RandomCutForestMapper;
+import com.amazon.randomcutforest.state.RandomCutForestState;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Serialize a Random Cut Forest to JSON using
+ * <a href="https://github.com/FasterXML/jackson">Jackson</a>.
+ */
+public class JsonExample implements Example {
+    @Override
+    public String command() {
+        return "json";
+    }
+
+    @Override
+    public String description() {
+        return "serialize a Random Cut Forest as a JSON string";
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Create and populate a random cut forest
+
+        int dimensions = 4;
+        int numberOfTrees = 50;
+        int sampleSize = 256;
+        Precision precision = Precision.DOUBLE;
+
+        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+                .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
+
+        int dataSize = 4 * sampleSize;
+        NormalMixtureTestData testData = new NormalMixtureTestData();
+        for (double[] point : testData.generateTestData(dataSize, dimensions)) {
+            forest.update(point);
+        }
+
+        // Convert to JSON and print the number of bytes
+
+        RandomCutForestMapper mapper = new RandomCutForestMapper();
+        mapper.setSaveExecutorContext(true);
+        mapper.setCopy(true);
+        ObjectMapper jsonMapper = new ObjectMapper();
+
+        String json = jsonMapper.writeValueAsString(mapper.toState(forest));
+
+        System.out.printf("dimensions = %d, numberOfTrees = %d, sampleSize = %d, precision = %s%n", dimensions,
+                numberOfTrees, sampleSize, precision);
+        System.out.printf("JSON size = %d bytes%n", json.getBytes().length);
+
+        // Restore from JSON and compare anomaly scores produced by the two forests
+
+        RandomCutForest forest2 = mapper.toModel(jsonMapper.readValue(json, RandomCutForestState.class));
+
+        int testSize = 100;
+        double delta = Math.log(sampleSize) / Math.log(2) * 0.05;
+
+        int differences = 0;
+        int anomalies = 0;
+
+        for (double[] point : testData.generateTestData(testSize, dimensions)) {
+            double score = forest.getAnomalyScore(point);
+            double score2 = forest2.getAnomalyScore(point);
+
+            // we mostly care that points that are scored as an anomaly by one forest are
+            // also scored as an anomaly by the other forest
+            if (score > 1 || score2 > 1) {
+                anomalies++;
+                if (Math.abs(score - score2) > delta) {
+                    differences++;
+                }
+            }
+
+            forest.update(point);
+            forest2.update(point);
+        }
+
+        // first validate that this was a nontrivial test
+        if (anomalies == 0) {
+            throw new IllegalStateException("test data did not produce any anomalies");
+        }
+
+        // validate that the two forests agree on anomaly scores
+        if (differences >= 0.01 * testSize) {
+            throw new IllegalStateException("restored forest does not agree with original forest");
+        }
+
+        System.out.println("Looks good!");
+    }
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.serialization;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.state.RandomCutForestMapper;
+import com.amazon.randomcutforest.state.RandomCutForestState;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+
+import io.protostuff.LinkedBuffer;
+import io.protostuff.ProtostuffIOUtil;
+import io.protostuff.Schema;
+import io.protostuff.runtime.RuntimeSchema;
+
+/**
+ * Serialize a Random Cut Forest using the
+ * <a href="https://github.com/protostuff/protostuff">protostuff</a> library.
+ */
+public class ProtostuffExample implements Example {
+    @Override
+    public String command() {
+        return "protostuff";
+    }
+
+    @Override
+    public String description() {
+        return "serialize a Random Cut Forest with the protostuff library";
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Create and populate a random cut forest
+
+        int dimensions = 4;
+        int numberOfTrees = 50;
+        int sampleSize = 256;
+        Precision precision = Precision.DOUBLE;
+
+        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+                .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
+
+        int dataSize = 4 * sampleSize;
+        NormalMixtureTestData testData = new NormalMixtureTestData();
+        for (double[] point : testData.generateTestData(dataSize, dimensions)) {
+            forest.update(point);
+        }
+
+        // Convert to an array of bytes and print the size
+
+        RandomCutForestMapper mapper = new RandomCutForestMapper();
+        mapper.setSaveExecutorContext(true);
+        mapper.setCopy(true);
+
+        Schema<RandomCutForestState> schema = RuntimeSchema.getSchema(RandomCutForestState.class);
+        LinkedBuffer buffer = LinkedBuffer.allocate(512);
+        byte[] bytes;
+        try {
+            RandomCutForestState state = mapper.toState(forest);
+            bytes = ProtostuffIOUtil.toByteArray(state, schema, buffer);
+        } finally {
+            buffer.clear();
+        }
+
+        System.out.printf("dimensions = %d, numberOfTrees = %d, sampleSize = %d, precision = %s%n", dimensions,
+                numberOfTrees, sampleSize, precision);
+        System.out.printf("protostuff size = %d bytes%n", bytes.length);
+
+        // Restore from protostuff and compare anomaly scores produced by the two
+        // forests
+
+        RandomCutForestState state2 = schema.newMessage();
+        ProtostuffIOUtil.mergeFrom(bytes, state2, schema);
+        RandomCutForest forest2 = mapper.toModel(state2);
+
+        int testSize = 100;
+        double delta = Math.log(sampleSize) / Math.log(2) * 0.05;
+
+        int differences = 0;
+        int anomalies = 0;
+
+        for (double[] point : testData.generateTestData(testSize, dimensions)) {
+            double score = forest.getAnomalyScore(point);
+            double score2 = forest2.getAnomalyScore(point);
+
+            // we mostly care that points that are scored as an anomaly by one forest are
+            // also scored as an anomaly by the other forest
+            if (score > 1 || score2 > 1) {
+                anomalies++;
+                if (Math.abs(score - score2) > delta) {
+                    differences++;
+                }
+            }
+
+            forest.update(point);
+            forest2.update(point);
+        }
+
+        // first validate that this was a nontrivial test
+        if (anomalies == 0) {
+            throw new IllegalStateException("test data did not produce any anomalies");
+        }
+
+        // validate that the two forests agree on anomaly scores
+        if (differences >= 0.01 * testSize) {
+            throw new IllegalStateException("restored forest does not agree with original forest");
+        }
+
+        System.out.println("Looks good!");
+    }
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
@@ -32,6 +32,10 @@ import io.protostuff.runtime.RuntimeSchema;
  * <a href="https://github.com/protostuff/protostuff">protostuff</a> library.
  */
 public class ProtostuffExample implements Example {
+    public static void main(String[] args) throws Exception {
+        new ProtostuffExample().run();
+    }
+
     @Override
     public String command() {
         return "protostuff";

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -38,6 +38,7 @@
     <modules>
         <module>core</module>
         <module>benchmark</module>
+        <module>examples</module>
         <module>serialization-json</module>
         <module>testutils</module>
     </modules>


### PR DESCRIPTION
Add new module with serialization examples and runner.

We are planning to remove the serialization-json module from v2 (#128) because the new state classes are POJOs that shouldn't require special logic to work with any Java serialization library. However, we think it will be useful for users to see code examples of serialization, as well as applications of different RCF algorithms. This PR creates a new Maven module for examples that can be invoked by a simple CLI runner. Since these are primarily intended to be code examples and not  functional utilities, the design does not include support for passing arguments to the examples.

Closes #129 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
