### PR TITLE
Update the `isOutputReady()` method to check component models

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
@@ -66,4 +66,17 @@ public interface ITraversable {
      *         paths.
      */
     <R> R traverseMulti(double[] point, Function<ITree<?, ?>, MultiVisitor<R>> visitorFactory);
+
+    /**
+     * After a new traversable model is initialized, it will not be able to return
+     * meaningful results to queries until it has been updated with (i.e., learned
+     * from) some number of points. The exact number of points may vary for
+     * different models. After this method returns true for the first time, it
+     * should continue to return true unless the user takes an explicit action to
+     * reset the model state.
+     *
+     * @return true if this model is ready to provide a meaningful response to a
+     *         traversal query, otherwise false.
+     */
+    boolean isOutputReady();
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
@@ -39,11 +39,10 @@ import com.amazon.randomcutforest.tree.ITree;
  *            in this list.
  * @param <Q> The explicit data type of points being passed
  */
+@Getter
 public class SamplerPlusTree<P, Q> implements IComponentModel<P, Q> {
 
-    @Getter
     private ITree<P, Q> tree;
-    @Getter
     private IStreamSampler<P> sampler;
 
     /**
@@ -130,5 +129,10 @@ public class SamplerPlusTree<P, Q> implements IComponentModel<P, Q> {
         } else {
             throw new IllegalArgumentException("Unsupported configuration setting: " + name);
         }
+    }
+
+    @Override
+    public boolean isOutputReady() {
+        return tree.isOutputReady();
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
@@ -80,11 +80,18 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
         this.enableSequenceIndices = enableSequenceIndices;
     }
 
-    public AbstractRandomCutTree(AbstractRandomCutTree.Builder builder) {
-        this.random = new Random(builder.randomSeed);
+    public AbstractRandomCutTree(AbstractRandomCutTree.Builder<?> builder) {
+        if (builder.random != null) {
+            this.random = builder.random;
+        } else {
+            this.random = new Random(builder.randomSeed);
+        }
         this.enableCenterOfMass = builder.centerOfMassEnabled;
         this.enableSequenceIndices = builder.storeSequenceIndexesEnabled;
         this.boundingBoxCacheFraction = builder.boundingBoxCacheFraction;
+
+        // This should be set to an appropriate value in a subclass
+        outputAfter = Integer.MAX_VALUE;
     }
 
     @Override
@@ -698,12 +705,18 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
         return outputAfter;
     }
 
+    @Override
+    public boolean isOutputReady() {
+        return getMass() >= outputAfter;
+    }
+
     // TODO: decide on ownership of builder constants, across the major classes
     public static class Builder<T> {
         protected boolean storeSequenceIndexesEnabled = RandomCutForest.DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
         protected boolean centerOfMassEnabled = RandomCutForest.DEFAULT_CENTER_OF_MASS_ENABLED;
         protected double boundingBoxCacheFraction = RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION;
         protected long randomSeed = new Random().nextLong();
+        protected Random random = null;
         protected Optional<Integer> outputAfter = Optional.empty();
 
         public T storeSequenceIndexesEnabled(boolean storeSequenceIndexesEnabled) {
@@ -723,6 +736,11 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
 
         public T randomSeed(long randomSeed) {
             this.randomSeed = randomSeed;
+            return (T) this;
+        }
+
+        public T random(Random random) {
+            this.random = random;
             return (T) this;
         }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -40,32 +40,13 @@ import com.amazon.randomcutforest.Visitor;
  */
 public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[]> {
 
-    /**
-     * By default, trees will not store sequence indexes.
-     */
-    public static final boolean DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED = false;
-
-    /**
-     * By default, nodes will not store center of mass.
-     */
-    public static final boolean DEFAULT_CENTER_OF_MASS_ENABLED = false;
-
-    /**
-     * a random number generator to decide on storing the cached boxes for the new
-     * nodes.
-     */
-
-    protected RandomCutTree(Builder<?> builder) {
-        super(builder.random, builder.boundingBoxCacheFraction, builder.centerOfMassEnabled,
-                builder.storeSequenceIndexesEnabled);
-        super.root = null;
-    }
+    public static final int DEFAULT_OUTPUT_AFTER = 64;
 
     /**
      * @return a new RandomCutTree builder.
      */
-    public static Builder builder() {
-        return new Builder();
+    public static Builder<?> builder() {
+        return new Builder<>();
     }
 
     /**
@@ -76,7 +57,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
      * @return a new RandomCutTree with optional arguments set to default values.
      */
     public static RandomCutTree defaultTree(long randomSeed) {
-        return builder().random(new Random(randomSeed)).build();
+        return builder().randomSeed(randomSeed).build();
     }
 
     /**
@@ -117,6 +98,12 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
         super(random, enableCache, enableCenterOfMass, enableSequenceIndices);
         root = null;
         setBoundingBoxCacheFraction(RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION);
+    }
+
+    protected RandomCutTree(Builder<?> builder) {
+        super(builder);
+        super.root = null;
+        outputAfter = builder.outputAfter.orElse(DEFAULT_OUTPUT_AFTER);
     }
 
     @Override
@@ -343,41 +330,9 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
         node.deleteSequenceIndex(uniqueSequenceNumber);
     }
 
-    public static class Builder<T extends RandomCutTree.Builder<T>> {
-        private boolean storeSequenceIndexesEnabled = DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
-        private boolean centerOfMassEnabled = DEFAULT_CENTER_OF_MASS_ENABLED;
-        private double boundingBoxCacheFraction = RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION;
-        private Random random;
-
-        public T storeSequenceIndexesEnabled(boolean storeSequenceIndexesEnabled) {
-            this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
-            return (T) this;
-        }
-
-        public T centerOfMassEnabled(boolean centerOfMassEnabled) {
-            this.centerOfMassEnabled = centerOfMassEnabled;
-            return (T) this;
-        }
-
-        public T boundingBoxCacheFraction(double boundingBoxCacheFraction) {
-            this.boundingBoxCacheFraction = boundingBoxCacheFraction;
-            return (T) this;
-        }
-
-        public T randomSeed(long randomSeed) {
-            this.random = new Random(randomSeed);
-            return (T) this;
-        }
-
-        public T random(Random random) {
-            this.random = random;
-            return (T) this;
-        }
-
+    public static class Builder<T extends Builder<T>> extends AbstractRandomCutTree.Builder<T> {
         public RandomCutTree build() {
-            return new RandomCutTree(random, boundingBoxCacheFraction, centerOfMassEnabled,
-                    storeSequenceIndexesEnabled);
+            return new RandomCutTree(this);
         }
     }
-
 }


### PR DESCRIPTION
Add a new isOutputReady method to the ITraversable interface. The forest
will now check all component models for readiness, instead of waiting
for a fixed number of updates.

Closes #181

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
