### PR TITLE
Store point data as bytes in PointStoreState

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
@@ -53,7 +53,7 @@ public class CompactSamplerMapper implements IStateMapper<CompactSampler, Compac
 
         int size = state.getSize();
         System.arraycopy(state.getWeight(), 0, weight, 0, size);
-        System.arraycopy(ArrayPacking.unPackInts(state.getPointIndex(), state.isCompressed()), 0, pointIndex, 0, size);
+        System.arraycopy(ArrayPacking.unpackInts(state.getPointIndex(), state.isCompressed()), 0, pointIndex, 0, size);
         if (state.isStoreSequenceIndicesEnabled()) {
             sequenceIndex = new long[state.getCapacity()];
             System.arraycopy(state.getSequenceIndex(), 0, sequenceIndex, 0, size);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
@@ -49,11 +49,11 @@ public class NodeStoreMapper implements IStateMapper<NodeStore, NodeStoreState> 
     @Override
     public NodeStore toModel(NodeStoreState state, long seed) {
         int capacity = state.getCapacity();
-        int[] cutDimension = ArrayPacking.unPackInts(state.getCutDimension(), state.isCompressed());
+        int[] cutDimension = ArrayPacking.unpackInts(state.getCutDimension(), state.isCompressed());
         double[] cutValue = Arrays.copyOf(state.getCutValueDouble(), state.getCutValueDouble().length);
 
-        int[] leftIndex = ArrayPacking.unPackInts(state.getLeftIndex(), state.isCompressed());
-        int[] rightIndex = ArrayPacking.unPackInts(state.getRightIndex(), state.isCompressed());
+        int[] leftIndex = ArrayPacking.unpackInts(state.getLeftIndex(), state.isCompressed());
+        int[] rightIndex = ArrayPacking.unpackInts(state.getRightIndex(), state.isCompressed());
         if (state.isCanonicalAndNotALeaf()) {
             reverseBits(state.getSize(), leftIndex, rightIndex);
         }
@@ -64,13 +64,13 @@ public class NodeStoreMapper implements IStateMapper<NodeStore, NodeStoreState> 
             leafMass = null;
             leafPointIndex = null;
         } else {
-            leafMass = ArrayPacking.unPackInts(state.getLeafmass(), state.isCompressed());
-            leafPointIndex = ArrayPacking.unPackInts(state.getLeafPointIndex(), state.isCompressed());
+            leafMass = ArrayPacking.unpackInts(state.getLeafmass(), state.isCompressed());
+            leafPointIndex = ArrayPacking.unpackInts(state.getLeafPointIndex(), state.isCompressed());
         }
 
-        int[] nodeFreeIndexes = ArrayPacking.unPackInts(state.getNodeFreeIndexes(), state.isCompressed());
+        int[] nodeFreeIndexes = ArrayPacking.unpackInts(state.getNodeFreeIndexes(), state.isCompressed());
         int nodeFreeIndexPointer = state.getNodeFreeIndexPointer();
-        int[] leafFreeIndexes = ArrayPacking.unPackInts(state.getLeafFreeIndexes(), state.isCompressed());
+        int[] leafFreeIndexes = ArrayPacking.unpackInts(state.getLeafFreeIndexes(), state.isCompressed());
         int leafFreeIndexPointer = state.getLeafFreeIndexPointer();
 
         return new NodeStore(capacity, leftIndex, rightIndex, cutDimension, cutValue, leafMass, leafPointIndex,

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
@@ -45,16 +45,16 @@ public class PointStoreDoubleMapper implements IStateMapper<PointStoreDouble, Po
     @Override
     public PointStoreDouble toModel(PointStoreState state, long seed) {
         checkNotNull(state.getRefCount(), "refCount must not be null");
-        checkNotNull(state.getDoubleData(), "doubleData must not be null");
+        checkNotNull(state.getPointData(), "pointData must not be null");
         checkArgument(!state.isSinglePrecisionSet(), "incorrect use");
         int indexCapacity = state.getIndexCapacity();
         int dimensions = state.getDimensions();
-        double[] store = Arrays.copyOf(state.getDoubleData(), state.getCurrentStoreCapacity() * dimensions);
+        double[] store = ArrayPacking.unpackDoubles(state.getPointData(), state.getCurrentStoreCapacity() * dimensions);
         int startOfFreeSegment = state.getStartOfFreeSegment();
-        int[] refCount = ArrayPacking.unPackInts(state.getRefCount(), indexCapacity, state.isCompressed());
+        int[] refCount = ArrayPacking.unpackInts(state.getRefCount(), indexCapacity, state.isCompressed());
         int[] locationList = new int[indexCapacity];
         Arrays.fill(locationList, PointStore.INFEASIBLE_POINTSTORE_LOCATION);
-        int[] tempList = ArrayPacking.unPackInts(state.getLocationList(), state.isCompressed());
+        int[] tempList = ArrayPacking.unpackInts(state.getLocationList(), state.isCompressed());
         System.arraycopy(tempList, 0, locationList, 0, tempList.length);
 
         return PointStoreDouble.builder().internalRotationEnabled(state.isRotationEnabled())
@@ -88,8 +88,7 @@ public class PointStoreDoubleMapper implements IStateMapper<PointStoreDouble, Po
         int prefix = model.getValidPrefix();
         state.setRefCount(ArrayPacking.pack(model.getRefCount(), prefix, state.isCompressed()));
         state.setLocationList(ArrayPacking.pack(model.getLocationList(), prefix, state.isCompressed()));
-        state.setDoubleData(Arrays.copyOf(model.getStore(), model.getStartOfFreeSegment()));
+        state.setPointData(ArrayPacking.pack(model.getStore(), model.getStartOfFreeSegment()));
         return state;
     }
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
@@ -40,16 +40,16 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
     @Override
     public PointStoreFloat toModel(PointStoreState state, long seed) {
         checkNotNull(state.getRefCount(), "refCount must not be null");
-        checkNotNull(state.getFloatData(), "doubleData must not be null");
+        checkNotNull(state.getPointData(), "pointData must not be null");
         checkArgument(state.isSinglePrecisionSet(), "incorrect use");
         int indexCapacity = state.getIndexCapacity();
         int dimensions = state.getDimensions();
-        float[] store = Arrays.copyOf(state.getFloatData(), state.getCurrentStoreCapacity() * dimensions);
+        float[] store = ArrayPacking.unpackFloats(state.getPointData(), state.getCurrentStoreCapacity() * dimensions);
         int startOfFreeSegment = state.getStartOfFreeSegment();
-        int[] refCount = ArrayPacking.unPackInts(state.getRefCount(), indexCapacity, state.isCompressed());
+        int[] refCount = ArrayPacking.unpackInts(state.getRefCount(), indexCapacity, state.isCompressed());
         int[] locationList = new int[indexCapacity];
         Arrays.fill(locationList, PointStore.INFEASIBLE_POINTSTORE_LOCATION);
-        int[] tempList = ArrayPacking.unPackInts(state.getLocationList(), state.isCompressed());
+        int[] tempList = ArrayPacking.unpackInts(state.getLocationList(), state.isCompressed());
         System.arraycopy(tempList, 0, locationList, 0, tempList.length);
 
         return PointStoreFloat.builder().internalRotationEnabled(state.isRotationEnabled())
@@ -83,8 +83,7 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
         int prefix = model.getValidPrefix();
         state.setRefCount(ArrayPacking.pack(model.getRefCount(), prefix, state.isCompressed()));
         state.setLocationList(ArrayPacking.pack(model.getLocationList(), prefix, state.isCompressed()));
-        state.setFloatData(Arrays.copyOf(model.getStore(), model.getStartOfFreeSegment()));
+        state.setPointData(ArrayPacking.pack(model.getStore(), model.getStartOfFreeSegment()));
         return state;
     }
-
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreState.java
@@ -47,13 +47,9 @@ public class PointStoreState {
      */
     private int startOfFreeSegment;
     /**
-     * Point data for a {@link com.amazon.randomcutforest.store.PointStoreDouble}.
+     * Point data converted to raw bytes.
      */
-    private double[] doubleData;
-    /**
-     * Point data for a {@link com.amazon.randomcutforest.store.PointStoreFloat}.
-     */
-    private float[] floatData;
+    private byte[] pointData;
     /**
      * use compressed representatiomn for arrays
      */

--- a/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayPacking.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayPacking.java
@@ -170,7 +170,7 @@ public class ArrayPacking {
             int count = 0;
             for (int i = 3; i < packedArray.length; i++) {
                 long code = packedArray[i];
-                for (int j = 0; j < packNum && count < min(output.length, length); j++) {
+                for (int j = 0; j < packNum && count < min(packedArray[2], length); j++) {
                     output[count++] = (int) (min + code % base);
                     code = (int) (code / base);
                 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayPacking.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayPacking.java
@@ -19,11 +19,25 @@ import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 import static java.lang.Math.min;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 public class ArrayPacking {
 
-    static int logMax(long base) {
+    /**
+     * For a given base value, return the smallest int value {@code p} so that
+     * {@code base^(p + 1) >= Integer.MAX_VALUE}. If
+     * {@code base >= Integer.MAX_VALUE}, return 1.
+     * 
+     * @param base Compute the approximate log of {@code Integer.MAX_VALUE} in this
+     *             base.
+     * @return the largest int value {@code p} so that
+     *         {@code base^p >= Integer.MAX_VALUE} or 1 if
+     *         {@code base >= Integer.MAX_VALUE}.
+     */
+    public static int logMax(long base) {
+        checkArgument(base > 1, "Absolute value of base must be greater than 1");
+
         int pack = 0;
         long num = base;
         while (num < Integer.MAX_VALUE) {
@@ -33,13 +47,34 @@ public class ArrayPacking {
         return Math.max(pack, 1); // pack can be 0 for max - min being more than Integer.MaxValue
     }
 
+    /**
+     * Pack an array of ints. If {@code compress} is true, then this method will
+     * apply arithmetic compression to the inputs, otherwise it returns a copy of
+     * the input.
+     *
+     * @param inputArray An array of ints to pack.
+     * @param compress   A flag indicating whether to apply arithmetic compression.
+     * @return an array of packed ints.
+     */
     public static int[] pack(int[] inputArray, boolean compress) {
         return pack(inputArray, inputArray.length, compress);
     }
 
+    /**
+     * Pack an array of ints. If {@code compress} is true, then this method will
+     * apply arithmetic compression to the inputs, otherwise it returns a copy of
+     * the input.
+     *
+     * @param inputArray An array of ints to pack.
+     * @param length     The length of the output array. Only the first
+     *                   {@code length} values in {@code inputArray} will be packed.
+     * @param compress   A flag indicating whether to apply arithmetic compression.
+     * @return an array of packed ints.
+     */
     public static int[] pack(int[] inputArray, int length, boolean compress) {
-        checkNotNull(inputArray, " array packing invoked on null arrays");
-        checkArgument(length <= inputArray.length && length >= 0, "incorrect length parameter");
+        checkNotNull(inputArray, "inputArray must not be null");
+        checkArgument(0 <= length && length <= inputArray.length,
+                "length must be between 0 and inputArray.length (inclusive)");
 
         if (!compress || length < 3) {
             return Arrays.copyOf(inputArray, length);
@@ -78,28 +113,54 @@ public class ArrayPacking {
 
     }
 
-    public static int[] unPackInts(int[] inputArray, boolean decompress) {
-        checkNotNull(inputArray, " array unpacking invoked on null arrays");
+    /**
+     * Unpack an array previously created by {@link #pack(int[], int, boolean)}.
+     * 
+     * @param packedArray An array previously created by
+     *                    {@link #pack(int[], int, boolean)}.
+     * @param decompress  A flag indicating whether the packed array was created
+     *                    with arithmetic compression enabled.
+     * @return the array of unpacked ints.
+     */
+    public static int[] unpackInts(int[] packedArray, boolean decompress) {
+        checkNotNull(packedArray, " array unpacking invoked on null arrays");
 
-        return (inputArray.length < 3) ? unPackInts(inputArray, inputArray.length, decompress)
-                : unPackInts(inputArray, inputArray[2], decompress);
+        if (!decompress) {
+            return Arrays.copyOf(packedArray, packedArray.length);
+        }
+
+        return (packedArray.length < 3) ? unpackInts(packedArray, packedArray.length, decompress)
+                : unpackInts(packedArray, packedArray[2], decompress);
     }
 
-    public static int[] unPackInts(int[] inputArray, int length, boolean decompress) {
-        checkNotNull(inputArray, " array unpacking invoked on null arrays");
+    /**
+     * Unpack an array previously created by {@link #pack(int[], int, boolean)}.
+     * 
+     * @param packedArray An array previously created by
+     *                    {@link #pack(int[], int, boolean)}.
+     * @param length      The desired length of the output array. If this number is
+     *                    different from the length of the array that was originally
+     *                    packed, then the result will be truncated or padded with
+     *                    zeros as needed.
+     * @param decompress  A flag indicating whether the packed array was created
+     *                    with arithmetic compression enabled.
+     * @return the array of unpacked ints.
+     */
+    public static int[] unpackInts(int[] packedArray, int length, boolean decompress) {
+        checkNotNull(packedArray, " array unpacking invoked on null arrays");
         checkArgument(length >= 0, "incorrect length parameter");
 
-        if (inputArray.length < 3 || !decompress) {
-            return Arrays.copyOf(inputArray, length);
+        if (packedArray.length < 3 || !decompress) {
+            return Arrays.copyOf(packedArray, length);
         }
-        int min = inputArray[0];
-        int max = inputArray[1];
+        int min = packedArray[0];
+        int max = packedArray[1];
         int[] output = new int[length];
         if (min == max) {
-            if (inputArray[2] >= length) {
+            if (packedArray[2] >= length) {
                 Arrays.fill(output, min);
             } else {
-                for (int i = 0; i < inputArray[2]; i++) {
+                for (int i = 0; i < packedArray[2]; i++) {
                     output[i] = min;
                 }
             }
@@ -107,8 +168,8 @@ public class ArrayPacking {
             long base = ((long) max - min + 1);
             int packNum = logMax(base);
             int count = 0;
-            for (int i = 3; i < inputArray.length; i++) {
-                long code = inputArray[i];
+            for (int i = 3; i < packedArray.length; i++) {
+                long code = packedArray[i];
                 for (int j = 0; j < packNum && count < min(output.length, length); j++) {
                     output[count++] = (int) (min + code % base);
                     code = (int) (code / base);
@@ -118,4 +179,141 @@ public class ArrayPacking {
         return output;
     }
 
+    /**
+     * Pack an array of doubles into an array of bytes.
+     * 
+     * @param array An array of doubles.
+     * @return An array of bytes representing the original array of doubles.
+     */
+    public static byte[] pack(double[] array) {
+        checkNotNull(array, "array must not be null");
+        return pack(array, array.length);
+    }
+
+    /**
+     * Pack an array of doubles into an array of bytes.
+     * 
+     * @param array  An array of doubles.
+     * @param length The number of doubles in the input array to pack into the
+     *               resulting byte array.
+     * @return An array of bytes representing the original array of doubles.
+     */
+    public static byte[] pack(double[] array, int length) {
+        checkNotNull(array, "array must not be null");
+        checkArgument(0 <= length && length <= array.length,
+                "length must be between 0 and inputArray.length (inclusive)");
+
+        ByteBuffer buf = ByteBuffer.allocate(length * Double.BYTES);
+        for (int i = 0; i < length; i++) {
+            buf.putDouble(array[i]);
+        }
+
+        return buf.array();
+    }
+
+    /**
+     * Pack an array of floats into an array of bytes.
+     * 
+     * @param array An array of floats.
+     * @return An array of bytes representing the original array of floats.
+     */
+    public static byte[] pack(float[] array) {
+        checkNotNull(array, "array must not be null");
+        return pack(array, array.length);
+    }
+
+    /**
+     * Pack an array of floats into an array of bytes.
+     * 
+     * @param array  An array of floats.
+     * @param length The number of doubles in the input array to pack into the
+     *               resulting byte array.
+     * @return An array of bytes representing the original array of floats.
+     */
+    public static byte[] pack(float[] array, int length) {
+        checkNotNull(array, "array must not be null");
+        checkArgument(0 <= length && length <= array.length,
+                "length must be between 0 and inputArray.length (inclusive)");
+
+        ByteBuffer buf = ByteBuffer.allocate(length * Float.BYTES);
+        for (int i = 0; i < length; i++) {
+            buf.putFloat(array[i]);
+        }
+
+        return buf.array();
+    }
+
+    /**
+     * Unpack an array of bytes as an array of doubles.
+     * 
+     * @param bytes An array of bytes.
+     * @return an array of doubles obtained by marshalling consecutive bytes in the
+     *         input array into doubles.
+     */
+    public static double[] unpackDoubles(byte[] bytes) {
+        checkNotNull(bytes, "bytes must not be null");
+        return unpackDoubles(bytes, bytes.length / Double.BYTES);
+    }
+
+    /**
+     * Unpack an array of bytes as an array of doubles.
+     * 
+     * @param bytes  An array of bytes.
+     * @param length The desired length of the resulting double array. The input
+     *               will be truncated or padded with zeros as needed.
+     * @return an array of doubles obtained by marshalling consecutive bytes in the
+     *         input array into doubles.
+     */
+    public static double[] unpackDoubles(byte[] bytes, int length) {
+        checkNotNull(bytes, "bytes must not be null");
+        checkArgument(length >= 0, "length must be greater than or equal to 0");
+        checkArgument(bytes.length % Double.BYTES == 0, "bytes.length must be divisible by Double.BYTES");
+
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        double[] result = new double[length];
+        int m = Math.min(length, bytes.length / Double.BYTES);
+
+        for (int i = 0; i < m; i++) {
+            result[i] = buf.getDouble();
+        }
+
+        return result;
+    }
+
+    /**
+     * Unpack an array of bytes as an array of floats.
+     * 
+     * @param bytes An array of bytes.
+     * @return an array of floats obtained by marshalling consecutive bytes in the
+     *         input array into floats.
+     */
+    public static float[] unpackFloats(byte[] bytes) {
+        checkNotNull(bytes, "bytes must not be null");
+        return unpackFloats(bytes, bytes.length / Float.BYTES);
+    }
+
+    /**
+     * Unpack an array of bytes as an array of floats.
+     * 
+     * @param bytes  An array of bytes.
+     * @param length The desired length of the resulting float array. The input will
+     *               be truncated or padded with zeros as needed.
+     * @return an array of doubles obtained by marshalling consecutive bytes in the
+     *         input array into floats.
+     */
+    public static float[] unpackFloats(byte[] bytes, int length) {
+        checkNotNull(bytes, "bytes must not be null");
+        checkArgument(length >= 0, "length must be greater than or equal to 0");
+        checkArgument(bytes.length % Float.BYTES == 0, "bytes.length must be divisible by Float.BYTES");
+
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        float[] result = new float[length];
+        int m = Math.min(length, bytes.length / Float.BYTES);
+
+        for (int i = 0; i < m; i++) {
+            result[i] = buf.getFloat();
+        }
+
+        return result;
+    }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
@@ -15,11 +15,18 @@
 
 package com.amazon.randomcutforest;
 
-import com.amazon.randomcutforest.config.Precision;
-import com.amazon.randomcutforest.returntypes.DensityOutput;
-import com.amazon.randomcutforest.returntypes.DiVector;
-import com.amazon.randomcutforest.state.RandomCutForestMapper;
-import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+import static java.lang.Math.PI;
+import static java.lang.Math.cos;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -30,17 +37,11 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import java.util.Random;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static java.lang.Math.PI;
-import static java.lang.Math.cos;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.returntypes.DensityOutput;
+import com.amazon.randomcutforest.returntypes.DiVector;
+import com.amazon.randomcutforest.state.RandomCutForestMapper;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
 
 @Tag("functional")
 public class CompactRandomCutForestFunctionalTest {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/util/ArrayPackingTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/util/ArrayPackingTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ArrayPackingTest {
+    private Random rng;
+
+    @BeforeEach
+    public void setUp() {
+        rng = new Random();
+    }
+
+    @Test
+    public void testLogMax() {
+        long[] bases = new long[] { 2, 101, 3_456_789 };
+        Arrays.stream(bases).forEach(base -> {
+            int log = ArrayPacking.logMax(base);
+            assertTrue(Math.pow(base, log + 1) >= Integer.MAX_VALUE);
+            assertTrue(Math.pow(base, log) < Integer.MAX_VALUE);
+        });
+    }
+
+    @Test
+    public void testLogMaxInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> ArrayPacking.logMax(1));
+        assertThrows(IllegalArgumentException.class, () -> ArrayPacking.logMax(0));
+        assertThrows(IllegalArgumentException.class, () -> ArrayPacking.logMax(-123467890));
+    }
+
+    @Test
+    public void testIntsPackRoundTrip() {
+        int inputLength = 100;
+        int[] inputArray = rng.ints().limit(inputLength).toArray();
+        assertArrayEquals(inputArray, ArrayPacking.unpackInts(ArrayPacking.pack(inputArray, false), false));
+        assertArrayEquals(inputArray, ArrayPacking.unpackInts(ArrayPacking.pack(inputArray, true), true));
+    }
+
+    @Test
+    public void testUnpackIntsWithLengthGiven() {
+        int inputLength = 100;
+        int[] inputArray = rng.ints().limit(inputLength).toArray();
+
+        int[] uncompressed = ArrayPacking.pack(inputArray, false);
+        int[] compressed = ArrayPacking.pack(inputArray, true);
+
+        int[] result = ArrayPacking.unpackInts(uncompressed, 50, false);
+        assertEquals(50, result.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, 50), result);
+
+        result = ArrayPacking.unpackInts(compressed, 50, true);
+        assertEquals(50, result.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, 50), result);
+
+        result = ArrayPacking.unpackInts(uncompressed, 200, false);
+        assertEquals(200, result.length);
+        assertArrayEquals(inputArray, Arrays.copyOf(result, 100));
+        for (int i = 100; i < 200; i++) {
+            assertEquals(0, result[i]);
+        }
+
+        result = ArrayPacking.unpackInts(compressed, 200, true);
+        assertEquals(200, result.length);
+        assertArrayEquals(inputArray, Arrays.copyOf(result, 100));
+        for (int i = 100; i < 200; i++) {
+            assertEquals(0, result[i]);
+        }
+    }
+
+    @Test
+    public void testPackDoublesRoundTrip() {
+        int inputLength = 100;
+        double[] inputArray = rng.doubles().limit(inputLength).toArray();
+        assertArrayEquals(inputArray, ArrayPacking.unpackDoubles(ArrayPacking.pack(inputArray)));
+    }
+
+    @Test
+    public void testPackFloatsRoundTrip() {
+        int inputLength = 100;
+        float[] inputArray = new float[inputLength];
+        for (int i = 0; i < inputLength; i++) {
+            inputArray[i] = rng.nextFloat();
+        }
+        assertArrayEquals(inputArray, ArrayPacking.unpackFloats(ArrayPacking.pack(inputArray)));
+    }
+
+    @Test
+    public void testPackDoublesWithLength() {
+        int inputLength = 100;
+        int packLength = 76;
+        double[] inputArray = rng.doubles().limit(inputLength).toArray();
+        byte[] bytes = ArrayPacking.pack(inputArray, packLength);
+        double[] outputArray = ArrayPacking.unpackDoubles(bytes);
+
+        assertEquals(packLength, outputArray.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, packLength), outputArray);
+    }
+
+    @Test
+    public void testPackFloatsWithLength() {
+        int inputLength = 100;
+        int packLength = 76;
+        float[] inputArray = new float[inputLength];
+        for (int i = 0; i < inputLength; i++) {
+            inputArray[i] = rng.nextFloat();
+        }
+        byte[] bytes = ArrayPacking.pack(inputArray, packLength);
+        float[] outputArray = ArrayPacking.unpackFloats(bytes);
+
+        assertEquals(packLength, outputArray.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, packLength), outputArray);
+    }
+
+    @Test
+    public void testUnpackDoublesWithLength() {
+        int inputLength = 100;
+        double[] inputArray = rng.doubles().limit(inputLength).toArray();
+        byte[] bytes = ArrayPacking.pack(inputArray);
+
+        int unpackLength1 = 25;
+        double[] outputArray1 = ArrayPacking.unpackDoubles(bytes, unpackLength1);
+        assertEquals(unpackLength1, outputArray1.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, unpackLength1), outputArray1);
+
+        int unpackLength2 = 123;
+        double[] outputArray2 = ArrayPacking.unpackDoubles(bytes, unpackLength2);
+        assertEquals(unpackLength2, outputArray2.length);
+        assertArrayEquals(inputArray, Arrays.copyOf(outputArray2, inputLength));
+        for (int i = inputLength; i < unpackLength2; i++) {
+            assertEquals(0.0, outputArray2[i]);
+        }
+    }
+
+    @Test
+    public void testUnpackFloatWithLength() {
+        int inputLength = 100;
+        float[] inputArray = new float[inputLength];
+        for (int i = 0; i < inputLength; i++) {
+            inputArray[i] = rng.nextFloat();
+        }
+        byte[] bytes = ArrayPacking.pack(inputArray);
+
+        int unpackLength1 = 25;
+        float[] outputArray1 = ArrayPacking.unpackFloats(bytes, unpackLength1);
+        assertEquals(unpackLength1, outputArray1.length);
+        assertArrayEquals(Arrays.copyOf(inputArray, unpackLength1), outputArray1);
+
+        int unpackLength2 = 123;
+        float[] outputArray2 = ArrayPacking.unpackFloats(bytes, unpackLength2);
+        assertEquals(unpackLength2, outputArray2.length);
+        assertArrayEquals(inputArray, Arrays.copyOf(outputArray2, inputLength));
+        for (int i = inputLength; i < unpackLength2; i++) {
+            assertEquals(0.0, outputArray2[i]);
+        }
+    }
+}


### PR DESCRIPTION
Update `PointStoreState` to use a `byte[]` array field for point data, instead of separate `float[]` and `double[]` fields to handle the different cases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
