### PR TITLE
cleanup of point sum and allowing sequenceIndices to be non-unique

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -439,7 +439,7 @@ public class RandomCutForest {
      * reduce the memory size of the model at the cost of requiring double/float
      * conversions.
      *
-     * @return the desired precision to use internal to store points.
+     * @return the desired precision to use internally to store points.
      */
     public Precision getPrecision() {
         return precision;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -240,9 +240,9 @@ public class RandomCutForest {
     }
 
     private void initCompactDouble() {
-        int maxupdate = 1;
+        int maxUpdate = 1;
         int compactReserve = sampleSize / 10;
-        int storeSize = numberOfTrees * sampleSize + maxupdate + compactReserve;
+        int storeSize = numberOfTrees * sampleSize + maxUpdate + compactReserve;
         PointStoreDouble tempStore = new PointStoreDouble(dimensions, shingleSize, storeSize, (shingleSize > 1),
                 (shingleSize == 1));
 
@@ -261,9 +261,9 @@ public class RandomCutForest {
     }
 
     private void initCompactFloat() {
-        int maxupdate = 1;
+        int maxUpdate = 1;
         int compactReserve = sampleSize / 10;
-        int storeSize = numberOfTrees * sampleSize + maxupdate + compactReserve;
+        int storeSize = numberOfTrees * sampleSize + maxUpdate + compactReserve;
         PointStoreFloat tempStore = new PointStoreFloat(dimensions, shingleSize, storeSize, (shingleSize > 1),
                 (shingleSize == 1));
         IUpdateCoordinator<Integer> updateCoordinator = new PointStoreCoordinator(tempStore);
@@ -331,7 +331,7 @@ public class RandomCutForest {
                 "threadPoolSize must be greater/equal than 0. To disable thread pool, set parallel execution to 'false'."));
         checkArgument(builder.precision == Precision.DOUBLE || builder.compactEnabled,
                 "single precision is only supported for compact trees");
-        checkArgument(builder.shingleSize == 1 || builder.dimensions % builder.shingleSize == 0, "wrong singlesize");
+        checkArgument(builder.shingleSize == 1 || builder.dimensions % builder.shingleSize == 0, "wrong shingle size");
 
         numberOfTrees = builder.numberOfTrees;
         sampleSize = builder.sampleSize;
@@ -397,7 +397,7 @@ public class RandomCutForest {
     }
 
     /**
-     * @return the shingle size used by the pointstore.
+     * @return the shingle size used by the point store.
      */
     public int getShingleSize() {
         return shingleSize;
@@ -439,7 +439,7 @@ public class RandomCutForest {
      * reduce the memory size of the model at the cost of requiring double/float
      * conversions.
      *
-     * @return the desired precision to use internall to store points.
+     * @return the desired precision to use internal to store points.
      */
     public Precision getPrecision() {
         return precision;
@@ -511,7 +511,6 @@ public class RandomCutForest {
     public void update(double[] point, long sequenceNum) {
         checkNotNull(point, "point must not be null");
         checkArgument(point.length == dimensions, String.format("point.length must equal %d", dimensions));
-        checkArgument(!storeSequenceIndexesEnabled, "infeasible operation");
         updateExecutor.update(point, sequenceNum);
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
@@ -28,6 +28,18 @@ public interface IPointStoreView<Point> {
     Point get(int index);
 
     /**
+     * useful for managing points, convex combinations, etc., e.g. needed for center
+     * of mass
+     * 
+     * @param index  identifier of the point
+     * @param factor multiplier
+     * @return the new point; or raises an exception if such an object cannot be
+     *         defined
+     */
+
+    Point getScaledPoint(int index, double factor);
+
+    /**
      * Prints the point given the index, irrespective of the encoding of the point.
      * Used in exceptions and error messages
      * 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
@@ -36,7 +36,6 @@ public interface IPointStoreView<Point> {
      * @return the new point; or raises an exception if such an object cannot be
      *         defined
      */
-
     Point getScaledPoint(int index, double factor);
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreDouble.java
@@ -112,6 +112,15 @@ public class PointStoreDouble extends PointStore<double[], double[]> {
         return Arrays.copyOfRange(store, address, address + dimensions);
     }
 
+    // same as get; allows a multiplier to enable convex combinations
+    public double[] getScaledPoint(int index, double factor) {
+        double[] answer = get(index);
+        for (int i = 0; i < dimensions; i++) {
+            answer[i] *= factor;
+        }
+        return answer;
+    }
+
     @Override
     public String toString(int index) {
         return Arrays.toString(get(index));

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/PointStoreFloat.java
@@ -106,6 +106,14 @@ public class PointStoreFloat extends PointStore<float[], float[]> {
         return Arrays.copyOfRange(store, address, address + dimensions);
     }
 
+    public float[] getScaledPoint(int index, double factor) {
+        float[] answer = get(index);
+        for (int i = 0; i < dimensions; i++) {
+            answer[i] *= factor;
+        }
+        return answer;
+    }
+
     @Override
     public String toString(int index) {
         return Arrays.toString(get(index));

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
@@ -218,13 +218,15 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
     abstract protected void deleteSequenceIndex(NodeReference node, long uniqueSequenceNumber);
 
-    abstract void recomputePointSum(NodeReference node, Point point);
+    // the following does not need the information of the point in the current time
+    // however that information may be of use for different type of Points
+    abstract void recomputePointSum(NodeReference node);
 
-    void updateAncestorPointSum(NodeReference node, Point point) {
+    void updateAncestorPointSum(NodeReference node) {
         if (enableCenterOfMass) {
             NodeReference tempNode = node;
             while (tempNode != null) {
-                recomputePointSum(tempNode, point);
+                recomputePointSum(tempNode);
                 tempNode = getParent(tempNode);
             }
         }
@@ -241,7 +243,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
             boxNeedsUpdate = (box == null) || !(box.contains(point));
             tempNode = getParent(tempNode);
         }
-        updateAncestorPointSum(nodeReference, point);
+        updateAncestorPointSum(nodeReference);
     }
 
     /**
@@ -281,7 +283,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
             }
             // decrease mass for the delete
             if (decrementMass(nodeReference) > 0) {
-                updateAncestorPointSum(nodeReference, point);
+                updateAncestorPointSum(nodeReference);
                 return;
             }
 
@@ -331,7 +333,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
             }
         }
         if (enableCenterOfMass) {
-            updateAncestorPointSum(mergedNode, point);
+            updateAncestorPointSum(mergedNode);
         }
     }
 
@@ -405,7 +407,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
                 if (enableSequenceIndices) {
                     addSequenceIndex(nodeReference, sequenceNumber);
                 }
-                updateAncestorPointSum(nodeReference, point);
+                updateAncestorPointSum(nodeReference);
                 AddPointState<Point, NodeReference, PointReference> newState = new AddPointState<>(
                         getPointReference(nodeReference));
                 // the following will ensure that no further processing happens

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
@@ -61,9 +61,9 @@ public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<floa
 
     @Override
     protected AbstractBoundingBox<float[]> getMutableLeafBoxFromLeafNode(Integer nodeReference) {
-        float[] leafpoint = pointStore.get(getPointReference(nodeReference));
-        return new BoundingBoxFloat(Arrays.copyOf(leafpoint, leafpoint.length),
-                Arrays.copyOf(leafpoint, leafpoint.length), 0);
+        // pointStore makes an explicit copy
+        float[] leafPoint = pointStore.get(getPointReference(nodeReference));
+        return new BoundingBoxFloat(leafPoint, Arrays.copyOf(leafPoint, leafPoint.length), 0);
     }
 
     @Override
@@ -86,32 +86,14 @@ public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<floa
         return toDoubleArray(getPointFromLeafNode(nodeOffset));
     }
 
-    float[] getPointSum(int ref, float[] point) {
-        if (isLeaf(ref)) {
-            if (getMass(ref) == 1) {
-                return getPointFromLeafNode(ref);
-            } else {
-                float[] answer = Arrays.copyOf(getPointFromLeafNode(ref), point.length);
-                for (int i = 0; i < point.length; i++) {
-                    answer[i] *= getMass(ref);
-                }
-                return answer;
-            }
-        }
-        if (pointSum[ref] == null) {
-            recomputePointSum(ref, point);
-        }
-        return pointSum[ref];
-    }
-
     @Override
-    void recomputePointSum(Integer node, float[] point) {
+    void recomputePointSum(Integer node) {
         if (pointSum[node] == null) {
-            pointSum[node] = new float[point.length];
+            pointSum[node] = new float[pointStore.getDimensions()];
         }
-        float[] leftSum = getPointSum(getLeftChild(node), point);
-        float[] rightSum = getPointSum(getRightChild(node), point);
-        for (int i = 0; i < point.length; i++) {
+        float[] leftSum = getPointSum(getLeftChild(node));
+        float[] rightSum = getPointSum(getRightChild(node));
+        for (int i = 0; i < pointStore.getDimensions(); i++) {
             pointSum[node][i] = leftSum[i] + rightSum[i];
         }
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
@@ -15,11 +15,12 @@
 
 package com.amazon.randomcutforest.tree;
 
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.checkState;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Set;
 
 /**
@@ -75,7 +76,7 @@ public class Node implements INode<Node> {
      * RandomCutTree, this set stores the indexes corresponding to times when the
      * given leaf point was added to the tree.
      */
-    private Set<Long> sequenceIndexes;
+    private HashMap<Long, Integer> sequenceIndexes;
 
     /**
      * Create a new non-leaf Node.
@@ -407,7 +408,7 @@ public class Node implements INode<Node> {
      */
     public Set<Long> getSequenceIndexes() {
         if (sequenceIndexes != null) {
-            return Collections.unmodifiableSet(sequenceIndexes);
+            return sequenceIndexes.keySet();
         } else {
             return Collections.emptySet();
         }
@@ -420,9 +421,13 @@ public class Node implements INode<Node> {
      */
     protected void addSequenceIndex(long sequenceIndex) {
         if (sequenceIndexes == null) {
-            sequenceIndexes = new HashSet<>();
+            sequenceIndexes = new HashMap<>();
         }
-        sequenceIndexes.add(sequenceIndex);
+        int num = 0;
+        if (sequenceIndexes.containsKey(sequenceIndex)) {
+            num = sequenceIndexes.get(sequenceIndex);
+        }
+        sequenceIndexes.put(sequenceIndex, num + 1);
     }
 
     /**
@@ -432,7 +437,12 @@ public class Node implements INode<Node> {
      */
     protected void deleteSequenceIndex(long sequenceIndex) {
         if (sequenceIndexes != null) {
-            sequenceIndexes.remove(sequenceIndex);
+            int num = sequenceIndexes.get(sequenceIndex);
+            if (num == 1) {
+                sequenceIndexes.remove(sequenceIndex);
+            } else {
+                sequenceIndexes.put(sequenceIndex, num - 1);
+            }
         }
     }
 
@@ -480,11 +490,12 @@ public class Node implements INode<Node> {
         }
     }
 
-    void reComputePointSum(double[] point) {
+    void reComputePointSum() {
         if (!isLeaf()) {
             double[] leftSum = getLeftChild().getPointSum();
             double[] rightSum = getRightChild().getPointSum();
-            for (int i = 0; i < point.length; i++) {
+            checkArgument(leftSum.length == rightSum.length, "incorrect state");
+            for (int i = 0; i < leftSum.length; i++) {
                 pointSum[i] = leftSum[i] + rightSum[i];
             }
         }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/Node.java
@@ -21,6 +21,7 @@ import static com.amazon.randomcutforest.CommonUtils.checkState;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -76,7 +77,7 @@ public class Node implements INode<Node> {
      * RandomCutTree, this set stores the indexes corresponding to times when the
      * given leaf point was added to the tree.
      */
-    private HashMap<Long, Integer> sequenceIndexes;
+    private Map<Long, Integer> sequenceIndexes;
 
     /**
      * Create a new non-leaf Node.
@@ -490,7 +491,7 @@ public class Node implements INode<Node> {
         }
     }
 
-    void reComputePointSum() {
+    void recomputePointSum() {
         if (!isLeaf()) {
             double[] leftSum = getLeftChild().getPointSum();
             double[] rightSum = getRightChild().getPointSum();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -142,7 +142,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
 
     @Override
     void recomputePointSum(Node node) {
-        node.reComputePointSum();
+        node.recomputePointSum();
     }
 
     @Override

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -141,8 +141,8 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
     }
 
     @Override
-    void recomputePointSum(Node node, double[] point) {
-        node.reComputePointSum(point);
+    void recomputePointSum(Node node) {
+        node.reComputePointSum();
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:* 85 and 116

*Description of changes:* cleans up center of mass calculation for abstract trees and allows sequence indices to be non-unique


