### PR TITLE
Return a valid int value in getRootIndex

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
@@ -60,14 +60,14 @@ public class CompactRandomCutTreeDoubleMapper implements
         }
 
         return new CompactRandomCutTreeDouble(context.getMaxSize(), seed, (PointStoreDouble) context.getPointStore(),
-                leafStore, nodeStore, state.getRootIndex(), boundingBoxCacheEnabled);
+                leafStore, nodeStore, state.getRoot(), boundingBoxCacheEnabled);
 
     }
 
     @Override
     public CompactRandomCutTreeState toState(CompactRandomCutTreeDouble model) {
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
-        state.setRootIndex(model.getRootIndex());
+        state.setRoot(model.getRootIndex());
 
         if (model.getMaxSize() < SmallNodeStore.MAX_TREE_SIZE) {
             SmallLeafStoreMapper leafStoreMapper = new SmallLeafStoreMapper();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
@@ -59,13 +59,13 @@ public class CompactRandomCutTreeFloatMapper implements
             nodeStore = nodeStoreMapper.toModel(state.getNodeStoreState());
         }
         return new CompactRandomCutTreeFloat(context.getMaxSize(), seed, (PointStoreFloat) context.getPointStore(),
-                leafStore, nodeStore, state.getRootIndex(), boundingBoxCacheEnabled);
+                leafStore, nodeStore, state.getRoot(), boundingBoxCacheEnabled);
     }
 
     @Override
     public CompactRandomCutTreeState toState(CompactRandomCutTreeFloat model) {
         CompactRandomCutTreeState state = new CompactRandomCutTreeState();
-        state.setRootIndex(model.getRootIndex());
+        state.setRoot(model.getRoot());
 
         if (model.getMaxSize() < SmallNodeStore.MAX_TREE_SIZE) {
             SmallLeafStoreMapper leafStoreMapper = new SmallLeafStoreMapper();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
@@ -22,7 +22,7 @@ import com.amazon.randomcutforest.state.store.NodeStoreState;
 
 @Data
 public class CompactRandomCutTreeState {
-    private int rootIndex;
+    private int root;
     private LeafStoreState leafStoreState;
     private NodeStoreState nodeStoreState;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -75,7 +75,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
             leafStore = new LeafStore(maxSize);
             nodeStore = new NodeStore(maxSize - 1);
         }
-        rootIndex = null;
+        root = null;
         this.enableCache = enableCache;
         if (enableSequenceIndices) {
             sequenceIndexes = new HashSet[maxSize];
@@ -85,8 +85,8 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         // setBoundingBoxCacheFraction(0.3);
     }
 
-    public AbstractCompactRandomCutTree(int maxSize, long seed, ILeafStore leafStore, INodeStore nodeStore,
-            int rootIndex, boolean enableCache) {
+    public AbstractCompactRandomCutTree(int maxSize, long seed, ILeafStore leafStore, INodeStore nodeStore, int root,
+            boolean enableCache) {
         super(seed, enableCache, false, false);
         checkArgument(maxSize > 0, "maxSize must be greater than 0");
         checkNotNull(leafStore, "leafStore must not be null");
@@ -95,7 +95,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         this.maxSize = maxSize;
         this.leafStore = leafStore;
         this.nodeStore = nodeStore;
-        this.rootIndex = rootIndex;
+        this.root = root == NULL ? null : root;
         this.enableCache = enableCache;
     }
 
@@ -199,10 +199,6 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
         if (cachedBoxes[tempNode] != null) {
             cachedBoxes[tempNode].addPoint(point); // internal boxes can be updated in place
         }
-    }
-
-    public int getRootIndex() {
-        return rootIndex;
     }
 
     @Override
@@ -399,5 +395,9 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
 
     public int getMaxSize() {
         return maxSize;
+    }
+
+    public int getRootIndex() {
+        return intValue(root);
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
@@ -49,7 +49,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
      */
 
     private final Random random;
-    protected NodeReference rootIndex;
+    protected NodeReference root;
     public final boolean enableCache;
     public final boolean enableCenterOfMass;
     public final boolean enableSequenceIndices;
@@ -154,24 +154,6 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
     protected abstract AbstractBoundingBox<Point> constructBoxInPlace(NodeReference nodeReference);
 
-    /*
-     * // constructing a bounding box in place protected AbstractBoundingBox<Point>
-     * constructBoxInPlace(NodeReference nodeReference) { if (isLeaf(nodeReference))
-     * { return getMutableLeafBoxFromLeafNode(nodeReference); } else {
-     * AbstractBoundingBox<Point> currentBox =
-     * constructBoxInPlace(getLeftChild(nodeReference)); return
-     * constructBoxInPlace(currentBox, getRightChild(nodeReference));
-     * 
-     * } }
-     * 
-     * AbstractBoundingBox<Point> constructBoxInPlace(AbstractBoundingBox<Point>
-     * currentBox, NodeReference nodeReference) { if (isLeaf(nodeReference)) {
-     * return currentBox.addPoint(getPointFromLeafNode(nodeReference)); } else {
-     * AbstractBoundingBox<Point> tempBox = constructBoxInPlace(currentBox,
-     * getLeftChild(nodeReference)); // the box may be changed for single points
-     * return constructBoxInPlace(tempBox, getRightChild(nodeReference)); } }
-     */
-
     // gets the actual values of a point from its reference which can be
     // Integer/direct reference
     abstract Point getPointFromPointReference(PointReference pointIndex);
@@ -269,8 +251,8 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
     @Override
     public void deletePoint(PointReference pointReference, long sequenceNumber) {
-        checkState(rootIndex != null, "root must not be null");
-        deletePoint(rootIndex, getPointFromPointReference(pointReference), sequenceNumber, 0);
+        checkState(root != null, "root must not be null");
+        deletePoint(root, getPointFromPointReference(pointReference), sequenceNumber, 0);
     }
 
     /**
@@ -306,7 +288,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
             NodeReference parent = getParent(nodeReference);
 
             if (parent == null) {
-                rootIndex = null;
+                root = null;
                 delete(nodeReference);
                 return;
             }
@@ -314,8 +296,8 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
             NodeReference grandParent = getParent(parent);
             if (grandParent == null) {
-                rootIndex = getSibling(nodeReference);
-                setParent(rootIndex, null);
+                root = getSibling(nodeReference);
+                setParent(root, null);
             } else {
                 replaceNodeBySibling(grandParent, parent, nodeReference);
                 updateAncestorNodesAfterDelete(grandParent, point);
@@ -380,7 +362,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
             NodeReference parent = getParent(siblingNode);
             if (parent == null) {
-                rootIndex = mergedNode;
+                root = mergedNode;
             } else {
                 replaceChild(parent, siblingNode, mergedNode);
             }
@@ -510,15 +492,15 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
     public PointReference addPoint(PointReference pointReference, long sequenceNumber) {
         int saveMass = getMass();
         Point pointValue = getPointFromPointReference(pointReference);
-        if (rootIndex == null) {
-            rootIndex = addLeaf(pointReference);
+        if (root == null) {
+            root = addLeaf(pointReference);
             if (enableSequenceIndices) {
-                addSequenceIndex(rootIndex, sequenceNumber);
+                addSequenceIndex(root, sequenceNumber);
             }
             checkState(saveMass + 1 == getMass(), "incorrect add");
             return pointReference;
         } else {
-            AddPointState<Point, NodeReference, PointReference> addPointState = addPoint(rootIndex, pointValue,
+            AddPointState<Point, NodeReference, PointReference> addPointState = addPoint(root, pointValue,
                     pointReference, sequenceNumber);
             resolve(pointValue, null, addPointState);
             checkState(saveMass + 1 == getMass(), "incorrect add");
@@ -569,9 +551,9 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
      */
     @Override
     public <R> R traverse(double[] point, Function<ITree<?>, Visitor<R>> visitorFactory) {
-        checkState(rootIndex != null, "this tree doesn't contain any nodes");
+        checkState(root != null, "this tree doesn't contain any nodes");
         Visitor<R> visitor = visitorFactory.apply(this);
-        traversePathToLeafAndVisitNodes(point, visitor, rootIndex, 0);
+        traversePathToLeafAndVisitNodes(point, visitor, root, 0);
         return visitor.getResult();
     }
 
@@ -608,9 +590,9 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
     public <R> R traverseMulti(double[] point, Function<ITree<?>, MultiVisitor<R>> visitorFactory) {
         checkNotNull(point, "point must not be null");
         checkNotNull(visitorFactory, "visitor must not be null");
-        checkState(rootIndex != null, "this tree doesn't contain any nodes");
+        checkState(root != null, "this tree doesn't contain any nodes");
         MultiVisitor<R> visitor = visitorFactory.apply(this);
-        traverseTreeMulti(point, visitor, rootIndex, 0);
+        traverseTreeMulti(point, visitor, root, 0);
         return visitor.getResult();
     }
 
@@ -637,7 +619,10 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
     @Override
     public int getMass() {
-        return (rootIndex == null) ? 0 : getMass(rootIndex);
+        return root == null ? 0 : getMass(root);
     }
 
+    public NodeReference getRoot() {
+        return root;
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -40,8 +40,8 @@ public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<dou
     }
 
     public CompactRandomCutTreeDouble(int maxSize, long seed, IPointStore<double[]> pointStore, ILeafStore leafStore,
-            INodeStore nodeStore, int rootIndex, boolean cacheEnabled) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, cacheEnabled);
+            INodeStore nodeStore, int root, boolean cacheEnabled) {
+        super(maxSize, seed, leafStore, nodeStore, root, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
         if (cacheEnabled) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
@@ -40,8 +40,8 @@ public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<floa
     }
 
     public CompactRandomCutTreeFloat(int maxSize, long seed, IPointStore<float[]> pointStore, ILeafStore leafStore,
-            INodeStore nodeStore, int rootIndex, boolean cacheEnabled) {
-        super(maxSize, seed, leafStore, nodeStore, rootIndex, cacheEnabled);
+            INodeStore nodeStore, int root, boolean cacheEnabled) {
+        super(maxSize, seed, leafStore, nodeStore, root, cacheEnabled);
         checkNotNull(pointStore, "pointStore must not be null");
         super.pointStore = pointStore;
         if (cacheEnabled) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
@@ -44,9 +44,9 @@ public class HyperTree extends RandomCutTree {
         // this function allows a public call, which may be useful someday
         if (list.size() > 0) {
             // dimensions = list.get(0).length;
-            rootIndex = makeTreeInt(list, seed, 0, this.gVecBuild);
+            root = makeTreeInt(list, seed, 0, this.gVecBuild);
         } else {
-            rootIndex = null;
+            root = null;
         }
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -57,7 +57,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
     protected RandomCutTree(Builder<?> builder) {
         super(builder.random, builder.boundingBoxCachingEnabled, builder.centerOfMassEnabled,
                 builder.storeSequenceIndexesEnabled);
-        super.rootIndex = null;
+        super.root = null;
     }
 
     /**
@@ -103,14 +103,14 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
 
     public RandomCutTree(long seed, boolean enableCache, boolean enableCenterOfMass, boolean enableSequenceIndices) {
         super(seed, enableCache, enableCenterOfMass, enableSequenceIndices);
-        rootIndex = null;
+        root = null;
         setBoundingBoxCacheFraction(1.0);
     }
 
     public RandomCutTree(Random random, boolean enableCache, boolean enableCenterOfMass,
             boolean enableSequenceIndices) {
         super(random, enableCache, enableCenterOfMass, enableSequenceIndices);
-        rootIndex = null;
+        root = null;
     }
 
     @Override
@@ -309,10 +309,6 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
     @Override
     protected int getMass(Node node) {
         return node.getMass();
-    }
-
-    protected Node getRoot() {
-        return rootIndex;
     }
 
     @Override

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
@@ -82,6 +82,6 @@ public class CompactRandomCutTreeDoubleMapperTest {
     public void testRoundTrip(CompactRandomCutTreeDouble tree, CompactRandomCutTreeContext context) {
         CompactRandomCutTreeDouble tree2 = mapper.toModel(mapper.toState(tree), context);
 
-        assertEquals(tree.getRootIndex(), tree2.getRootIndex());
+        assertEquals(tree.getRoot(), tree2.getRoot());
     }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
@@ -82,6 +82,6 @@ public class CompactRandomCutTreeFloatMapperTest {
     public void testRoundTrip(CompactRandomCutTreeFloat tree, CompactRandomCutTreeContext context) {
         CompactRandomCutTreeFloat tree2 = mapper.toModel(mapper.toState(tree), context);
 
-        assertEquals(tree.getRootIndex(), tree2.getRootIndex());
+        assertEquals(tree.getRoot(), tree2.getRoot());
     }
 }


### PR DESCRIPTION
Closes #142 

Previously, `getRootIndex` could throw an NPE when the root was null. This change encodes `null` using the `intValue` method. 

I also changed the variable name rootIndex in AbstractRandomCutTree to root and added a getter for this field. The "index" part of the name only made sense for compact trees.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
