### PR TITLE
[rust] Sampled trees and reservoir samplers

### DIFF
--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -34,6 +34,12 @@
 //! cut forest based anomaly detection on streams."* International Conference
 //! on Machine Learning, pp. 2712-2721. PMLR, 2016. ()
 
+pub mod sampler;
+pub use sampler::{SamplerResult, StreamSampler, WeightedSample};
+
+mod sampled_tree;
+pub use sampled_tree::SampledTree;
+
 mod store;
 pub use store::{NodeStore, PointStore};
 

--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -34,7 +34,7 @@
 //! cut forest based anomaly detection on streams."* International Conference
 //! on Machine Learning, pp. 2712-2721. PMLR, 2016. ()
 
-pub mod sampler;
+mod sampler;
 pub use sampler::{SamplerResult, StreamSampler, WeightedSample};
 
 mod sampled_tree;

--- a/Rust/src/sampled_tree.rs
+++ b/Rust/src/sampled_tree.rs
@@ -52,8 +52,8 @@ impl<T> SampledTree<T>
     /// Create a new sampled tree.
     ///
     /// Specify the tree's `sample_size`, the number of point maintained by the
-    /// tree, and decay factor `lambda` for the time-decay sampler defined in
-    /// [`StreamSampler`].
+    /// tree, and decay factor `time_decay` for the time-decay sampler defined
+    /// in [`StreamSampler`].
     ///
     /// # Examples
     ///
@@ -61,9 +61,9 @@ impl<T> SampledTree<T>
     /// use random_cut_forest::SampledTree;
     /// let tree: SampledTree<f32> = SampledTree::new(128, 0.01);
     /// ```
