### PR TITLE
Automatically apply spotless formatting instead of failing the build

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -134,7 +134,7 @@
                     <execution>
                         <phase>compile</phase>
                         <goals>
-                            <goal>check</goal>
+                            <goal>apply</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Previously we were failing the compile step if the spotless check failed. This is considered a best practice by some, because it prevents badly formatted code from being committed to the repository. However, given that we typically run tests before creating a PR, we think the convenience of automatic formatting is worth the tradeoff of potentially committing incorrectly formatted code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
