### PR TITLE
Standardize property names in model classes

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/RandomCutForestBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/RandomCutForestBenchmark.java
@@ -64,7 +64,7 @@ public class RandomCutForestBenchmark {
         @Setup(Level.Invocation)
         public void setUpForest() {
             forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).dimensions(dimensions)
-                    .parallelExecutionEnabled(parallelExecutionEnabled).compactEnabled(true).randomSeed(99).build();
+                    .parallelExecutionEnabled(parallelExecutionEnabled).compact(true).randomSeed(99).build();
         }
     }
 

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
@@ -64,7 +64,7 @@ public class StateMapperBenchmark {
         @Param({ "false", "true" })
         boolean saveTreeState;
 
-        @Param({ "SINGLE", "DOUBLE" })
+        @Param({ "FLOAT_32", "FLOAT_64" })
         Precision precision;
 
         double[][] trainingData;
@@ -82,7 +82,7 @@ public class StateMapperBenchmark {
 
         @Setup(Level.Invocation)
         public void setUpForest() throws JsonProcessingException {
-            RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+            RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                     .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision)
                     .boundingBoxCacheFraction(0.0).build();
 

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperShingledBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperShingledBenchmark.java
@@ -67,7 +67,7 @@ public class StateMapperShingledBenchmark {
         @Param({ "false", "true" })
         boolean saveTreeState;
 
-        @Param({ "SINGLE", "DOUBLE" })
+        @Param({ "FLOAT_32", "FLOAT_64" })
         Precision precision;
 
         double[][] trainingData;
@@ -84,7 +84,7 @@ public class StateMapperShingledBenchmark {
 
         @Setup(Level.Invocation)
         public void setUpForest() throws JsonProcessingException {
-            RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+            RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                     .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).shingleSize(dimensions)
                     .build();
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -110,7 +110,7 @@ public class RandomCutForest {
     /**
      * By default, trees will not create indexed references.
      */
-    public static final boolean DEFAULT_COMPACT_ENABLED = false;
+    public static final boolean DEFAULT_COMPACT = false;
 
     /**
      * By default, trees will accept every point until full.
@@ -141,7 +141,7 @@ public class RandomCutForest {
     /**
      * Default floating-point precision for internal data structures.
      */
-    public static final Precision DEFAULT_PRECISION = Precision.DOUBLE;
+    public static final Precision DEFAULT_PRECISION = Precision.FLOAT_64;
 
     /**
      * By default, bounding boxes will be used. Disabling this will force
@@ -209,7 +209,7 @@ public class RandomCutForest {
     /**
      * Enable compact representation
      */
-    protected final boolean compactEnabled;
+    protected final boolean compact;
     /**
      * enables internal shingling
      */
@@ -274,9 +274,9 @@ public class RandomCutForest {
     public RandomCutForest(Builder<?> builder) {
         this(builder, false);
         rng = builder.getRandom();
-        if (precision == Precision.SINGLE) {
+        if (precision == Precision.FLOAT_32) {
             initCompactFloat(builder);
-        } else if (compactEnabled) {
+        } else if (compact) {
             initCompactDouble(builder);
         } else {
             initNonCompact();
@@ -386,7 +386,7 @@ public class RandomCutForest {
         });
         builder.threadPoolSize.ifPresent(n -> checkArgument((n > 0) || ((n == 0) && !builder.parallelExecutionEnabled),
                 "threadPoolSize must be greater/equal than 0. To disable thread pool, set parallel execution to 'false'."));
-        checkArgument(builder.precision == Precision.DOUBLE || builder.compactEnabled,
+        checkArgument(builder.precision == Precision.FLOAT_64 || builder.compact,
                 "single precision is only supported for compact trees");
         checkArgument(builder.internalShinglingEnabled || builder.shingleSize == 1
                 || builder.dimensions % builder.shingleSize == 0, "wrong shingle size");
@@ -395,12 +395,12 @@ public class RandomCutForest {
         if (builder.internalRotationEnabled) {
             checkArgument(builder.internalShinglingEnabled, " enable internal shingling");
         }
-        checkArgument(!builder.compactEnabled || builder.compactEnabled, " option not supported, enable compact trees");
+        checkArgument(!builder.compact || builder.compact, " option not supported, enable compact trees");
         builder.initialPointStoreSize.ifPresent(n -> {
             checkArgument(n > 0, "initial point store must be greater than 0");
             checkArgument(n > builder.sampleSize * builder.numberOfTrees || builder.dynamicResizingEnabled,
                     " enable dynamic resizing ");
-            checkArgument(builder.compactEnabled, " enable compact trees ");
+            checkArgument(builder.compact, " enable compact trees ");
         });
         checkArgument(builder.boundingBoxCacheFraction >= 0 && builder.boundingBoxCacheFraction <= 1,
                 "incorrect cache fraction range");
@@ -414,12 +414,12 @@ public class RandomCutForest {
         storeSequenceIndexesEnabled = builder.storeSequenceIndexesEnabled;
         centerOfMassEnabled = builder.centerOfMassEnabled;
         parallelExecutionEnabled = builder.parallelExecutionEnabled;
-        compactEnabled = builder.compactEnabled;
+        compact = builder.compact;
         precision = builder.precision;
         boundingBoxCacheFraction = builder.boundingBoxCacheFraction;
         builder.directLocationMapEnabled = builder.directLocationMapEnabled || shingleSize == 1;
         inputDimensions = (internalShinglingEnabled) ? dimensions / shingleSize : dimensions;
-        if (!builder.initialPointStoreSize.isPresent() && compactEnabled) {
+        if (!builder.initialPointStoreSize.isPresent() && compact) {
             builder.initialPointStoreSize = Optional.of(2 * sampleSize);
         }
 
@@ -525,8 +525,8 @@ public class RandomCutForest {
     /**
      * @return true if points are saved with sequence indexes, false otherwise.
      */
-    public boolean isCompactEnabled() {
-        return compactEnabled;
+    public boolean isCompact() {
+        return compact;
     }
 
     /**
@@ -1278,7 +1278,7 @@ public class RandomCutForest {
         private int numberOfTrees = DEFAULT_NUMBER_OF_TREES;
         private Optional<Double> lambda = Optional.empty();
         private Optional<Long> randomSeed = Optional.empty();
-        private boolean compactEnabled = DEFAULT_COMPACT_ENABLED;
+        private boolean compact = DEFAULT_COMPACT;
         private boolean storeSequenceIndexesEnabled = DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
         private boolean centerOfMassEnabled = DEFAULT_CENTER_OF_MASS_ENABLED;
         private boolean parallelExecutionEnabled = DEFAULT_PARALLEL_EXECUTION_ENABLED;
@@ -1358,8 +1358,8 @@ public class RandomCutForest {
             return (T) this;
         }
 
-        public T compactEnabled(boolean compactEnabled) {
-            this.compactEnabled = compactEnabled;
+        public T compact(boolean compact) {
+            this.compact = compact;
             return (T) this;
         }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
@@ -19,5 +19,12 @@ package com.amazon.randomcutforest.config;
  * Options for floating-point precision.
  */
 public enum Precision {
-    SINGLE, DOUBLE
+    /**
+     * Single-precision (32 bit) floating point numbers.
+     */
+    FLOAT_32,
+    /**
+     * Double-precision (64 bit) floating point numbers.
+     */
+    FLOAT_64
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -187,8 +187,8 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         } else {
             this.sequenceIndex = null;
         }
-        this.random = random;
-        this.lambda = lambda;
+        this.rng = random;
+        this.timeDecay = lambda;
         this.initialAcceptFraction = initialAcceptFraction;
     }
 
@@ -218,10 +218,10 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
 
     @Override
     public boolean acceptPoint(long sequenceIndex) {
-        checkState(sequenceIndex >= sequenceIndexOfMostRecentLambdaUpdate, "incorrect sequences submitted to sampler");
+        checkState(sequenceIndex >= mostRecentTimeDecayUpdate, "incorrect sequences submitted to sampler");
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
-        if ((size < capacity && random.nextDouble() < initialAcceptFraction + 1 - 1.0 * size / capacity)
+        if ((size < capacity && rng.nextDouble() < initialAcceptFraction + 1 - 1.0 * size / capacity)
                 || (weight < this.weight[0])) {
             acceptPointState = new AcceptPointState(sequenceIndex, weight);
             if (size == capacity) {
@@ -348,14 +348,14 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
      * updates to lambda
      */
     private void reset_weights() {
-        if (accumulatedLambda == 0)
+        if (accumuluatedTimeDecay == 0)
             return;
         // now the weight computation of every element would not see this subtraction
         // which implies that every existing element should see the offset as addition
         for (int i = 0; i < size; i++) {
-            weight[i] += accumulatedLambda;
+            weight[i] += accumuluatedTimeDecay;
         }
-        accumulatedLambda = 0;
+        accumuluatedTimeDecay = 0;
     }
 
     /**
@@ -514,10 +514,10 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         this.capacity = builder.capacity;
         this.storeSequenceIndexesEnabled = builder.storeSequenceIndexesEnabled;
         this.initialAcceptFraction = builder.initialAcceptFraction;
-        this.random = builder.random;
-        this.lambda = builder.lambda;
+        this.rng = builder.random;
+        this.timeDecay = builder.lambda;
         this.maxSequenceIndex = builder.maxSequenceIndex;
-        this.sequenceIndexOfMostRecentLambdaUpdate = builder.sequenceIndexOfMostRecentLambdaUpdate;
+        this.mostRecentTimeDecayUpdate = builder.sequenceIndexOfMostRecentLambdaUpdate;
 
         if (builder.weight != null || builder.pointIndex != null || builder.weight != null
                 || builder.sequenceIndex != null || builder.validateHeap) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -95,8 +95,8 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         super();
         this.sampleSize = sampleSize;
         sample = new PriorityQueue<>(Comparator.comparingDouble(Weighted<P>::getWeight).reversed());
-        this.random = random;
-        this.lambda = lambda;
+        this.rng = random;
+        this.timeDecay = lambda;
         this.initialAcceptFraction = initialAcceptFraction;
     }
 
@@ -123,12 +123,12 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
      * @return A weighted point that can be added to the sampler or null
      */
     public boolean acceptPoint(long sequenceIndex) {
-        checkState(sequenceIndex >= sequenceIndexOfMostRecentLambdaUpdate, "incorrect sequences submitted to sampler");
+        checkState(sequenceIndex >= mostRecentTimeDecayUpdate, "incorrect sequences submitted to sampler");
 
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
 
-        if ((sample.size() < sampleSize && random.nextDouble() < initialAcceptFraction + 1 - 1.0 * size() / sampleSize)
+        if ((sample.size() < sampleSize && rng.nextDouble() < initialAcceptFraction + 1 - 1.0 * size() / sampleSize)
                 || weight < sample.element().getWeight()) {
             if (isFull()) {
                 evictedPoint = sample.poll();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
@@ -83,7 +83,7 @@ public class ArraySamplersToCompactStateConverter {
         samplerState.setPointIndex(pointIndex);
         samplerState.setWeight(weight);
         samplerState.setSequenceIndex(sequenceIndex);
-        samplerState.setSequenceIndexOfMostRecentLambdaUpdate(sampler.getSequenceIndexOfMostRecentLambdaUpdate());
+        samplerState.setSequenceIndexOfMostRecentLambdaUpdate(sampler.getMostRecentTimeDecayUpdate());
         samplerState.setMaxSequenceIndex(sampler.getMaxSequenceIndex());
         samplerState.setInitialAcceptFraction(sampler.getInitialAcceptFraction());
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
@@ -76,7 +76,7 @@ public class CompactSamplerMapper implements IStateMapper<CompactSampler, Compac
         state.setCompressed(compress);
         state.setCapacity(model.getCapacity());
         state.setLambda(model.getTimeDecay());
-        state.setSequenceIndexOfMostRecentLambdaUpdate(model.getSequenceIndexOfMostRecentLambdaUpdate());
+        state.setSequenceIndexOfMostRecentLambdaUpdate(model.getMostRecentTimeDecayUpdate());
         state.setMaxSequenceIndex(model.getMaxSequenceIndex());
         state.setInitialAcceptFraction(model.getInitialAcceptFraction());
         state.setStoreSequenceIndicesEnabled(model.isStoreSequenceIndexesEnabled());

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
@@ -58,9 +58,9 @@ public class CompactRandomCutTreeDoubleMapper implements
         model.reorderNodesInBreadthFirstOrder();
         state.setMaxSize(model.getMaxSize());
         state.setRoot(model.getRootIndex());
-        state.setPartialTreeInUse(model.enableSequenceIndices || partialTreeInUse);
-        state.setStoreSequenceIndices(model.enableSequenceIndices);
-        state.setEnableCenterOfMass(model.enableCenterOfMass);
+        state.setPartialTreeInUse(model.storeSequenceIndexesEnabled || partialTreeInUse);
+        state.setStoreSequenceIndices(model.storeSequenceIndexesEnabled);
+        state.setEnableCenterOfMass(model.centerOfMassEnabled);
         state.setOutputAfter(model.getOutputAfter());
 
         NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
@@ -58,9 +58,9 @@ public class CompactRandomCutTreeFloatMapper implements
         model.reorderNodesInBreadthFirstOrder();
         state.setRoot(model.getRoot());
         state.setMaxSize(model.getMaxSize());
-        state.setPartialTreeInUse(model.enableSequenceIndices || partialTreeInUse);
-        state.setStoreSequenceIndices(model.enableSequenceIndices);
-        state.setEnableCenterOfMass(model.enableCenterOfMass);
+        state.setPartialTreeInUse(model.storeSequenceIndexesEnabled || partialTreeInUse);
+        state.setStoreSequenceIndices(model.storeSequenceIndexesEnabled);
+        state.setEnableCenterOfMass(model.centerOfMassEnabled);
         state.setBoundingBoxCacheFraction(model.getBoundingBoxCacheFraction());
         state.setOutputAfter(model.getOutputAfter());
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -85,7 +85,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
             this.root = builder.root;
         }
 
-        if (enableSequenceIndices) {
+        if (storeSequenceIndexesEnabled) {
             sequenceIndexes = new HashMap[maxSize];
         }
     }
@@ -200,7 +200,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
 
                 boxCache.swapCaches(map);
 
-                if (enableSequenceIndices) {
+                if (storeSequenceIndexesEnabled) {
                     HashMap<Long, Integer>[] newSequence = new HashMap[maxSize];
                     for (int i = 0; i < maxSize; i++) { // iterate over leaves
                         if (map[i + maxSize - 1] != NULL) { // leaf is in use
@@ -211,7 +211,7 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
                     sequenceIndexes = newSequence;
                 }
                 root = 0;
-                if (enableCenterOfMass) {
+                if (centerOfMassEnabled) {
                     recomputePointSum(root);
                 }
             } else {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -72,7 +72,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
      *         otherwise.
      */
     public boolean centerOfMassEnabled() {
-        return super.enableCenterOfMass;
+        return super.centerOfMassEnabled;
     }
 
     /**
@@ -80,7 +80,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
      *         otherwise.
      */
     public boolean storeSequenceIndexesEnabled() {
-        return super.enableSequenceIndices;
+        return super.storeSequenceIndexesEnabled;
     }
 
     public RandomCutTree(Random random, double cacheFraction, boolean enableCenterOfMass,
@@ -283,7 +283,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
 
     @Override
     protected Node addNode(Node leftChild, Node rightChild, int cutDimension, double cutValue, int mass) {
-        Node candidate = new Node(leftChild, rightChild, new Cut(cutDimension, cutValue), null, enableCenterOfMass);
+        Node candidate = new Node(leftChild, rightChild, new Cut(cutDimension, cutValue), null, centerOfMassEnabled);
         candidate.setMass(mass);
         return candidate;
     }
@@ -322,7 +322,7 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
 
     @Override
     protected void deleteSequenceIndex(Node node, long uniqueSequenceNumber) {
-        if (enableSequenceIndices) {
+        if (storeSequenceIndexesEnabled) {
             if (!node.getSequenceIndexes().contains(uniqueSequenceNumber)) {
                 throw new IllegalStateException("Error in sequence index. Inconsistency in trees in delete step.");
             }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
@@ -59,8 +59,7 @@ public class AttributionExamplesFunctionalTest {
         randomSeed = 101;
         sampleSize = 256;
         RandomCutForest newForest = RandomCutForest.builder().numberOfTrees(100).sampleSize(sampleSize)
-                .dimensions(newDimensions).randomSeed(randomSeed).compactEnabled(false).boundingBoxCacheFraction(0.0)
-                .build();
+                .dimensions(newDimensions).randomSeed(randomSeed).compact(false).boundingBoxCacheFraction(0.0).build();
 
         dataSize = 2000 + 5;
 
@@ -162,7 +161,7 @@ public class AttributionExamplesFunctionalTest {
         randomSeed = 179;
         sampleSize = 256;
         DynamicScoringRandomCutForest newForest = DynamicScoringRandomCutForest.builder().numberOfTrees(100)
-                .sampleSize(sampleSize).dimensions(newDimensions).randomSeed(randomSeed).compactEnabled(false)
+                .sampleSize(sampleSize).dimensions(newDimensions).randomSeed(randomSeed).compact(false)
                 .boundingBoxCacheFraction(1.0).lambda(1e-5).build();
 
         dataSize = 2000 + 5;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
@@ -71,21 +71,20 @@ public class CompactRandomCutForestFunctionalTest {
         randomSeed = 123;
 
         parallelExecutionForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
-                .build();
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).storeSequenceIndexesEnabled(false).build();
 
         singleThreadedForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).storeSequenceIndexesEnabled(false)
                 .boundingBoxCacheFraction(new Random().nextDouble()).parallelExecutionEnabled(false).build();
 
         parallelExecutionForestFloat = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
-                .precision(Precision.SINGLE).build();
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).storeSequenceIndexesEnabled(false)
+                .precision(Precision.FLOAT_32).build();
 
         singleThreadedForestFloat = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).storeSequenceIndexesEnabled(false)
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).storeSequenceIndexesEnabled(false)
                 .boundingBoxCacheFraction(new Random().nextDouble()).parallelExecutionEnabled(false)
-                .precision(Precision.SINGLE).build();
+                .precision(Precision.FLOAT_32).build();
 
         dataSize = 10_000;
 
@@ -239,7 +238,7 @@ public class CompactRandomCutForestFunctionalTest {
     public void treeSizeChangeTest(int numDims, int numTrees, int numSamples, int numTrainSamples, int numTestSamples,
             int enableParallel, int numThreads) {
         RandomCutForest.Builder<?> forestBuilder = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compactEnabled(true);
+                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compact(true);
         if (enableParallel == 0) {
             forestBuilder.parallelExecutionEnabled(false);
         }
@@ -248,8 +247,8 @@ public class CompactRandomCutForestFunctionalTest {
         }
         RandomCutForest forest = forestBuilder.build();
         RandomCutForest anotherForest = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(50000).outputAfter(numSamples / 4).randomSeed(0).compactEnabled(true)
-                .boundingBoxCacheFraction(1.0).build();
+                .sampleSize(50000).outputAfter(numSamples / 4).randomSeed(0).compact(true).boundingBoxCacheFraction(1.0)
+                .build();
 
         int count = 0;
         assertEquals(numTrainSamples, numSamples);
@@ -474,7 +473,7 @@ public class CompactRandomCutForestFunctionalTest {
     @Test
     public void testUpdateWithSignedZeros() {
         RandomCutForest forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(2).dimensions(1)
-                .randomSeed(randomSeed).compactEnabled(true).build();
+                .randomSeed(randomSeed).compact(true).build();
 
         forest.update(new double[] { 0.0 });
         forest.getAnomalyScore(new double[] { 0.0 });
@@ -504,7 +503,7 @@ public class CompactRandomCutForestFunctionalTest {
         randomSeed = 123;
 
         RandomCutForest newForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compactEnabled(true).lambda(1e-5).build();
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).lambda(1e-5).build();
 
         dataSize = 10_000;
 
@@ -634,8 +633,8 @@ public class CompactRandomCutForestFunctionalTest {
     public void testUpdateAfterRoundTrip() {
         int dimensions = 10;
         for (int trials = 0; trials < 1000; trials++) {
-            RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
-                    .sampleSize(64).precision(Precision.SINGLE).build();
+            RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).sampleSize(64)
+                    .precision(Precision.FLOAT_32).build();
 
             Random r = new Random();
             for (int i = 0; i < 30; i++) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestConsistencyFunctionalTest.java
@@ -42,17 +42,17 @@ public class RandomCutForestConsistencyFunctionalTest {
         RandomCutForest.Builder<?> builder = RandomCutForest.builder().dimensions(dimensions).sampleSize(sampleSize)
                 .randomSeed(randomSeed);
 
-        RandomCutForest pointerCachedSequential = builder.compactEnabled(false).boundingBoxCacheFraction(1.0)
+        RandomCutForest pointerCachedSequential = builder.compact(false).boundingBoxCacheFraction(1.0)
                 .parallelExecutionEnabled(false).build();
-        RandomCutForest pointerCachedParallel = builder.compactEnabled(false).boundingBoxCacheFraction(1.0)
+        RandomCutForest pointerCachedParallel = builder.compact(false).boundingBoxCacheFraction(1.0)
                 .parallelExecutionEnabled(true).build();
-        RandomCutForest pointerUncachedSequential = builder.compactEnabled(false).boundingBoxCacheFraction(0.0)
+        RandomCutForest pointerUncachedSequential = builder.compact(false).boundingBoxCacheFraction(0.0)
                 .parallelExecutionEnabled(false).build();
-        RandomCutForest compactCachedSequential = builder.compactEnabled(true).boundingBoxCacheFraction(1.0)
+        RandomCutForest compactCachedSequential = builder.compact(true).boundingBoxCacheFraction(1.0)
                 .parallelExecutionEnabled(false).build();
-        RandomCutForest compactCachedParallel = builder.compactEnabled(true).boundingBoxCacheFraction(1.0)
+        RandomCutForest compactCachedParallel = builder.compact(true).boundingBoxCacheFraction(1.0)
                 .parallelExecutionEnabled(true).build();
-        RandomCutForest compactUncachedSequential = builder.compactEnabled(true).boundingBoxCacheFraction(0.0)
+        RandomCutForest compactUncachedSequential = builder.compact(true).boundingBoxCacheFraction(0.0)
                 .parallelExecutionEnabled(false).build();
 
         NormalMixtureTestData testData = new NormalMixtureTestData();
@@ -87,12 +87,14 @@ public class RandomCutForestConsistencyFunctionalTest {
     @Test
     public void testConsistentScoringSinglePrecision() {
         RandomCutForest.Builder<?> builder = RandomCutForest.builder().dimensions(dimensions).sampleSize(sampleSize)
-                .randomSeed(randomSeed).parallelExecutionEnabled(false).compactEnabled(true);
+                .randomSeed(randomSeed).parallelExecutionEnabled(false).compact(true);
 
-        RandomCutForest compactFloatCached = builder.boundingBoxCacheFraction(1.0).precision(Precision.SINGLE).build();
-        RandomCutForest compactFloatUncached = builder.boundingBoxCacheFraction(0.0).precision(Precision.SINGLE)
+        RandomCutForest compactFloatCached = builder.boundingBoxCacheFraction(1.0).precision(Precision.FLOAT_32)
                 .build();
-        RandomCutForest compactDoubleCached = builder.boundingBoxCacheFraction(1.0).precision(Precision.DOUBLE).build();
+        RandomCutForest compactFloatUncached = builder.boundingBoxCacheFraction(0.0).precision(Precision.FLOAT_32)
+                .build();
+        RandomCutForest compactDoubleCached = builder.boundingBoxCacheFraction(1.0).precision(Precision.FLOAT_64)
+                .build();
 
         NormalMixtureTestData testData = new NormalMixtureTestData();
         int anomalies = 0;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
@@ -840,7 +840,7 @@ public class RandomCutForestFunctionalTest {
     public void dynamicCachingChangeTest(int numDims, int numTrees, int numSamples, int numTrainSamples,
             int numTestSamples, int enableParallel, int numThreads) {
         RandomCutForest.Builder<?> forestBuilder = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compactEnabled(false);
+                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compact(false);
         if (enableParallel == 0) {
             forestBuilder.parallelExecutionEnabled(false);
         }
@@ -849,7 +849,7 @@ public class RandomCutForestFunctionalTest {
         }
         RandomCutForest forest = forestBuilder.build();
         RandomCutForest anotherForest = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).compactEnabled(true).boundingBoxCacheFraction(1.0).build();
+                .sampleSize(numSamples).randomSeed(0).compact(true).boundingBoxCacheFraction(1.0).build();
 
         int count = 0;
         for (double[] point : generate(numTrainSamples, numDims, 0)) {
@@ -879,7 +879,7 @@ public class RandomCutForestFunctionalTest {
     public void dynamicCachingChangeTestLarge(int numDims, int numTrees, int numSamples, int numTrainSamples,
             int numTestSamples, int enableParallel, int numThreads) {
         RandomCutForest.Builder<?> forestBuilder = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compactEnabled(false);
+                .sampleSize(numSamples).randomSeed(0).boundingBoxCacheFraction(1.0).compact(false);
         if (enableParallel == 0) {
             forestBuilder.parallelExecutionEnabled(false);
         }
@@ -888,7 +888,7 @@ public class RandomCutForestFunctionalTest {
         }
         RandomCutForest forest = forestBuilder.build();
         RandomCutForest anotherForest = RandomCutForest.builder().dimensions(numDims).numberOfTrees(numTrees)
-                .sampleSize(numSamples).randomSeed(0).compactEnabled(true).boundingBoxCacheFraction(1.0).build();
+                .sampleSize(numSamples).randomSeed(0).compact(true).boundingBoxCacheFraction(1.0).build();
 
         int count = 0;
         for (double[] point : generate(numTrainSamples, numDims, 0)) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
@@ -42,14 +42,14 @@ public class ShinglingFunctionalTest {
         long randomSeed = 123;
 
         RandomCutForest newforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize)
-                .precision(Precision.SINGLE).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize)
+                .precision(Precision.FLOAT_32).build();
         RandomCutForest anotherforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(1)
-                .precision(Precision.SINGLE).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(1)
+                .precision(Precision.FLOAT_32).build();
         RandomCutForest yetAnotherforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize)
-                .internalShinglingEnabled(true).precision(Precision.SINGLE).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize)
+                .internalShinglingEnabled(true).precision(Precision.FLOAT_32).build();
 
         double amplitude = 50.0;
         double noise = 2.0;
@@ -106,11 +106,11 @@ public class ShinglingFunctionalTest {
         long randomSeed = 123;
 
         RandomCutForest newforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize).build();
         RandomCutForest anotherforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(1).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(1).build();
         RandomCutForest yetAnotherforest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize)
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize)
                 .internalShinglingEnabled(true).build();
 
         double amplitude = 50.0;
@@ -166,16 +166,15 @@ public class ShinglingFunctionalTest {
         long randomSeed = 123;
 
         RandomCutForest newforestA = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).precision(Precision.SINGLE)
-                .build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).precision(Precision.FLOAT_32).build();
 
         RandomCutForest newforestB = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .dimensions(shinglesize).randomSeed(randomSeed).internalShinglingEnabled(true)
-                .internalRotationEnabled(true).compactEnabled(true).shingleSize(shinglesize).precision(Precision.SINGLE)
+                .internalRotationEnabled(true).compact(true).shingleSize(shinglesize).precision(Precision.FLOAT_32)
                 .build();
         RandomCutForest newforestC = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize)
-                .precision(Precision.SINGLE).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize)
+                .precision(Precision.FLOAT_32).build();
         double amplitude = 50.0;
         double noise = 2.0;
         Random noiseprg = new Random(72);
@@ -231,13 +230,13 @@ public class ShinglingFunctionalTest {
         long randomSeed = 123;
 
         RandomCutForest newforestA = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).build();
 
         RandomCutForest newforestB = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .dimensions(shinglesize).randomSeed(randomSeed).internalShinglingEnabled(true)
-                .internalRotationEnabled(true).compactEnabled(true).shingleSize(shinglesize).build();
+                .internalRotationEnabled(true).compact(true).shingleSize(shinglesize).build();
         RandomCutForest newforestC = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).shingleSize(shinglesize).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).shingleSize(shinglesize).build();
         double amplitude = 50.0;
         double noise = 2.0;
         Random noiseprg = new Random(72);
@@ -296,10 +295,10 @@ public class ShinglingFunctionalTest {
         // subsequent inputs and test adaptation to stream evolution
 
         RandomCutForest newforestC = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).lambda(1.0 / 300).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).lambda(1.0 / 300).build();
 
         RandomCutForest newforestD = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compactEnabled(true).lambda(1.0 / 300).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).lambda(1.0 / 300).build();
 
         double amplitude = 50.0;
         double noise = 2.0;
@@ -444,8 +443,8 @@ public class ShinglingFunctionalTest {
     public void testUpdate() {
         int dimensions = 10;
 
-        RandomCutForest forest = RandomCutForest.builder().numberOfTrees(100).compactEnabled(true)
-                .dimensions(dimensions).randomSeed(0).sampleSize(200).precision(Precision.SINGLE).build();
+        RandomCutForest forest = RandomCutForest.builder().numberOfTrees(100).compact(true).dimensions(dimensions)
+                .randomSeed(0).sampleSize(200).precision(Precision.FLOAT_32).build();
 
         double[][] trainingData = genShingledData(1000, dimensions, 0);
         double[][] testData = genShingledData(100, dimensions, 1);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
@@ -39,15 +39,15 @@ public class RandomCutForestMapperTest {
     private static int sampleSize = 128;
 
     private static Stream<RandomCutForest> compactForestProvider() {
-        RandomCutForest.Builder<?> builder = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+        RandomCutForest.Builder<?> builder = RandomCutForest.builder().compact(true).dimensions(dimensions)
                 .sampleSize(sampleSize);
 
         RandomCutForest cachedDouble = builder.boundingBoxCacheFraction(new Random().nextDouble())
-                .precision(Precision.DOUBLE).build();
+                .precision(Precision.FLOAT_64).build();
         RandomCutForest cachedFloat = builder.boundingBoxCacheFraction(new Random().nextDouble())
-                .precision(Precision.SINGLE).build();
-        RandomCutForest uncachedDouble = builder.boundingBoxCacheFraction(0.0).precision(Precision.DOUBLE).build();
-        RandomCutForest uncachedFloat = builder.boundingBoxCacheFraction(0.0).precision(Precision.SINGLE).build();
+                .precision(Precision.FLOAT_32).build();
+        RandomCutForest uncachedDouble = builder.boundingBoxCacheFraction(0.0).precision(Precision.FLOAT_64).build();
+        RandomCutForest uncachedFloat = builder.boundingBoxCacheFraction(0.0).precision(Precision.FLOAT_32).build();
 
         return Stream.of(cachedDouble, cachedFloat, uncachedDouble, uncachedFloat);
     }
@@ -67,7 +67,7 @@ public class RandomCutForestMapperTest {
         assertEquals(forest.getNumberOfTrees(), forest2.getNumberOfTrees());
         assertEquals(forest.getLambda(), forest2.getLambda());
         assertEquals(forest.isStoreSequenceIndexesEnabled(), forest2.isStoreSequenceIndexesEnabled());
-        assertEquals(forest.isCompactEnabled(), forest2.isCompactEnabled());
+        assertEquals(forest.isCompact(), forest2.isCompact());
         assertEquals(forest.getPrecision(), forest2.getPrecision());
         assertEquals(forest.getBoundingBoxCacheFraction(), forest2.getBoundingBoxCacheFraction());
         assertEquals(forest.isCenterOfMassEnabled(), forest2.isCenterOfMassEnabled());
@@ -77,7 +77,7 @@ public class RandomCutForestMapperTest {
         PointStoreCoordinator coordinator = (PointStoreCoordinator) forest.getUpdateCoordinator();
         PointStoreCoordinator coordinator2 = (PointStoreCoordinator) forest2.getUpdateCoordinator();
 
-        if (forest.getPrecision() == Precision.DOUBLE) {
+        if (forest.getPrecision() == Precision.FLOAT_64) {
             PointStoreDouble store = (PointStoreDouble) coordinator.getStore();
             PointStoreDouble store2 = (PointStoreDouble) coordinator2.getStore();
             assertArrayEquals(store.getRefCount(), store2.getRefCount());
@@ -120,10 +120,10 @@ public class RandomCutForestMapperTest {
 
     @Test
     public void testRoundTripForEmptyForest() {
-        Precision precision = Precision.DOUBLE;
+        Precision precision = Precision.FLOAT_64;
 
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
-                .sampleSize(sampleSize).precision(precision).build();
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).sampleSize(sampleSize)
+                .precision(precision).build();
 
         mapper.setSaveTreeState(true);
         RandomCutForest forest2 = mapper.toModel(mapper.toState(forest));

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapperTest.java
@@ -71,7 +71,7 @@ public class CompactRandomCutTreeDoubleMapperTest {
             CompactRandomCutTreeContext context = new CompactRandomCutTreeContext();
             context.setMaxSize(capacity);
             context.setPointStore(pointStore);
-            context.setPrecision(Precision.DOUBLE);
+            context.setPrecision(Precision.FLOAT_64);
 
             return trees.stream().map(t -> Arguments.of(t, context));
         }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapperTest.java
@@ -71,7 +71,7 @@ public class CompactRandomCutTreeFloatMapperTest {
             CompactRandomCutTreeContext context = new CompactRandomCutTreeContext();
             context.setMaxSize(capacity);
             context.setPointStore(pointStore);
-            context.setPrecision(Precision.DOUBLE);
+            context.setPrecision(Precision.FLOAT_64);
 
             return trees.stream().map(t -> Arguments.of(t, context));
         }

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
@@ -44,13 +44,13 @@ public class DynamicSampling implements Example {
         int dimensions = 4;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.DOUBLE;
+        Precision precision = Precision.FLOAT_64;
         int dataSize = 4 * sampleSize;
         NormalMixtureTestData testData = new NormalMixtureTestData();
 
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions).randomSeed(0)
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).randomSeed(0)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
-        RandomCutForest forest2 = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions).randomSeed(0)
+        RandomCutForest forest2 = RandomCutForest.builder().compact(true).dimensions(dimensions).randomSeed(0)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
 
         int first_anomalies = 0;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicThroughput.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicThroughput.java
@@ -46,7 +46,7 @@ public class DynamicThroughput implements Example {
         int dimensions = 4;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.DOUBLE;
+        Precision precision = Precision.FLOAT_64;
         int dataSize = 10 * sampleSize;
         NormalMixtureTestData testData = new NormalMixtureTestData();
         // generate data once to eliminate caching issues
@@ -55,10 +55,10 @@ public class DynamicThroughput implements Example {
 
         for (int i = 0; i < 5; i++) {
 
-            RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions).randomSeed(0)
+            RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).randomSeed(0)
                     .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
-            RandomCutForest forest2 = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
-                    .randomSeed(0).numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
+            RandomCutForest forest2 = RandomCutForest.builder().compact(true).dimensions(dimensions).randomSeed(0)
+                    .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
             forest2.setBoundingBoxCacheFraction(i * 0.25);
 
             int anomalies = 0;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
@@ -50,9 +50,9 @@ public class JsonExample implements Example {
         int dimensions = 4;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.DOUBLE;
+        Precision precision = Precision.FLOAT_64;
 
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
 
         int dataSize = 4 * sampleSize;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
@@ -53,9 +53,9 @@ public class ProtostuffExample implements Example {
         int dimensions = 10;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.SINGLE;
+        Precision precision = Precision.FLOAT_32;
 
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
 
         int dataSize = 1000 * sampleSize;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
@@ -55,9 +55,9 @@ public class ProtostuffExampleWithDynamicLambda implements Example {
         int dimensions = 4;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.DOUBLE;
+        Precision precision = Precision.FLOAT_64;
 
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).build();
 
         int dataSize = 4 * sampleSize;
@@ -103,11 +103,10 @@ public class ProtostuffExampleWithDynamicLambda implements Example {
             if (sampler.getMaxSequenceIndex() != sampler2.getMaxSequenceIndex()) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
-            if (sampler.getSequenceIndexOfMostRecentLambdaUpdate() != sampler2
-                    .getSequenceIndexOfMostRecentLambdaUpdate()) {
+            if (sampler.getMostRecentTimeDecayUpdate() != sampler2.getMostRecentTimeDecayUpdate()) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
-            if (sampler2.getSequenceIndexOfMostRecentLambdaUpdate() != dataSize - 1) {
+            if (sampler2.getMostRecentTimeDecayUpdate() != dataSize - 1) {
                 throw new IllegalStateException("Incorrect sampler state");
             }
         }

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithShingles.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithShingles.java
@@ -56,8 +56,8 @@ public class ProtostuffExampleWithShingles implements Example {
         int dimensions = 10;
         int numberOfTrees = 50;
         int sampleSize = 256;
-        Precision precision = Precision.DOUBLE;
-        RandomCutForest forest = RandomCutForest.builder().compactEnabled(true).dimensions(dimensions)
+        Precision precision = Precision.FLOAT_64;
+        RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                 .numberOfTrees(numberOfTrees).sampleSize(sampleSize).precision(precision).shingleSize(dimensions)
                 .build();
         int count = 1;


### PR DESCRIPTION
- Change property `compactEnabled` to `compact`.
- Change Preceision enum values from `SINGLE` and `DOUBLE` to `FLOAT_32`
  and `FLOAT_64`.
- Use `centerOfMassEnabled` instead of `enableCenterOfMass`
- Change `lambda` property to `timeDecay`.
- Use `rng` instead of `random` for instance fields of type `Random`.
- Change `getSequenceIndexOfMostRecentLambdaUpdate` to
  `mostRecentTimeDecayUpdate`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