-    pub fn new(sample_size: usize, lambda: f64) -> Self {
+    pub fn new(sample_size: usize, time_decay: f32) -> Self {
         let point_store: Rc<RefCell<PointStore<T>>> = Rc::new(RefCell::new(PointStore::new()));
-        SampledTree::new_with_point_store(sample_size, lambda, point_store)
+        SampledTree::new_with_point_store(sample_size, time_decay, point_store)
     }
 
     /// Create a new sampled tree with a given point store.
@@ -87,13 +87,13 @@ impl<T> SampledTree<T>
     /// ```
     pub fn new_with_point_store(
         sample_size: usize,
-        lambda: f64,
+        time_decay: f32,
         point_store: Rc<RefCell<PointStore<T>>>,
     ) -> Self {
         SampledTree {
             point_store: point_store.clone(),
             tree: Tree::new_with_point_store(point_store.clone()),
-            sampler: StreamSampler::new(sample_size, lambda),
+            sampler: StreamSampler::new(sample_size, time_decay),
         }
     }
 
@@ -110,7 +110,7 @@ impl<T> SampledTree<T>
     /// Update the sampled tree with a new point.
     ///
     /// The stream sampler decides if the new point will be accepted into the
-    /// tree as a function of the decay factor `lambda` and the input
+    /// tree as a function of the decay factor `time_decay` and the input
     /// `sequence_index` for this point.
     ///
     /// # Examples
@@ -201,7 +201,7 @@ impl<T> SampledTree<T>
     /// ```
     pub fn sample_size(&self) -> usize { self.sampler.capacity() }
 
-    /// Returns the decay factor of the random sampler.
+    /// Returns the time decay factor of the random sampler.
     ///
     /// # Examples
     ///
@@ -209,9 +209,9 @@ impl<T> SampledTree<T>
     /// use random_cut_forest::SampledTree;
     ///
     /// let tree: SampledTree<f32> = SampledTree::new(256, 0.001);
-    /// assert_eq!(tree.lambda(), 0.001);
+    /// assert_eq!(tree.time_decay(), 0.001);
     /// ```
-    pub fn lambda(&self) -> f64 { self.sampler.lambda() }
+    pub fn time_decay(&self) -> f32 { self.sampler.time_decay() }
 
     /// Returns the total number of observations made by the tree.
     ///

--- a/Rust/src/sampled_tree.rs
+++ b/Rust/src/sampled_tree.rs
@@ -215,7 +215,7 @@ impl<T> SampledTree<T>
 
     /// Returns the total number of observations made by the tree.
     ///
-    /// For every point sent to [`SampledTree::sample`], the total number of
+    /// For every point sent to [`SampledTree::update`], the total number of
     /// observations is incremented independent of the sample size or whether
     /// or not the point is accepted into the sample.
     ///

--- a/Rust/src/sampled_tree.rs
+++ b/Rust/src/sampled_tree.rs
@@ -1,0 +1,267 @@
+extern crate num_traits;
+use num_traits::Float;
+
+use std::cell::{Ref, RefCell, RefMut};
+use std::iter::Sum;
+use std::rc::Rc;
+
+use crate::{PointStore, SamplerResult, StreamSampler};
+use crate::tree::{AddResult, NodeTraverser, Tree};
+
+/// Combination of a tree and a reservoir sampler.
+///
+/// A random cut tree, represented by the [`Tree`] struct, is a data structure
+/// for organizing vectors using bounding boxes and random cuts. In a random
+/// cut forest model we wish to limit the number of points contained in the
+/// tree. This is done using a reservoir sampler. A `SampledTree` coordinates
+/// point additions and deletions between a reservoir sampler, given by a
+/// [`StreamSampler`], and the random cut tree.
+///
+/// # Examples
+///
+/// ```
+/// use random_cut_forest::{Node, SampledTree};
+///
+/// // create a sampled tree that can hold 32 points witha a decay factor 0.01
+/// let mut tree: SampledTree<f32> = SampledTree::new(32, 0.01);
+///
+/// // if necessary, we can set the random seed used in point sampling as well
+/// // as the random cut process
+/// tree.seed(42);
+///
+/// // update the tree with some points. every point will be accepted into the
+/// // tree until the sample size is reached.
+/// tree.update(vec![0.0, 0.0], 0);
+/// tree.update(vec![1.0, -1.0], 1);
+/// tree.update(vec![2.0, 3.0], 2);
+/// assert_eq!(tree.num_observations(), 3);
+///
+/// // given a query point, we can traverse the tree by following random cuts
+/// let query = vec![0.5, 1.5];
+/// let traversal_nodes: Vec<&Node<f32>> = tree.traverse(&query).collect();
+/// ```
+pub struct SampledTree<T> {
+    point_store: Rc<RefCell<PointStore<T>>>,
+    tree: Tree<T>,
+    sampler: StreamSampler<usize>,
+}
+
+impl<T> SampledTree<T>
+    where T: Float + Sum
+{
+    /// Create a new sampled tree.
+    ///
+    /// Specify the tree's `sample_size`, the number of point maintained by the
+    /// tree, and decay factor `lambda` for the time-decay sampler defined in
+    /// [`StreamSampler`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::SampledTree;
+    /// let tree: SampledTree<f32> = SampledTree::new(128, 0.01);
+    /// ```
+    pub fn new(sample_size: usize, lambda: f64) -> Self {
+        let point_store: Rc<RefCell<PointStore<T>>> = Rc::new(RefCell::new(PointStore::new()));
+        SampledTree::new_with_point_store(sample_size, lambda, point_store)
+    }
+
+    /// Create a new sampled tree with a given point store.
+    ///
+    /// In addition to the parameters in `new()`, specifies a point store to
+    /// be used by the sampled tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::RefCell;
+    /// use std::rc::Rc;
+    /// use random_cut_forest::{SampledTree, PointStore};
+    ///
+    /// // create a point store
+    /// let point_store = Rc::new(RefCell::new(PointStore::new()));
+    ///
+    /// // initialize the sampled tree with a new point store
+    /// let tree: SampledTree<f32> = SampledTree::new_with_point_store(
+    ///     128, 0.01, point_store);
+    /// ```
+    pub fn new_with_point_store(
+        sample_size: usize,
+        lambda: f64,
+        point_store: Rc<RefCell<PointStore<T>>>,
+    ) -> Self {
+        SampledTree {
+            point_store: point_store.clone(),
+            tree: Tree::new_with_point_store(point_store.clone()),
+            sampler: StreamSampler::new(sample_size, lambda),
+        }
+    }
+
+    /// Sets the seed of the `SampledTree`'s tree and stream sampler.
+    ///
+    /// Randomness is used in [`Tree`] primarily for generating random cuts.
+    /// Randomness is used in [`StreamSampler`] to determine which points are
+    /// accepted into the sample.
+    pub fn seed(&mut self, seed: u64) {
+        self.tree.seed(seed);
+        self.sampler.seed(seed);
+    }
+
+    /// Update the sampled tree with a new point.
+    ///
+    /// The stream sampler decides if the new point will be accepted into the
+    /// tree as a function of the decay factor `lambda` and the input
+    /// `sequence_index` for this point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::SampledTree;
+    /// let mut tree: SampledTree<f32> = SampledTree::new(128, 0.01);
+    ///
+    /// tree.update(vec![0.0, 0.0], 0);
+    /// tree.update(vec![1.0, -1.0], 1);
+    /// assert_eq!(tree.num_observations(), 2);
+    /// ```
+    pub fn update(&mut self, point: Vec<T>, sequence_index: usize) {
+        // we need a point key that we can submit to the sampler. the strategy,
+        // then, is to first add the point to the tree and then sample using
+        // the output key. if the key is accepted by the sampler then we
+        // evict if necessary. otherwise, we delete the point we just added
+        //
+        // TODO: is there a way to do this without cloning? We need a reference
+        // to the point if we need to delete afterward. Slabs allow you to
+        // obtain the next available key...
+        let point_key = match self.tree.add_point(point.clone()) {
+            AddResult::AddedPoint(key) => key,
+            AddResult::MassIncreased(key) => key,
+        };
+
+        match self.sampler.sample(point_key, sequence_index) {
+            SamplerResult::Accepted(evicted) => match evicted {
+                Some(evicted) => {
+                    // TODO: can we satisfy the borrow checker so that we can
+                    // perform the delete without needing to clone the point?
+                    let evicted_point = {
+                        let point_store = self.point_store.borrow();
+                        point_store.get(*evicted.value()).unwrap().clone()
+                    };
+                    self.tree.delete_point(&evicted_point);
+                }
+                None => ()
+            },
+            SamplerResult::Ignored => { self.tree.delete_point(&point); }
+        }
+    }
+
+    /// Traverse the tree with a given query point as input.
+    ///
+    /// Returns an iterator on the nodes of the tree. The iterator begins at the
+    /// tree's root node and follows the branch to the leaf node containing the
+    /// point nearest to the query point in L1 norm.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::{Node, SampledTree};
+    /// let mut tree: SampledTree<f32> = SampledTree::new(32, 0.01);
+    /// tree.update(vec![0.0, 0.0], 0);
+    /// tree.update(vec![1.0, 1.0], 1);
+    ///
+    /// // provide a query point that will always be to the left of any cut
+    /// // on the two points inserted above, no matter the cut location
+    /// let query = vec![-2.0, -2.0];
+    /// let nodes: Vec<&Node<f32>> = tree.traverse(&query).collect();
+    /// assert_eq!(nodes.len(), 2);
+    ///
+    /// // verify the last point of the tree is equal to the left-most point
+    /// if let Node::Leaf(leaf) = nodes[1] {
+    ///     let point_key = leaf.point();
+    ///     let point_store = tree.borrow_point_store();
+    ///     let point = point_store.get(point_key).unwrap();
+    ///     assert_eq!(point, &vec![0.0, 0.0]);
+    /// } else {
+    ///     panic!("Last node in traversal should be a leaf!")
+    /// }
+    /// ```
+    ///
+    pub fn traverse<'a>(&'a self, point: &'a Vec<T>) -> NodeTraverser<'a, T> {
+        self.tree.traverse(point)
+    }
+
+    /// Returns the sample size of the sampled tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::SampledTree;
+    ///
+    /// let tree: SampledTree<f32> = SampledTree::new(256, 0.001);
+    /// assert_eq!(tree.sample_size(), 256);
+    /// ```
+    pub fn sample_size(&self) -> usize { self.sampler.capacity() }
+
+    /// Returns the decay factor of the random sampler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::SampledTree;
+    ///
+    /// let tree: SampledTree<f32> = SampledTree::new(256, 0.001);
+    /// assert_eq!(tree.lambda(), 0.001);
+    /// ```
+    pub fn lambda(&self) -> f64 { self.sampler.lambda() }
+
+    /// Returns the total number of observations made by the tree.
+    ///
+    /// For every point sent to [`SampledTree::sample`], the total number of
+    /// observations is incremented independent of the sample size or whether
+    /// or not the point is accepted into the sample.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::SampledTree;
+    ///
+    /// let mut tree: SampledTree<f32> = SampledTree::new(2, 1.0);
+    /// assert_eq!(tree.num_observations(), 0);
+    ///
+    /// tree.update(vec![0.0, 0.0], 0);
+    /// assert_eq!(tree.num_observations(), 1);
+    ///
+    /// tree.update(vec![1.0, 1.0], 10);
+    /// assert_eq!(tree.num_observations(), 2);
+    ///
+    /// tree.update(vec![2.0, 2.0], 20);
+    /// assert_eq!(tree.num_observations(), 3);
+    /// ```
+    pub fn num_observations(&self) -> usize { self.sampler.num_observations() }
+
+    /// Returns a reference to the tree in the sampled tree.
+    pub fn tree(&self) -> &Tree<T> { &self.tree }
+
+    /// Borrow the sampled tree's point store.
+    pub fn borrow_point_store(&self) -> Ref<PointStore<T>> { self.point_store.borrow() }
+
+    /// Mutably borrow the sample's tree's point store.
+    pub fn mut_borrow_point_store(&self) -> RefMut<PointStore<T>> { self.point_store.borrow_mut() }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filled_sample() {
+        let mut tree: SampledTree<f32> = SampledTree::new(2, 8.0);
+
+        // update until full
+        tree.update(vec![0.0, 0.0], 0);
+        tree.update(vec![1.0, 0.0], 1);
+
+        // additional points that cause evictions
+        tree.update(vec![0.0, 1.0], 100);
+    }
+}

--- a/Rust/src/sampler.rs
+++ b/Rust/src/sampler.rs
@@ -1,0 +1,440 @@
+//! Random sampling of data from a stream.
+//!
+//! A stream sampler is a mechanism for maintaining a fixed-size random sample
+//! from a stream of data. Specifically, we maintain "weighted samples": data
+//! samples that have assigned to them a "weight" which is proportional to the
+//! probability that the point will be included in the sample. This allows for
+//! something like time-decay random sampling where we prefer to accept
+//! recently observed samples.
+//!
+//! ```
+//! use random_cut_forest::{SamplerResult, StreamSampler, WeightedSample};
+//!
+//! // create a sampler that can contain two elements with a time decay
+//! // parameter large enough that it should be very rare for a new point
+//! // to not be accepted
+//! let mut sampler = StreamSampler::new(2, 100000.0);
+//!
+//! // sample a new value. this is guaranteed to be sampled as long as
+//! // the sampler is not full
+//! match sampler.sample("hello", 10) {
+//!     SamplerResult::Accepted(evicted) => assert!(evicted.is_none()),
+//!     SamplerResult::Ignored => panic!(),
+//! }
+//!
+//! // confirm that this value is contained within the samples
+//! let samples: Vec<&WeightedSample<&str>> = sampler.iter().collect();
+//! assert_eq!(samples.len(), 1);
+//! assert_eq!(samples[0].value(), &"hello");
+//!
+//! // sample a second value. this too should be accepted since the sampler
+//! // is not yet full
+//! match sampler.sample("world", 20) {
+//!     SamplerResult::Accepted(evicted) => assert!(evicted.is_none()),
+//!     SamplerResult::Ignored => panic!(),
+//! }
+//!
+//! // the sampler is full, but because of the large decay parameter, it is
+//! // almost guaranteed that the third sample will be accepted
+//! match sampler.sample("I'm taking over", 123) {
+//!     SamplerResult::Accepted(evicted) => assert_eq!(evicted.unwrap().value(), &"hello"),
+//!     SamplerResult::Ignored => panic!(),
+//! }
+//!
+//! // again, with a large decay parameter, an element with a small sequence
+//! // index will likely not by sampled
+//! match sampler.sample("Just passing by", 0) {
+//!     SamplerResult::Accepted(_) => panic!(),
+//!     SamplerResult::Ignored => println!("This sample was ignored"),
+//! }
+//! ```
+
+extern crate rand;
+use rand::{Rng, SeedableRng};
+
+extern crate rand_chacha;
+use rand_chacha::ChaCha8Rng;
+
+use std::cmp::{Ord, PartialOrd, Eq, Ordering};
+use std::collections::BinaryHeap;
+use std::collections::binary_heap;
+
+/// Weighted samples stored in a stream sampler.
+///
+/// Weighted samples store a value along with a weight. Depending on the
+/// configuration of the sampler, the weight can be used to affect the
+/// probability that the point will be accepted into sampler. Within a sampler,
+/// weighted samples are ranked by their weight.
+///
+/// Weighted samples also use a "sequence index", which indicates when this
+/// sample was observed relative to other samples in the stream. Stream samplers
+/// use this information to determine which points
+///
+/// # Examples
+///
+/// ```
+/// use random_cut_forest::WeightedSample;
+///
+/// let x = WeightedSample::new("Hello, ", 42.0);
+/// let y = WeightedSample::new("world.", 123.0);
+/// let z = WeightedSample::new("Same weight as 'Hello'", 42.0);
+///
+/// assert!(x < y);
+/// assert!(x == z);
+/// ```
+pub struct WeightedSample<T> {
+    value: T,
+    weight: f64,
+}
+
+impl<T> WeightedSample<T> {
+    pub fn new(value: T, weight: f64) -> Self {
+        WeightedSample {
+            value: value,
+            weight: weight,
+        }
+    }
+
+    /// Get the value stored in the weighted sample.
+    pub fn value(&self) -> &T { &self.value }
+
+    /// Get the weight of the sample.
+    pub fn weight(&self) -> &f64 { &self.weight }
+}
+
+/// Weighted samples are ordered by their weight. Because weighted samples are
+/// stored in a heap ([`std::collections::BinaryHeap`]) we need to implement
+/// [`Ord`].
+///
+/// # Note
+///
+/// Floats do not actually implement `Ord`, so this is a bit of a hack in order
+/// to get a heap/priority queue working on weighted samples.
+impl<T> Ord for WeightedSample<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.weight < other.weight {
+            return Ordering::Less;
+        } else if self.weight > other.weight {
+            return Ordering::Greater;
+        } else {
+            return Ordering::Equal;
+        }
+    }
+}
+
+impl<T> PartialOrd for WeightedSample<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.weight.partial_cmp(&other.weight)
+    }
+}
+
+impl<T> PartialEq for WeightedSample<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.weight.eq(&other.weight)
+    }
+}
+
+impl<T> Eq for WeightedSample<T> { }
+
+
+/// Returned when a stream samper accepts or is updated with a new value.
+///
+/// When [`StreamSampler::sample`] is called with a new value, the value is
+/// either ignored or accepted into the sampler. If accepted, a weighted sample
+/// might be evicted from the sampler.
+pub enum SamplerResult<T> {
+    Ignored,
+    Accepted(Option<WeightedSample<T>>),
+}
+
+/// Maintains a fixed-size random sample from a data stream.
+///
+/// When a new value is submitted to the sampler it decides whether to accept
+/// the point into the sample. The decision is based on the current number of
+/// samples as well as the weights of these samples. Newer values, indicated by
+/// their sequence index, are assigned a larger weight than older values.
+///
+/// This sampler is based on a weighted reservoir sampling algorithm. As such,
+/// it has a time decay parameter `lambda`. The value of `lambda` indicates how
+/// aggressively the sampler should prefer to store the most recently obesrved
+/// samples. When `lambda == 0.0`, samples are uniformly retained; that is,
+/// given `N` observations a sampler of size `S` will keep `S` samples
+/// distributed uniformly across the `N` observations without replacement.
+///
+/// # Examples
+///
+/// ```
+/// use random_cut_forest::{SamplerResult, StreamSampler};
+///
+/// // create a seeded stream sampler on strings
+/// let mut sampler: StreamSampler<&str> = StreamSampler::new(2, 123.4);
+/// sampler.seed(42);
+/// assert_eq!(sampler.capacity(), 2);
+///
+/// // add a sample to the empty stream sampler with a sequence index of zero
+/// sampler.sample("Hello", 0);
+/// assert!(!sampler.is_full());
+/// assert_eq!(sampler.size(), 1);
+/// assert_eq!(sampler.num_observations(), 1);
+///
+/// // the sample function returns a SampleResult
+/// let result = sampler.sample(", world!", 1);
+/// assert!(sampler.is_full());
+/// assert_eq!(sampler.size(), 2);
+/// assert_eq!(sampler.num_observations(), 2);
+///
+/// // until the sampler is full it will always return an `Accepted` result
+/// if let SamplerResult::Accepted(evicted_sample) = result {
+///     assert!(evicted_sample.is_none());
+/// } else { panic!("Expected accepted sample") }
+///
+///
+/// // with the random seed above, the next sample should be accepted as well,
+/// // evicting some older point from the sample
+/// let result = sampler.sample("-- Some Programmer", 20);
+/// assert!(sampler.is_full());
+/// assert_eq!(sampler.size(), 2);
+/// assert_eq!(sampler.num_observations(), 3);
+///
+/// if let SamplerResult::Accepted(evicted_sample) = result {
+///     assert!(evicted_sample.is_some());
+///     println!("evicted value = {}", evicted_sample.unwrap().value());
+/// } else { panic!("Expected accepted sample") }
+/// ```
+///
+pub struct StreamSampler<T> {
+    weighted_samples: BinaryHeap<WeightedSample<T>>,
+    sample_size: usize,
+    num_observations: usize,
+    lambda: f64,
+    rng: ChaCha8Rng,
+}
+
+
+impl<T> StreamSampler<T> {
+
+    /// Create a new stream sampler.
+    ///
+    /// A `sample_size` must be provided to indicate the number of samples that
+    /// the stream sampler can store. Additionally, a decay factor `lambda`
+    /// must be provided to indicate how aggressively the sampler favors keeping
+    /// more recently observed sampler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::StreamSampler;
+    ///
+    /// // create a new stream sampler on floats with capacity two
+    /// let sampler: StreamSampler<&str> = StreamSampler::new(2, 0.1);
+    /// ```
+    pub fn new(sample_size: usize, lambda: f64) -> Self {
+        if lambda < 0.0 {
+            panic!("Lambda must be non-negative")
+        }
+
+        StreamSampler {
+            weighted_samples: BinaryHeap::with_capacity(sample_size),
+            sample_size: sample_size,
+            num_observations: 0,
+            lambda: lambda,
+            rng: ChaCha8Rng::from_entropy(),
+        }
+    }
+
+    /// Reset the stream samplers random number generator with a specified seed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::StreamSampler;
+    ///
+    /// let mut sampler: StreamSampler<&str> = StreamSampler::new(2, 0.1);
+    /// sampler.seed(42);
+    /// ```
+    pub fn seed(&mut self, seed: u64) {
+        self.rng = ChaCha8Rng::seed_from_u64(seed);
+    }
+
+
+    /// Sample a new value with a given sequence index.
+    ///
+    /// A value along with `sequence_index`, indicating the relative order of
+    /// this value to other observed values, is provided to be a candidate
+    /// addition to this sample. If the value is **not** sampled then a
+    /// [`SamplerResult::Ignored`] is returned by this function. Otherwise,
+    /// a [`SamplerResult::Accepted`] is returned containing an `evicted_sample`
+    /// of type `Option<WeightedSample<T>>`. This is the sample that had to be
+    /// evicted in order to make room for the newly accepted sample.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::{SamplerResult, StreamSampler};
+    ///
+    /// // create a sampler that can hold two samples
+    /// let mut sampler: StreamSampler<&str> = StreamSampler::new(2, 0.1);
+    /// sampler.seed(0);
+    ///
+    /// // pass in the value "hello" with sequence index zero
+    /// let result = sampler.sample("hello", 0);
+    ///
+    /// // the result should be accepted and no points are evicted (the sampler
+    /// // is currently empty)
+    /// if let SamplerResult::Accepted(evicted) = result {
+    ///     assert!(evicted.is_none());
+    /// } else { panic!("Expected accepted sample") }
+    /// ```
+    ///
+    pub fn sample(&mut self, value: T, sequence_index: usize) -> SamplerResult<T> {
+        let weight = self.compute_weight(sequence_index);
+        self.num_observations += 1;
+
+        // determine if we should accept the new value into the sample
+        let under_sampled = self.num_observations <= self.sample_size;
+        let new_observation_has_smaller_weight = match self.weighted_samples.peek() {
+            Some(sample) => weight < *sample.weight(),
+            None => false,
+        };
+        let accept_sample = under_sampled || new_observation_has_smaller_weight;
+
+        // if accepted, add to samples and evict a sample if necessary
+        if accept_sample {
+            let evicted_sample = match self.is_full() {
+                true => self.weighted_samples.pop(),
+                false => None,
+            };
+            let candidate_sample = WeightedSample { value: value, weight: weight };
+            self.weighted_samples.push(candidate_sample);
+
+            return SamplerResult::Accepted(evicted_sample);
+        }
+
+        SamplerResult::Ignored
+    }
+
+    /// Transform a sequence index to a weight using this sampler's decay factor.
+    ///
+    /// The weight of sample is used to determine the priority of the samples;
+    /// the sampler maintains those samples with largest observed weight. Given
+    /// a sequence index, `n`, the computed weight is `R = u^(1/w)` where
+    /// `w = exp(lambda * n)`.
+    ///
+    /// In practice we transform these weights into log-space for numerical
+    /// stability. The more negative these transformed weights are the more
+    /// likely the value will be accepted into the sample.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use random_cut_forest::StreamSampler;
+    /// extern crate rand;
+    ///
+    /// let mut sampler = StreamSampler::new(128, 0.1);
+    /// sampler.sample("hello", 0);
+    ///
+    /// println!("{}", sampler.compute_weight(1));
+    /// println!("{}", sampler.compute_weight(2));
+    /// println!("{}", sampler.compute_weight(1000)); // likely to be more negative
+    /// ```
+    pub fn compute_weight(&mut self, sequence_index: usize) -> f64 {
+        let random: f64 = self.rng.gen();
+        -(sequence_index as f64) * self.lambda + (-random.ln()).ln()
+    }
+
+    /// Returns an iterator on the elements of the sampler.
+    ///
+    /// This simply returns the result of [`BinaryHeap.iter()`]. The weighted
+    /// samples are visited in arbitrary order.
+    pub fn iter(&self) -> binary_heap::Iter<'_, WeightedSample<T>> {
+        self.weighted_samples.iter()
+    }
+
+    pub fn num_observations(&self) -> usize { self.num_observations }
+    pub fn is_full(&self) -> bool { self.sample_size == self.weighted_samples.len() }
+    pub fn capacity(&self) -> usize { self.sample_size }
+    pub fn size(&self) -> usize { self.weighted_samples.len() }
+    pub fn lambda(&self) -> f64 { self.lambda }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_weighted_sample() {
+        let x1 = WeightedSample { value: "Without education we", weight: 0.0 };
+        let x2 = WeightedSample { value: "are in a horrible and", weight: 1.0 };
+        let x3 = WeightedSample { value: "deadly danger of taking", weight: -2.0 };
+        let x4 = WeightedSample { value: "educated people seriously.", weight: 3.0 };
+        let x5 = WeightedSample { value: "-- G. K. Chesterton", weight: 0.0 };
+
+        assert!(x3 < x1 && x1 < x2 && x2 < x4);
+        assert!(x1 == x5);
+    }
+
+    #[test]
+    fn test_sampler() {
+        // set the time decay parameter large enough that it should be very
+        // rare for a new point to not be accepted into the sampler
+        let mut sampler = StreamSampler::new(2, 100000.0);
+        assert_eq!(sampler.capacity(), 2);
+        assert_eq!(sampler.size(), 0);
+        assert_eq!(sampler.is_full(), false);
+
+        match sampler.sample("Without education we", 0) {
+            SamplerResult::Accepted(evicted) => {
+                assert!(evicted.is_none());
+                assert_eq!(sampler.size(), 1);
+                assert_eq!(sampler.is_full(), false);
+            }
+            SamplerResult::Ignored => panic!("Expected data accepted")
+        }
+
+        match sampler.sample("are in a horrible and", 10) {
+            SamplerResult::Accepted(evicted) => {
+                assert!(evicted.is_none());
+                assert_eq!(sampler.size(), 2);
+                assert_eq!(sampler.is_full(), true);
+            }
+            SamplerResult::Ignored => panic!("Expected data accepted")
+        }
+
+        match sampler.sample("deadly danger of taking", 100) {
+            SamplerResult::Accepted(evicted) => match evicted {
+                    Some(evicted) => {
+                        assert_eq!(evicted.value(), &"Without education we");
+                        assert_eq!(sampler.size(), 2);
+                        assert_eq!(sampler.is_full(), true);
+                    }
+                    None => panic!("Expected evicted point")
+                }
+            SamplerResult::Ignored => panic!("Expected data accepted")
+        }
+
+        match sampler.sample("educated people seriously.", 1000) {
+            SamplerResult::Accepted(evicted) => match evicted {
+                Some(evicted) => {
+                    assert_eq!(evicted.value(), &"are in a horrible and");
+                    assert_eq!(sampler.size(), 2);
+                    assert_eq!(sampler.is_full(), true);
+                }
+                None => panic!("Expected evicted point")
+            }
+            SamplerResult::Ignored => panic!("Expected data accepted")
+        }
+
+        match sampler.sample("-- G. K. Chesterton", 10000) {
+            SamplerResult::Accepted(evicted) => match evicted {
+                Some(evicted) => {
+                    assert_eq!(evicted.value(), &"deadly danger of taking");
+                    assert_eq!(sampler.size(), 2);
+                    assert_eq!(sampler.is_full(), true);
+                }
+                None => panic!("Expected evicted point")
+                }
+            SamplerResult::Ignored => panic!("Expected data accepted")
+        }
+    }
+}

