### PR TITLE
Reduce the sensitivy of the single-precision consistency test

### DIFF
--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
@@ -110,7 +110,7 @@ public class RandomCutForestConsistencyFunctionalTest {
 
             // we expect some loss of precision when comparing to the score computed as a
             // double
-            assertEquals(score, compactDoubleCached.getAnomalyScore(point), 1e-5);
+            assertEquals(score, compactDoubleCached.getAnomalyScore(point), 1e-3);
 
             compactFloatCached.update(point);
             compactFloatUncached.update(point);


### PR DESCRIPTION
Reduce the sensitivity of testConsistentScoringSinglePrecision by increasing the delta used when comparing score values. Currently this is a flaky test, and this change should reduce the number of sporadic failures.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
