### PR TITLE
Add support for dynamically configurable models

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collector;
 
 import com.amazon.randomcutforest.anomalydetection.AnomalyAttributionVisitor;
 import com.amazon.randomcutforest.anomalydetection.AnomalyScoreVisitor;
+import com.amazon.randomcutforest.config.Config;
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.executor.AbstractForestTraversalExecutor;
 import com.amazon.randomcutforest.executor.AbstractForestUpdateExecutor;
@@ -522,8 +523,8 @@ public class RandomCutForest {
      *                      caching.
      */
     public void setBoundingBoxCacheFraction(double cacheFraction) {
-        checkArgument(0 <= cacheFraction && cacheFraction <= 1, String.format("fraction must be in [0,1]"));
-        updateExecutor.forEachTree(t -> t.setBoundingBoxCacheFraction(cacheFraction));
+        checkArgument(0 <= cacheFraction && cacheFraction <= 1, "cacheFraction must be between 0 and 1 (inclusive)");
+        updateExecutor.getComponents().forEach(c -> c.setConfig(Config.BOUNDING_BOX_CACHE_FRACTION, cacheFraction));
     }
 
     /**
@@ -532,9 +533,9 @@ public class RandomCutForest {
      * @param lambda new value of sampling rate
      */
     public void setLambda(double lambda) {
-        checkArgument(0 <= lambda, String.format("lambda cannot be negative"));
+        checkArgument(0 <= lambda, "lambda must be greater than or equal to 0");
         this.lambda = lambda;
-        updateExecutor.forEachSampler(t -> t.setTimeDecay(lambda));
+        updateExecutor.getComponents().forEach(c -> c.setConfig(Config.TIME_DECAY, lambda));
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/Config.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/Config.java
@@ -13,19 +13,9 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.randomcutforest;
+package com.amazon.randomcutforest.config;
 
-import com.amazon.randomcutforest.config.IDynamicConfig;
-import com.amazon.randomcutforest.executor.ITraversable;
-import com.amazon.randomcutforest.executor.IUpdatable;
-
-/**
- *
- * @param <PointReference> The internal point representation expected by the
- *                         component models in this list.
- * @param <Point>          The explicit data type of points being passed
- */
-
-public interface IComponentModel<PointReference, Point>
-        extends ITraversable, IUpdatable<PointReference>, IDynamicConfig {
+public class Config {
+    public static final String BOUNDING_BOX_CACHE_FRACTION = "bounding_box_cache_fraction";
+    public static final String TIME_DECAY = "time_decay";
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/IDynamicConfig.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/IDynamicConfig.java
@@ -24,8 +24,16 @@ public interface IDynamicConfig {
 
     <T> void setConfig(String name, T value, Class<T> clazz);
 
+    default void setConfig(String name, short value) {
+        setConfig(name, value, Short.class);
+    }
+
     default void setConfig(String name, int value) {
         setConfig(name, value, Integer.class);
+    }
+
+    default void setConfig(String name, long value) {
+        setConfig(name, value, Long.class);
     }
 
     default void setConfig(String name, float value) {
@@ -34,6 +42,10 @@ public interface IDynamicConfig {
 
     default void setConfig(String name, double value) {
         setConfig(name, value, Double.class);
+    }
+
+    default void setConfig(String name, boolean value) {
+        setConfig(name, value, Boolean.class);
     }
 
     <T> T getConfig(String name, Class<T> clazz);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/IDynamicConfig.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/IDynamicConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.config;
+
+/**
+ * This interface is used by model classes to configure model parameters by
+ * name. This is intended primarily for settings that a user may want to change
+ * at runtime.
+ */
+public interface IDynamicConfig {
+
+    <T> void setConfig(String name, T value, Class<T> clazz);
+
+    default void setConfig(String name, int value) {
+        setConfig(name, value, Integer.class);
+    }
+
+    default void setConfig(String name, float value) {
+        setConfig(name, value, Float.class);
+    }
+
+    default void setConfig(String name, double value) {
+        setConfig(name, value, Double.class);
+    }
+
+    <T> T getConfig(String name, Class<T> clazz);
+
+    default Object getConfig(String name) {
+        return getConfig(name, Object.class);
+    }
+}

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
@@ -17,13 +17,10 @@ package com.amazon.randomcutforest.executor;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import lombok.Getter;
 
 import com.amazon.randomcutforest.ComponentList;
-import com.amazon.randomcutforest.sampler.IStreamSampler;
-import com.amazon.randomcutforest.tree.ITree;
 
 /**
  * The class transforms input points into the form expected by internal models,
@@ -33,6 +30,7 @@ import com.amazon.randomcutforest.tree.ITree;
  *                         structures.
  * @param <Point>          The explicit data type of exchanging points
  */
+@Getter
 public abstract class AbstractForestUpdateExecutor<PointReference, Point> {
 
     protected final IUpdateCoordinator<PointReference, Point> updateCoordinator;
@@ -98,21 +96,5 @@ public abstract class AbstractForestUpdateExecutor<PointReference, Point> {
             }
         }
         return pointCopy;
-    }
-
-    public void forEachTree(Consumer<ITree<PointReference, Point>> function) {
-        components.forEach(t -> function.accept(t.getTree()));
-    }
-
-    public void forEachSampler(Consumer<IStreamSampler<PointReference>> function) {
-        components.forEach(t -> function.accept(t.getSampler()));
-    }
-
-    public <R> List<R> mapToTrees(Function<ITree<PointReference, Point>, R> function) {
-        return components.stream().map(t -> function.apply(t.getTree())).collect(Collectors.toList());
-    }
-
-    public <R> List<R> mapToSamplers(Function<IStreamSampler<PointReference>, R> function) {
-        return components.stream().map(t -> function.apply(t.getSampler())).collect(Collectors.toList());
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import com.amazon.randomcutforest.IComponentModel;
 import com.amazon.randomcutforest.MultiVisitor;
 import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.config.Config;
 import com.amazon.randomcutforest.sampler.ISampled;
 import com.amazon.randomcutforest.sampler.IStreamSampler;
 import com.amazon.randomcutforest.tree.ITree;
@@ -108,4 +109,26 @@ public class SamplerPlusTree<P, Q> implements IComponentModel<P, Q> {
         return tree.traverseMulti(point, visitorFactory);
     }
 
+    @Override
+    public <T> void setConfig(String name, T value, Class<T> clazz) {
+        if (Config.BOUNDING_BOX_CACHE_FRACTION.equals(name)) {
+            tree.setConfig(name, value, clazz);
+        } else if (Config.TIME_DECAY.equals(name)) {
+            sampler.setConfig(name, value, clazz);
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
+
+    @Override
+    public <T> T getConfig(String name, Class<T> clazz) {
+        checkNotNull(clazz, "clazz must not be null");
+        if (Config.BOUNDING_BOX_CACHE_FRACTION.equals(name)) {
+            return tree.getConfig(name, clazz);
+        } else if (Config.TIME_DECAY.equals(name)) {
+            return sampler.getConfig(name, clazz);
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
@@ -15,7 +15,12 @@
 
 package com.amazon.randomcutforest.sampler;
 
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
+
 import java.util.Random;
+
+import com.amazon.randomcutforest.config.Config;
 
 public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
     /**
@@ -96,7 +101,6 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
      * 
      * @param newLambda the new sampling rate
      */
-    @Override
     public void setTimeDecay(double newLambda) {
         // accumulatedLambda keeps track of adjustments and is zeroed out when the
         // arrays are
@@ -131,4 +135,26 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
         sequenceIndexOfMostRecentLambdaUpdate = index;
     }
 
+    @Override
+    public <T> void setConfig(String name, T value, Class<T> clazz) {
+        if (Config.TIME_DECAY.equals(name)) {
+            checkArgument(Double.class.isAssignableFrom(clazz),
+                    String.format("Setting '%s' must be a double value", name));
+            setTimeDecay((Double) value);
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
+
+    @Override
+    public <T> T getConfig(String name, Class<T> clazz) {
+        checkNotNull(clazz, "clazz must not be null");
+        if (Config.TIME_DECAY.equals(name)) {
+            checkArgument(clazz.isAssignableFrom(Double.class),
+                    String.format("Setting '%s' must be a double value", name));
+            return clazz.cast(getTimeDecay());
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/IStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/IStreamSampler.java
@@ -18,6 +18,8 @@ package com.amazon.randomcutforest.sampler;
 import java.util.List;
 import java.util.Optional;
 
+import com.amazon.randomcutforest.config.IDynamicConfig;
+
 /**
  * <p>
  * A sampler that can be updated iteratively from a stream of data points. The
@@ -45,7 +47,7 @@ import java.util.Optional;
  *
  * @param <P> The point type.
  */
-public interface IStreamSampler<P> {
+public interface IStreamSampler<P> extends IDynamicConfig {
     /**
      * Submit a point to the sampler and return true if the point is accepted into
      * the sample. By default this method chains together the {@link #acceptPoint}
@@ -136,15 +138,5 @@ public interface IStreamSampler<P> {
      */
     int size();
 
-    /**
-     * changes the time dependent sampling on the fly. Lambda is the decay rate of
-     * every non-recent point
-     * 
-     * @param lambda the rate of sampling
-     */
-    default void setTimeDecay(double lambda) {
-    };
-
     void setMaxSequenceIndex(long maxSequenceIndex);
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import com.amazon.randomcutforest.MultiVisitor;
 import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.config.Config;
 
 /**
  * A Compact Random Cut Tree is a tree data structure whose leaves represent
@@ -73,11 +74,33 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
         this.enableSequenceIndices = enableSequenceIndices;
     }
 
+    @Override
+    public <T> void setConfig(String name, T value, Class<T> clazz) {
+        if (Config.BOUNDING_BOX_CACHE_FRACTION.equals(name)) {
+            checkArgument(Double.class.isAssignableFrom(clazz),
+                    String.format("Setting '%s' must be a double value", name));
+            setBoundingBoxCacheFraction((Double) value);
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
+
+    @Override
+    public <T> T getConfig(String name, Class<T> clazz) {
+        checkNotNull(clazz, "clazz must not be null");
+        if (Config.BOUNDING_BOX_CACHE_FRACTION.equals(name)) {
+            checkArgument(clazz.isAssignableFrom(Double.class),
+                    String.format("Setting '%s' must be a double value", name));
+            return clazz.cast(boundingBoxCacheFraction);
+        } else {
+            throw new IllegalArgumentException("Unsupported configuration setting: " + name);
+        }
+    }
+
     // dynamically change the fraction of the new nodes which caches their bounding
     // boxes
     // 0 would mean less space usage, but slower throughput
     // 1 would imply larger space but better throughput
-    @Override
     public void setBoundingBoxCacheFraction(double fraction) {
         checkArgument(0 <= fraction && fraction <= 1, "incorrect parameter");
         boundingBoxCacheFraction = fraction;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/ITree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/ITree.java
@@ -15,6 +15,7 @@
 
 package com.amazon.randomcutforest.tree;
 
+import com.amazon.randomcutforest.config.IDynamicConfig;
 import com.amazon.randomcutforest.executor.ITraversable;
 
 /**
@@ -24,13 +25,10 @@ import com.amazon.randomcutforest.executor.ITraversable;
  *                         component models in this list.
  * @param <Point>          The explicit data type of points being passed
  */
-public interface ITree<PointReference, Point> extends ITraversable {
+public interface ITree<PointReference, Point> extends ITraversable, IDynamicConfig {
     int getMass();
 
     PointReference addPoint(PointReference point, long sequenceIndex);
 
     void deletePoint(PointReference point, long sequenceIndex);
-
-    default void setBoundingBoxCacheFraction(double fraction) {
-    };
 }

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
@@ -18,6 +18,7 @@ package com.amazon.randomcutforest.examples.serialization;
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.executor.SamplerPlusTree;
 import com.amazon.randomcutforest.sampler.CompactSampler;
 import com.amazon.randomcutforest.state.RandomCutForestMapper;
 import com.amazon.randomcutforest.state.RandomCutForestState;
@@ -97,18 +98,17 @@ public class ProtostuffExampleWithDynamicLambda implements Example {
         forest2.setLambda(10 * forest2.getLambda());
 
         for (int i = 0; i < numberOfTrees; i++) {
-            if (((CompactSampler) forest2.getComponents().get(i).getSampler())
-                    .getMaxSequenceIndex() != ((CompactSampler) forest.getComponents().get(i).getSampler())
-                            .getMaxSequenceIndex()) {
+            CompactSampler sampler = (CompactSampler) ((SamplerPlusTree) forest.getComponents().get(i)).getSampler();
+            CompactSampler sampler2 = (CompactSampler) ((SamplerPlusTree) forest2.getComponents().get(i)).getSampler();
+
+            if (sampler.getMaxSequenceIndex() != sampler2.getMaxSequenceIndex()) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
-            if (((CompactSampler) forest2.getComponents().get(i).getSampler())
-                    .getSequenceIndexOfMostRecentLambdaUpdate() != ((CompactSampler) forest.getComponents().get(i)
-                            .getSampler()).getSequenceIndexOfMostRecentLambdaUpdate()) {
+            if (sampler.getSequenceIndexOfMostRecentLambdaUpdate() != sampler2
+                    .getSequenceIndexOfMostRecentLambdaUpdate()) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
-            if (((CompactSampler) forest2.getComponents().get(i).getSampler())
-                    .getSequenceIndexOfMostRecentLambdaUpdate() != dataSize - 1) {
+            if (sampler2.getSequenceIndexOfMostRecentLambdaUpdate() != dataSize - 1) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
         }


### PR DESCRIPTION
Add support for configuring component models by setting name. This
change allows us to add new configurable settings in a backwards-compatible way.

Different model implementations may support different settings. By supporting the generic `setConfig` method, we avoid adding implementation-specific methods to our base abstractions: `ITree`, `IStreamSampler`, and `IComponentModel`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