--- a/Rust/src/tree/mod.rs
+++ b/Rust/src/tree/mod.rs
@@ -1,5 +1,5 @@
 //! Submodule containing types and components of a random cut tree.
-//! 
+//!
 mod bounding_box;
 pub use bounding_box::BoundingBox;
 

--- a/Rust/src/tree/tree.rs
+++ b/Rust/src/tree/tree.rs
@@ -14,8 +14,6 @@ use std::rc::Rc;
 use crate::store::{PointStore, NodeStore};
 use crate::tree::{Cut, Node};
 
-
-
 /// Random cut tree data structure on nodes and points.
 ///
 /// A random cut tree contains leaf nodes and internal nodes.
@@ -31,7 +29,6 @@ use crate::tree::{Cut, Node};
 /// a `Tree` to uniquely own its point store. In other cases, such as the case
 /// where we want share points across multiple trees in a forest, this tree's
 /// point store may live outside of this tree.
-/// 
 ///
 /// # Examples
 ///
@@ -55,7 +52,7 @@ pub struct Tree<T> {
 }
 
 
-impl<T> Tree<T> 
+impl<T> Tree<T>
     where T: Float + Sum
 {
 
@@ -189,6 +186,7 @@ impl<T> Tree<T>
     ///
     /// See [`NodeTraverser`] for more information.
     ///
+    ///
     /// # Examples
     ///
     /// ```
@@ -216,7 +214,7 @@ impl<T> Tree<T>
     /// ```
     pub fn traverse<'a>(&'a self, point: &'a Vec<T>) -> NodeTraverser<'a, T> {
         NodeTraverser::new(self, point)
-    }    
+    }
 
     // =========================================================================
     // Helper Functions
