### PR TITLE
Add object graph size profiler

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -182,13 +182,16 @@ benchmark methods will be executed.
 % java -jar benchmark/target/randomcutforest-benchmark-1.0-jar-with-dependencies.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
 ```
 
-If you are running the `StateMapperBenchmark`, you can enable the String size profiler to measure the size of
-a state object encoded as a JSON string by the flag `-prof com.amazon.randomcutforest.profilers.StringSizeProfiler`
-to the command-line invocation. For example:
+### Custom Profilers
 
-```text
-% java -jar benchmark/target/randomcutforest-benchmark-1.0-jar-with-dependencies.jar StateMapperBenchmark -prof com.amazon.randomcutforest.profilers.OutputSizeProfiler
-```
+This library defines two custom JMH profilers for use in benchmarks:
+
+| Name | Benchmarks | Description | Command-line Example |
+| ---- | ---------- | ----------- | ------------ |
+| OutputSizeProfiler | StateMapperBenchmark | Measures the length of a String or byte array | `java -jar benchmark/target/randomcutforest-benchmark-1.0-jar-with-dependencies.jar StateMapperBenchmark -prof com.amazon.randomcutforest.profilers.OutputSizeProfiler` |
+| ObjectGraphSizeProfiler | StateMapperBenchmark | Wraps the `MemoryMeter::measureDeep` method in the [JAMM](https://github.com/jbellis/jamm) library to measure the amount of memory allocated in an object graph. When using this profiler, you need to set the `javaagent` flag to point to the location of the JAMM JAR file. | `java -javaagent:$HOME/.m2/repository/com/github/jbellis/jamm/0.3.3/jamm-0.3.3.jar -jar benchmark/target/randomcutforest-benchmark-1.0-jar-with-dependencies.jar StateMapperBenchmark -prof com.amazon.randomcutforest.profilers.ObjectGraphSizeProfiler` 
+
+Note that you can enable OutputSizeProfiler and ObjectGraphSizeProfiler at the same time by adding their respective `-prof` flags to the command-line.
 
 ## Examples
 

--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -43,6 +43,11 @@
       <version>${jmh.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.jbellis</groupId>
+      <artifactId>jamm</artifactId>
+      <version>0.3.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.12.1</version>

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.profilers.ObjectGraphSizeProfiler;
 import com.amazon.randomcutforest.profilers.OutputSizeProfiler;
 import com.amazon.randomcutforest.state.RandomCutForestMapper;
 import com.amazon.randomcutforest.state.RandomCutForestState;
@@ -82,7 +83,8 @@ public class StateMapperBenchmark {
         @Setup(Level.Invocation)
         public void setUpForest() throws JsonProcessingException {
             RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
-                    .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
+                    .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision)
+                    .boundingBoxCachingEnabled(false).build();
 
             for (int i = 0; i < NUM_TRAIN_SAMPLES; i++) {
                 forest.update(trainingData[i]);
@@ -106,11 +108,13 @@ public class StateMapperBenchmark {
         }
     }
 
+    private RandomCutForest forest;
     private byte[] bytes;
 
     @TearDown(Level.Iteration)
     public void tearDown() {
         OutputSizeProfiler.setTestArray(bytes);
+        ObjectGraphSizeProfiler.setObject(forest);
     }
 
     @Benchmark
@@ -123,7 +127,7 @@ public class StateMapperBenchmark {
             RandomCutForestMapper mapper = new RandomCutForestMapper();
             mapper.setSaveExecutorContext(true);
             mapper.setSaveTreeState(state.saveTreeState);
-            RandomCutForest forest = mapper.toModel(forestState);
+            forest = mapper.toModel(forestState);
             double score = forest.getAnomalyScore(testData[i]);
             blackhole.consume(score);
             forest.update(testData[i]);
@@ -146,7 +150,7 @@ public class StateMapperBenchmark {
             RandomCutForestMapper mapper = new RandomCutForestMapper();
             mapper.setSaveExecutorContext(true);
             mapper.setSaveTreeState(state.saveTreeState);
-            RandomCutForest forest = mapper.toModel(forestState);
+            forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);
             blackhole.consume(score);
@@ -172,7 +176,7 @@ public class StateMapperBenchmark {
             RandomCutForestMapper mapper = new RandomCutForestMapper();
             mapper.setSaveExecutorContext(true);
             mapper.setSaveTreeState(state.saveTreeState);
-            RandomCutForest forest = mapper.toModel(forestState);
+            forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);
             blackhole.consume(score);

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/profilers/ObjectGraphSizeProfiler.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/profilers/ObjectGraphSizeProfiler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.profilers;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.github.jamm.MemoryMeter;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
+/**
+ * A profiler that uses the JAMM memory meter to measure the size of an object
+ * graph.
+ */
+public class ObjectGraphSizeProfiler implements InternalProfiler {
+
+    private static Object object;
+    private static MemoryMeter meter = new MemoryMeter();
+
+    public static void setObject(Object object) {
+        ObjectGraphSizeProfiler.object = object;
+    }
+
+    @Override
+    public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+    }
+
+    @Override
+    public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams,
+            IterationResult iterationResult) {
+        long size = 0;
+        if (object != null) {
+            size = meter.measureDeep(object);
+            object = null;
+        }
+        ScalarResult result = new ScalarResult("+object-graph-size.bytes", size, "bytes", AggregationPolicy.AVG);
+        return Collections.singleton(result);
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+}


### PR DESCRIPTION
Add a new JMH profiler to measure the size of an object graph, and update the `StateMapperBenchmark` to us the profile to measure the runtime size of a forest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
