### PR TITLE
Propagate initial accept fraction through array sampler converter

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -205,4 +205,7 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         return sample.size();
     }
 
+    public double getInitialAcceptFraction() {
+        return initialAcceptFraction;
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
@@ -85,6 +85,7 @@ public class ArraySamplersToCompactStateConverter {
         samplerState.setSequenceIndex(sequenceIndex);
         samplerState.setSequenceIndexOfMostRecentLambdaUpdate(sampler.getSequenceIndexOfMostRecentLambdaUpdate());
         samplerState.setMaxSequenceIndex(sampler.getMaxSequenceIndex());
+        samplerState.setInitialAcceptFraction(sampler.getInitialAcceptFraction());
 
         compactSamplerStates.add(samplerState);
     }


### PR DESCRIPTION
We failed to update `ArraysSamplersToCompactStateConverter` when we added the `initialAcceptFraction` option to stream samplers. This change fixes the converter class so that sampler states are correctly serialized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