@@ -275,7 +273,7 @@ pub struct NodeTraverser<'a, T> {
     current_node_key: Option<usize>,
 }
 
-impl<'a, T> NodeTraverser<'a, T> 
+impl<'a, T> NodeTraverser<'a, T>
     where T: Float + Sum
 {
 
@@ -316,7 +314,7 @@ impl<'a, T> NodeTraverser<'a, T>
     }
 }
 
-impl<'a, T> Iterator for NodeTraverser<'a, T> 
+impl<'a, T> Iterator for NodeTraverser<'a, T>
     where T: Float + Sum
 {
     type Item = &'a Node<T>;

--- a/Rust/src/tree/tree_point_addition.rs
+++ b/Rust/src/tree/tree_point_addition.rs
@@ -6,7 +6,7 @@ use std::iter::Sum;
 use crate::tree::{BoundingBox, Cut, Node, Tree};
 
 /// The result of a point addition operation.
-/// 
+///
 /// The `AddedPoint` result contains the key of the point that was added to the
 /// tree. The `MassIncreased` result contains the key of the point whose mass
 /// was increased.
@@ -15,7 +15,7 @@ pub enum AddResult {
     MassIncreased(usize),
 }
 
-impl<T> Tree<T> 
+impl<T> Tree<T>
     where T: Float + Sum
 {
 
@@ -78,23 +78,23 @@ impl<T> Tree<T>
 
     /// Main recursive point addition algorithm given a new point and a current
     /// node.
-    /// 
+    ///
     /// Steps of the point addition algorithm:
-    /// 
+    ///
     /// 1. Check if the current node is leaf representing the same point as the
     ///    one being inserted. If so, increase the mass of this leaf node and
     ///    return.
-    /// 2. Compute the bounding box made by the merging of the new point with 
+    /// 2. Compute the bounding box made by the merging of the new point with
     ///    the current node and create a random cut on this bounding box. If
     ///    the cut separates the point from the original contents of the current
-    ///    node then create a new leaf node at this level. See 
+    ///    node then create a new leaf node at this level. See
     ///    `insert_new_leaf()` for more information.
     /// 3. Otherwise, recurse to the left or right of the tree depending on the
     ///    location of the point relative to the proposed random cut.
     /// 4. When traversing back up the tree via recursion callback we update the
     ///    bounding boxes along the way using the merged boxes computed on the
     ///    way down.
-    /// 
+    ///
     fn add_point_by_node(&mut self, point: Vec<T>, node_key: usize) -> AddResult {
         // 1. this check will in-place increase the mass of the current node if
         // it is a leaf node. Is there a monadic way to do this?
@@ -144,7 +144,7 @@ impl<T> Tree<T>
     /// If the current node is a leaf *and* its point is equal to that of the
     /// input point then increase the mass of this leaf and return `true`.
     /// Otherwise, return `false`.
-    /// 
+    ///
     /// TODO: this function is a bit strange because it will in-place increase
     /// the mass but won't do anything (and return `false`) otherwise. This
     /// information is then used in `add_point_at_node()` to determine if we
@@ -170,7 +170,7 @@ impl<T> Tree<T>
 
     /// Returns a bounding box formed by the merging of the input point with
     /// the contents of the given node.
-    /// 
+    ///
     /// If the node is a leaf then the bounding box is just formed by these two
     /// points. If the node is internal then we return a new bounding box formed
     /// by the merging of the bounding box at this node with the new point.
@@ -196,10 +196,10 @@ impl<T> Tree<T>
 
     /// Given a proposed cut, return the range of values on the bounding box at
     /// the current node in the dimension of the cut.
-    /// 
+    ///
     /// For example, suppose the bounding box is two-dimensional with min values
-    /// `(0, 1)` and max values `(2, 4)`. If the input cut is along dimension 
-    /// 0 then the output range is `(0, 2)`. Otherwise, if the cut is along 
+    /// `(0, 1)` and max values `(2, 4)`. If the input cut is along dimension
+    /// 0 then the output range is `(0, 2)`. Otherwise, if the cut is along
     /// dimension 1 then the output range is `(1, 4)`.
     fn range_on_cut_dimension(&self, node_key: usize, cut: &Cut<T>) -> (T, T) {
         let dim = cut.dimension();
@@ -218,22 +218,22 @@ impl<T> Tree<T>
     }
 
     /// Insert a new leaf node into the tree containing the input point.
-    /// 
-    /// When this function is called we are at a node in the tree where the 
+    ///
+    /// When this function is called we are at a node in the tree where the
     /// merged box (between this node and the new point) has a proposed cut
-    /// that separates the point from original bounding box at this node. 
-    /// 
+    /// that separates the point from original bounding box at this node.
+    ///
     /// Our current tree state is:
-    ///     
+    ///
     /// ```text
     ///       A        N = current node
     ///      / \       A = parent
     ///     S   N      S = sibling of N
     ///        / \
     /// ```
-    /// 
+    ///
     /// This needs to be transformed to:
-    /// 
+    ///
     /// ```text
     ///       A        N = current node
     ///      / \       A = parent
@@ -242,17 +242,17 @@ impl<T> Tree<T>
     ///       N   P    P = new leaf node
     ///      / \
     /// ```
-    /// 
+    ///
     /// Note that the parent node and all nodes above the newly created node `B`
     /// will need to have their bounding boxes and masses updated. This is done
-    /// in the reverse recursion in `add_point_at_node()`. 
-    /// 
+    /// in the reverse recursion in `add_point_at_node()`.
+    ///
     /// Returns the key of the newly inserted point in the tree's point store.
     fn insert_new_leaf(
         &mut self,
         point: Vec<T>,
         node_key: usize,
-        merged_box: BoundingBox<T>, 
+        merged_box: BoundingBox<T>,
         proposed_cut: Cut<T>,
         min: T,
     ) -> usize {
@@ -265,7 +265,7 @@ impl<T> Tree<T>
 
         // B: new merged node. update parent to node's parent
         let (left, right) = if min > proposed_cut.value() {
-            (new_leaf_key, node_key) 
+            (new_leaf_key, node_key)
         } else {
             (node_key, new_leaf_key)
         };

--- a/Rust/src/tree/tree_point_deletion.rs
+++ b/Rust/src/tree/tree_point_deletion.rs
@@ -5,9 +5,9 @@ use std::iter::Sum;
 
 use crate::tree::{BoundingBox, Cut, Internal, Node, Tree};
 
-/// Description of the result of a point deletion operation on a tree by a 
+/// Description of the result of a point deletion operation on a tree by a
 /// `PointDeleter`.
-/// 
+///
 /// This enum has the following possible values:
 /// * `EmptyTree` - the deletion was performed on an empty tree
 /// * `PointNotFound` - the point could not be found in the tree
@@ -22,7 +22,7 @@ pub enum DeleteResult {
     MassDecreased(usize),
 }
 
-impl<T> Tree<T> 
+impl<T> Tree<T>
     where T: Float + Sum
 {
 
@@ -86,14 +86,14 @@ impl<T> Tree<T>
             Node::Leaf(_) => self.visit_leaf(point, node_key),
         }
     }
-    
+
     /// Deletion algorithm at an internal node.
-    /// 
+    ///
     /// We search for the point to delete by following cuts down the tree. That
     /// is, at a particular internal node we check if the input point to delete
     /// is on the left or right of the node's cut and select one of the node's
     /// children, accordingly.
-    /// 
+    ///
     /// One a leaf node is encountered and the leaf node contains the point that
     /// is to be deleted then we recurse back up, updating internal node
     /// bounding boxes as necessary.
@@ -139,11 +139,11 @@ impl<T> Tree<T>
             node.set_bounding_box(merged_box);
             node.decrement_mass();
         } else { panic!("Inconsistent node: expected non-leaf node"); }
-        
+
         result
     }
 
-    /// Returns the bounding box formed by the merging of point or bounding 
+    /// Returns the bounding box formed by the merging of point or bounding
     /// boxes of two different nodes.
     fn merged_box_from_nodes(&self, left: &Node<T>, right: &Node<T>) -> BoundingBox<T> {
         let left_bbox = self.node_bounding_box(left);
@@ -152,7 +152,7 @@ impl<T> Tree<T>
     }
 
     /// Returns the bounding box at a node.
-    /// 
+    ///
     /// If the node internal then it just returns a copy of that node's bounding
     /// box. If the node is a leaf then it returns the zero-size bounding
     /// box made of that leaf's point.
@@ -172,14 +172,14 @@ impl<T> Tree<T>
     }
 
     /// Deletion algorithm at a leaf node.
