### PR TITLE
Use -1 to represent missing root index in AbstractCompactRandomCutTree

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
@@ -60,14 +60,14 @@ public class CompactRandomCutTreeDoubleMapper implements
         }
 
         return new CompactRandomCutTreeDouble(context.getMaxSize(), seed, (PointStoreDouble) context.getPointStore(),
-                leafStore, nodeStore, state.getRootIndex(), boundingBoxCacheEnabled);
+                leafStore, nodeStore, state.getRoot(), boundingBoxCacheEnabled);
 
     }
 
     @Override
     public CompactRandomCutTreeState toState(CompactRandomCutTreeDouble model) {
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
-        state.setRootIndex(model.getRootIndex());
+        state.setRoot(model.getRoot());
 
         if (model.getMaxSize() < SmallNodeStore.MAX_TREE_SIZE) {
             SmallLeafStoreMapper leafStoreMapper = new SmallLeafStoreMapper();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
@@ -59,13 +59,13 @@ public class CompactRandomCutTreeFloatMapper implements
             nodeStore = nodeStoreMapper.toModel(state.getNodeStoreState());
         }
         return new CompactRandomCutTreeFloat(context.getMaxSize(), seed, (PointStoreFloat) context.getPointStore(),
-                leafStore, nodeStore, state.getRootIndex(), boundingBoxCacheEnabled);
+                leafStore, nodeStore, state.getRoot(), boundingBoxCacheEnabled);
     }
 
     @Override
     public CompactRandomCutTreeState toState(CompactRandomCutTreeFloat model) {
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
-        state.setRootIndex(model.getRootIndex());
+        state.setRoot(model.getRoot());
 
         if (model.getMaxSize() < SmallNodeStore.MAX_TREE_SIZE) {
             SmallLeafStoreMapper leafStoreMapper = new SmallLeafStoreMapper();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
@@ -22,7 +22,7 @@ import com.amazon.randomcutforest.state.store.NodeStoreState;
 
 @Data
 public class CompactRandomCutTreeState {
-    private int rootIndex;
+    private int root;
     private LeafStoreState leafStoreState;
     private NodeStoreState nodeStoreState;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -75,7 +75,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
             leafStore = new LeafStore(maxSize);
             nodeStore = new NodeStore(maxSize - 1);
         }
-        rootIndex = null;
+        root = NULL;
         this.enableCache = enableCache;
         if (enableSequenceIndices) {
             sequenceIndexes = new HashSet[maxSize];
@@ -85,8 +85,8 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         // setBoundingBoxCacheFraction(0.3);
     }
 
-    public AbstractCompactRandomCutTree(int maxSize, long seed, ILeafStore leafStore, INodeStore nodeStore,
-            int rootIndex, boolean enableCache) {
+    public AbstractCompactRandomCutTree(int maxSize, long seed, ILeafStore leafStore, INodeStore nodeStore, int root,
+            boolean enableCache) {
         super(seed, enableCache, false, false);
         checkArgument(maxSize > 0, "maxSize must be greater than 0");
         checkNotNull(leafStore, "leafStore must not be null");
@@ -95,7 +95,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         this.maxSize = maxSize;
         this.leafStore = leafStore;
         this.nodeStore = nodeStore;
-        this.rootIndex = rootIndex;
+        this.root = root;
         this.enableCache = enableCache;
     }
 
@@ -199,10 +199,6 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         if (cachedBoxes[tempNode] != null) {
             cachedBoxes[tempNode].addPoint(point); // internal boxes can be updated in place
         }
-    }
-
-    public int getRootIndex() {
-        return rootIndex;
     }
 
     @Override
@@ -399,5 +395,10 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
 
     public int getMaxSize() {
         return maxSize;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return root == NULL;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -40,8 +40,8 @@ public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<dou
     }
 
     public CompactRandomCutTreeDouble(int maxSize, long seed, IPointStore<double[]> pointStore, ILeafStore leafStore,
-            INodeStore nodeStore, int rootIndex, boolean cacheEnabled) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, cacheEnabled);
+            INodeStore nodeStore, int root, boolean cacheEnabled) {
+        super(maxSize, seed, leafStore, nodeStore, root, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
         if (cacheEnabled) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
@@ -40,8 +40,8 @@ public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<floa
     }
 
     public CompactRandomCutTreeFloat(int maxSize, long seed, IPointStore<float[]> pointStore, ILeafStore leafStore,
-            INodeStore nodeStore, int rootIndex, boolean cacheEnabled) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, cacheEnabled);
+            INodeStore nodeStore, int root, boolean cacheEnabled) {
+        super(maxSize, seed, leafStore, nodeStore, root, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
         if (cacheEnabled) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
@@ -44,9 +44,9 @@ public class HyperTree extends RandomCutTree {
         // this function allows a public call, which may be useful someday
         if (list.size() > 0) {
             // dimensions = list.get(0).length;
-            rootIndex = makeTreeInt(list, seed, 0, this.gVecBuild);
+            root = makeTreeInt(list, seed, 0, this.gVecBuild);
         } else {
-            rootIndex = null;
+            root = null;
         }
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -57,7 +57,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
     protected RandomCutTree(Builder<?> builder) {
         super(builder.random, builder.boundingBoxCachingEnabled, builder.centerOfMassEnabled,
                 builder.storeSequenceIndexesEnabled);
-        super.rootIndex = null;
+        super.root = null;
     }
 
     /**
@@ -103,14 +103,14 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
 
     public RandomCutTree(long seed, boolean enableCache, boolean enableCenterOfMass, boolean enableSequenceIndices) {
         super(seed, enableCache, enableCenterOfMass, enableSequenceIndices);
-        rootIndex = null;
+        root = null;
         setBoundingBoxCacheFraction(1.0);
     }
 
     public RandomCutTree(Random random, boolean enableCache, boolean enableCenterOfMass,
             boolean enableSequenceIndices) {
         super(random, enableCache, enableCenterOfMass, enableSequenceIndices);
-        rootIndex = null;
+        root = null;
     }
 
     @Override
@@ -309,10 +309,6 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
     @Override
     protected int getMass(Node node) {
         return node.getMass();
-    }
-
-    protected Node getRoot() {
-        return rootIndex;
     }
 
     @Override

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
@@ -82,6 +82,6 @@ public class CompactRandomCutTreeDoubleMapperTest {
     public void testRoundTrip(CompactRandomCutTreeDouble tree, CompactRandomCutTreeContext context) {
         CompactRandomCutTreeDouble tree2 = mapper.toModel(mapper.toState(tree), context);
 
-        assertEquals(tree.getRootIndex(), tree2.getRootIndex());
+        assertEquals(tree.getRoot(), tree2.getRoot());
     }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
@@ -82,6 +82,6 @@ public class CompactRandomCutTreeFloatMapperTest {
     public void testRoundTrip(CompactRandomCutTreeFloat tree, CompactRandomCutTreeContext context) {
         CompactRandomCutTreeFloat tree2 = mapper.toModel(mapper.toState(tree), context);
 
-        assertEquals(tree.getRootIndex(), tree2.getRootIndex());
+        assertEquals(tree.getRoot(), tree2.getRoot());
     }
 }


### PR DESCRIPTION
Previously we were using null, which resulted in a NPE when getting the root index. After this change, an empty compact tree will have its root value set to -1, which breaks existing logic in `AbstractRandomCutTree`. Specifically, that class assumed that an empty tree would have a null root value. I added a method `isEmpty` to `AbstractRandomCutTree` so that this assumption can overridden.

I also changed the variable name `rootIndex` in `AbstractRandomCutTree` to `root`, since the "index" part only made sense for compact trees. I moved the getter method `getRoot` to `AbstractRandomCutTree` (it was previously in `AbstractCompactRandomCutTree`.

Closes #142




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