-    /// 
-    /// If the point to delete is not equal to the point at this leaf then we 
+    ///
+    /// If the point to delete is not equal to the point at this leaf then we
     /// we return a no-op result. If the point has mass greater than one then
     /// we simply decrease mass.
-    /// 
+    ///
     /// In the general case we have reached a leaf node `P` in the following
     /// diagram:
-    /// 
+    ///
     /// ```text
     ///     A
     ///    / \     P = current leaf node with point P
@@ -187,23 +187,23 @@ impl<T> Tree<T>
     ///  / \       S = P's sibling
     /// P   S
     /// ```
-    /// 
+    ///
     /// What we want to do is delete this node along with its parent and replace
     /// with the current node's sibling:
-    /// 
+    ///
     /// ```text
     ///   A
     ///  / \
     /// S   B
     /// ```
-    /// 
+    ///
     /// This amounts to deleting these poitns and nodes from their respective
     /// stores and "rewiring" the parent-child relationshpis of the remaining
     /// nodes.
-    /// 
+    ///
     fn visit_leaf(&mut self, point: &Vec<T>, leaf_key: usize) -> DeleteResult {
         // Handle several edge cases: (1) the leaf node is not equal to the
-        // input point, (2) 
+        // input point, (2)
         if !self.leaf_matches_point(point, leaf_key) {
             return DeleteResult::PointNotFound;
         } else if let Some(point_key) = self.decremented_leaf_mass(leaf_key) {
@@ -211,10 +211,10 @@ impl<T> Tree<T>
         } else if let Some(point_key) = self.handle_only_node_case(leaf_key) {
             return DeleteResult::DeletedPoint(point_key);
         }
-        
+
         // Set the parent-child relationship between the sibling and grandparent
         //
-        // Two cases: if a grandparent to this leaf exists then perform the 
+        // Two cases: if a grandparent to this leaf exists then perform the
         // rewriring described above. Otherwise, the rewriring reduced to the
         // sibling node becoming the new root node
         let parent_key = self.get_parent(leaf_key).unwrap();
@@ -259,7 +259,7 @@ impl<T> Tree<T>
         } else { panic!("Inconsistent node: expected leaf") }
     }
 
-    /// Checks if the leaf node has a point with mass greater than one. If so, 
+    /// Checks if the leaf node has a point with mass greater than one. If so,
     /// returns `Some(key)` where `key` is the key of the point in the point
     /// store. Otherwise, returns `None`
     fn decremented_leaf_mass(&mut self, leaf_key: usize) -> Option<usize> {
@@ -274,9 +274,9 @@ impl<T> Tree<T>
     }
 
     /// Handle the case when this node is the only node in the tree. Returns
-    /// `Some(key)` if this is indeed the case where `key` is the key of the 
+    /// `Some(key)` if this is indeed the case where `key` is the key of the
     /// point in the point store.
-    /// 
+    ///
     /// Note that we've already handled the case where the node has mass
     /// greater than one.
     fn handle_only_node_case(&mut self, leaf_key: usize) -> Option<usize> {
@@ -297,7 +297,7 @@ impl<T> Tree<T>
     }
 
     /// Returns the node key of the sibling of the input node.
-    /// 
+    ///
     /// If the sibling doesn't exist, which should only happen in the case when
     /// the input node key is the root node, then returns `None`.
     fn sibling_of(&self, node_key: usize) -> Option<usize> {


### PR DESCRIPTION
Implement sampled trees, which are a combination of a point store,
a reservoir sampler, and a random cut tree.

Two files are added to the project:
* `sampler.rs` -- implements reservoir sampler and weighted sample types
* `sampled_tree.rs` -- implements a sampled tree that coordinates updates between a (shared) point store, random cut tree, and reservoir sampler.

Changes to other existing files are just whitespace fixes. (`mod.rs`, `tree.rs`, `tree_point_addition.rs`, and `tree_point_deletion.rs`)

To check the corresponding documentation:

    cargo doc --no-deps --open