### PR TITLE
Normalize names in the state package

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperBenchmark.java
@@ -91,8 +91,8 @@ public class StateMapperBenchmark {
             }
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(saveTreeState);
             forestState = mapper.toState(forest);
 
             ObjectMapper jsonMapper = new ObjectMapper();
@@ -125,8 +125,8 @@ public class StateMapperBenchmark {
 
         for (int i = 0; i < NUM_TEST_SAMPLES; i++) {
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             forest = mapper.toModel(forestState);
             double score = forest.getAnomalyScore(testData[i]);
             blackhole.consume(score);
@@ -148,8 +148,8 @@ public class StateMapperBenchmark {
             RandomCutForestState forestState = jsonMapper.readValue(json, RandomCutForestState.class);
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);
@@ -174,8 +174,8 @@ public class StateMapperBenchmark {
             ProtostuffIOUtil.mergeFrom(bytes, forestState, schema);
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperShingledBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/StateMapperShingledBenchmark.java
@@ -93,8 +93,8 @@ public class StateMapperShingledBenchmark {
             }
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(saveTreeState);
             forestState = mapper.toState(forest);
 
             ObjectMapper jsonMapper = new ObjectMapper();
@@ -125,8 +125,8 @@ public class StateMapperShingledBenchmark {
 
         for (int i = 0; i < NUM_TEST_SAMPLES; i++) {
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             RandomCutForest forest = mapper.toModel(forestState);
             double score = forest.getAnomalyScore(testData[i]);
             blackhole.consume(score);
@@ -148,8 +148,8 @@ public class StateMapperShingledBenchmark {
             RandomCutForestState forestState = jsonMapper.readValue(json, RandomCutForestState.class);
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             RandomCutForest forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);
@@ -174,8 +174,8 @@ public class StateMapperShingledBenchmark {
             ProtostuffIOUtil.mergeFrom(bytes, forestState, schema);
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(state.saveTreeState);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(state.saveTreeState);
             RandomCutForest forest = mapper.toModel(forestState);
 
             double score = forest.getAnomalyScore(testData[i]);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -318,7 +318,7 @@ public class RandomCutForest {
                 .dynamicResizingEnabled(builder.dynamicResizingEnabled).shingleSize(shingleSize).dimensions(dimensions)
                 .build();
 
-        IStateCoordinator<Integer, float[]> stateCoordinator = new PointStoreCoordinator(tempStore);
+        IStateCoordinator<Integer, float[]> stateCoordinator = new PointStoreCoordinator<>(tempStore);
         ComponentList<Integer, float[]> components = new ComponentList<>(numberOfTrees);
         for (int i = 0; i < numberOfTrees; i++) {
             ITree<Integer, float[]> tree = new CompactRandomCutTreeFloat.Builder().maxSize(sampleSize)

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/Precision.java
@@ -26,5 +26,5 @@ public enum Precision {
     /**
      * Double-precision (64 bit) floating point numbers.
      */
-    FLOAT_64
+    FLOAT_64;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestState.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import lombok.Data;
 
+import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.sampler.CompactSamplerState;
 import com.amazon.randomcutforest.state.store.PointStoreState;
 import com.amazon.randomcutforest.state.tree.CompactRandomCutTreeState;
@@ -36,7 +37,7 @@ public class RandomCutForestState {
 
     private long totalUpdates;
 
-    private double lambda;
+    private double timeDecay;
 
     private int numberOfTrees;
 
@@ -48,27 +49,21 @@ public class RandomCutForestState {
 
     private int outputAfter;
 
-    private boolean compress;
+    private boolean compressed;
 
-    private boolean partialTreesInUse;
+    private boolean partialTreeState;
 
     private double boundingBoxCacheFraction;
 
     private boolean storeSequenceIndexesEnabled;
 
-    private boolean compactEnabled;
+    private boolean compact;
 
     private boolean internalShinglingEnabled;
 
     private boolean centerOfMassEnabled;
 
-    private boolean saveTreeState;
-
-    private boolean saveSamplerState;
-
-    private boolean saveCoordinatorState;
-
-    private boolean singlePrecisionSet;
+    private String precision;
 
     private PointStoreState pointStoreState;
 
@@ -78,4 +73,15 @@ public class RandomCutForestState {
 
     private ExecutorContext executorContext;
 
+    // Mapper options
+
+    private boolean saveTreeStateEnabled;
+
+    private boolean saveSamplerStateEnabled;
+
+    private boolean saveCoordinatorStateEnabled;
+
+    public Precision getPrecisionEnumValue() {
+        return Precision.valueOf(precision);
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/ArraySamplersToCompactStateConverter.java
@@ -35,13 +35,13 @@ public class ArraySamplersToCompactStateConverter {
     private final Map<double[], Integer> pointMap;
     private final PointStoreDouble pointStoreDouble;
     private final List<CompactSamplerState> compactSamplerStates;
-    boolean storeSequences;
+    boolean storeSequenceIndexesEnabled;
 
-    public ArraySamplersToCompactStateConverter(boolean storeSequences, int dimensions, int capacity) {
+    public ArraySamplersToCompactStateConverter(boolean storeSequenceIndexesEnabled, int dimensions, int capacity) {
         pointMap = new HashMap<>();
         pointStoreDouble = new PointStoreDouble(dimensions, capacity);
         compactSamplerStates = new ArrayList<>();
-        this.storeSequences = storeSequences;
+        this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
     }
 
     public PointStoreState getPointStoreDoubleState() {
@@ -55,7 +55,7 @@ public class ArraySamplersToCompactStateConverter {
     public void addSampler(SimpleStreamSampler<double[]> sampler) {
         int[] pointIndex = new int[sampler.size()];
         float[] weight = new float[sampler.size()];
-        long[] sequenceIndex = storeSequences ? new long[sampler.size()] : null;
+        long[] sequenceIndex = storeSequenceIndexesEnabled ? new long[sampler.size()] : null;
 
         int i = 0;
         for (Weighted<double[]> sample : sampler.getWeightedSample()) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapper.java
@@ -35,15 +35,12 @@ public class CompactSamplerMapper implements IStateMapper<CompactSampler, Compac
      * validate that the weight array in a {@code CompactSamplerState} instance
      * satisfies the heap property. The heap property is not validated by default.
      */
-    private boolean validateHeap = false;
+    private boolean validateHeapEnabled = false;
 
     /**
      * used to compress data, can be set to false for debug
      */
-    private boolean compress = true;
-
-    // the following is for tests
-    private boolean copy = true;
+    private boolean compressionEnabled = true;
 
     @Override
     public CompactSampler toModel(CompactSamplerState state, long seed) {
@@ -61,9 +58,9 @@ public class CompactSamplerMapper implements IStateMapper<CompactSampler, Compac
             sequenceIndex = null;
         }
 
-        return new CompactSampler.Builder().capacity(state.getCapacity()).lambda(state.getLambda())
+        return new CompactSampler.Builder<>().capacity(state.getCapacity()).lambda(state.getLambda())
                 .random(new Random(seed)).storeSequenceIndexesEnabled(state.isStoreSequenceIndicesEnabled())
-                .weight(weight).pointIndex(pointIndex).sequenceIndex(sequenceIndex).validateHeap(validateHeap)
+                .weight(weight).pointIndex(pointIndex).sequenceIndex(sequenceIndex).validateHeap(validateHeapEnabled)
                 .initialAcceptFraction(state.getInitialAcceptFraction())
                 .mostRecentLambdaUpdate(state.getSequenceIndexOfMostRecentLambdaUpdate())
                 .maxSequenceIndex(state.getMaxSequenceIndex()).size(state.getSize()).build();
@@ -73,7 +70,7 @@ public class CompactSamplerMapper implements IStateMapper<CompactSampler, Compac
     public CompactSamplerState toState(CompactSampler model) {
         CompactSamplerState state = new CompactSamplerState();
         state.setSize(model.size());
-        state.setCompressed(compress);
+        state.setCompressed(compressionEnabled);
         state.setCapacity(model.getCapacity());
         state.setLambda(model.getTimeDecay());
         state.setSequenceIndexOfMostRecentLambdaUpdate(model.getMostRecentTimeDecayUpdate());

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreState.java
@@ -19,6 +19,8 @@ import static com.amazon.randomcutforest.state.Version.V2_0;
 
 import lombok.Data;
 
+import com.amazon.randomcutforest.config.Precision;
+
 @Data
 public class NodeStoreState {
 
@@ -28,7 +30,7 @@ public class NodeStoreState {
     private boolean compressed;
     private int[] cutDimension;
     private byte[] cutValueData;
-    private boolean singlePrecisionSet;
+    private String precision;
     private int root;
 
     private boolean canonicalAndNotALeaf;
@@ -41,7 +43,11 @@ public class NodeStoreState {
     private int[] leafFreeIndexes;
     private int leafFreeIndexPointer;
 
-    private boolean usePartialTrees;
-    private int[] leafmass;
+    private boolean partialTreeStateEnabled;
+    private int[] leafMass;
     private int[] leafPointIndex;
+
+    public Precision getPrecisionEnumValue() {
+        return Precision.valueOf(precision);
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.store.PointStore;
 import com.amazon.randomcutforest.store.PointStoreFloat;
@@ -35,13 +36,13 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
     /**
      * If true, then the arrays are compressed via simple data dependent scheme
      */
-    private boolean compress = true;
+    private boolean compressionEnabled = true;
 
     @Override
     public PointStoreFloat toModel(PointStoreState state, long seed) {
         checkNotNull(state.getRefCount(), "refCount must not be null");
         checkNotNull(state.getPointData(), "pointData must not be null");
-        checkArgument(state.isSinglePrecisionSet(), "incorrect use");
+        checkArgument(state.getPrecisionEnumValue() == Precision.FLOAT_32, "precision must be " + Precision.FLOAT_32);
         int indexCapacity = state.getIndexCapacity();
         int dimensions = state.getDimensions();
         float[] store = ArrayPacking.unpackFloats(state.getPointData(), state.getCurrentStoreCapacity() * dimensions);
@@ -66,7 +67,7 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
     public PointStoreState toState(PointStoreFloat model) {
         model.compact();
         PointStoreState state = new PointStoreState();
-        state.setCompressed(compress);
+        state.setCompressed(compressionEnabled);
         state.setDimensions(model.getDimensions());
         state.setCapacity(model.getCapacity());
         state.setShingleSize(model.getShingleSize());
@@ -79,7 +80,7 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
         state.setCurrentStoreCapacity(model.getCurrentStoreCapacity());
         state.setIndexCapacity(model.getIndexCapacity());
         state.setStartOfFreeSegment(model.getStartOfFreeSegment());
-        state.setSinglePrecisionSet(true);
+        state.setPrecision(Precision.FLOAT_32.name());
         int prefix = model.getValidPrefix();
         state.setRefCount(ArrayPacking.pack(model.getRefCount(), prefix, state.isCompressed()));
         state.setLocationList(ArrayPacking.pack(model.getLocationList(), prefix, state.isCompressed()));

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreState.java
@@ -19,6 +19,8 @@ import static com.amazon.randomcutforest.state.Version.V2_0;
 
 import lombok.Data;
 
+import com.amazon.randomcutforest.config.Precision;
+
 /**
  * A class for storing the state of a
  * {@link com.amazon.randomcutforest.store.PointStoreDouble} or a
@@ -45,9 +47,9 @@ public class PointStoreState {
      */
     private int shingleSize;
     /**
-     * boolean for precision
+     * precision of points in the point store state
      */
-    private boolean singlePrecisionSet;
+    private String precision;
     /**
      * location beyond which the store has no useful information
      */
@@ -109,4 +111,8 @@ public class PointStoreState {
      * current index capacity
      */
     private int indexCapacity;
+
+    public Precision getPrecisionEnumValue() {
+        return Precision.valueOf(precision);
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeDoubleMapper.java
@@ -30,7 +30,7 @@ import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 public class CompactRandomCutTreeDoubleMapper implements
         IContextualStateMapper<CompactRandomCutTreeDouble, CompactRandomCutTreeState, CompactRandomCutTreeContext> {
 
-    private boolean partialTreeInUse = false;
+    private boolean partialTreeStateEnabled = false;
     private boolean compress = true;
 
     @Override
@@ -44,9 +44,9 @@ public class CompactRandomCutTreeDoubleMapper implements
 
         CompactRandomCutTreeDouble tree = new CompactRandomCutTreeDouble.Builder()
                 .boundingBoxCacheFraction(state.getBoundingBoxCacheFraction())
-                .storeSequenceIndexesEnabled(state.isStoreSequenceIndices()).maxSize(state.getMaxSize())
+                .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled()).maxSize(state.getMaxSize())
                 .root(state.getRoot()).randomSeed(seed).pointStore((PointStoreDouble) context.getPointStore())
-                .nodeStore(nodeStore).centerOfMassEnabled(state.isEnableCenterOfMass())
+                .nodeStore(nodeStore).centerOfMassEnabled(state.isCenterOfMassEnabled())
                 .outputAfter(state.getOutputAfter()).build();
         return tree;
 
@@ -58,14 +58,14 @@ public class CompactRandomCutTreeDoubleMapper implements
         model.reorderNodesInBreadthFirstOrder();
         state.setMaxSize(model.getMaxSize());
         state.setRoot(model.getRootIndex());
-        state.setPartialTreeInUse(model.storeSequenceIndexesEnabled || partialTreeInUse);
-        state.setStoreSequenceIndices(model.storeSequenceIndexesEnabled);
-        state.setEnableCenterOfMass(model.centerOfMassEnabled);
+        state.setPartialTreeState(model.storeSequenceIndexesEnabled || partialTreeStateEnabled);
+        state.setStoreSequenceIndexesEnabled(model.storeSequenceIndexesEnabled);
+        state.setCenterOfMassEnabled(model.centerOfMassEnabled);
         state.setOutputAfter(model.getOutputAfter());
 
         NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
-        nodeStoreMapper.setCompress(compress);
-        nodeStoreMapper.setUsePartialTrees(state.isPartialTreeInUse());
+        nodeStoreMapper.setCompressionEnabled(compress);
+        nodeStoreMapper.setPartialTreeStateEnabled(state.isPartialTreeState());
         state.setNodeStoreState(nodeStoreMapper.toState((NodeStore) model.getNodeStore()));
         return state;
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeFloatMapper.java
@@ -18,6 +18,7 @@ package com.amazon.randomcutforest.state.tree;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.IContextualStateMapper;
 import com.amazon.randomcutforest.state.store.NodeStoreMapper;
 import com.amazon.randomcutforest.store.INodeStore;
@@ -30,8 +31,8 @@ import com.amazon.randomcutforest.tree.CompactRandomCutTreeFloat;
 public class CompactRandomCutTreeFloatMapper implements
         IContextualStateMapper<CompactRandomCutTreeFloat, CompactRandomCutTreeState, CompactRandomCutTreeContext> {
 
-    private boolean partialTreeInUse = false;
-    private boolean compress = true;
+    private boolean partialTreeStateEnabled = false;
+    private boolean compressed = true;
 
     @Override
     public CompactRandomCutTreeFloat toModel(CompactRandomCutTreeState state, CompactRandomCutTreeContext context,
@@ -40,14 +41,14 @@ public class CompactRandomCutTreeFloatMapper implements
         INodeStore nodeStore;
 
         NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
-        nodeStoreMapper.setUsePartialTrees(state.isPartialTreeInUse());
+        nodeStoreMapper.setPartialTreeStateEnabled(state.isPartialTreeState());
         nodeStore = nodeStoreMapper.toModel(state.getNodeStoreState());
 
         CompactRandomCutTreeFloat tree = new CompactRandomCutTreeFloat.Builder()
                 .boundingBoxCacheFraction(state.getBoundingBoxCacheFraction())
-                .storeSequenceIndexesEnabled(state.isStoreSequenceIndices()).maxSize(state.getMaxSize())
+                .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled()).maxSize(state.getMaxSize())
                 .root(state.getRoot()).randomSeed(seed).pointStore((PointStoreFloat) context.getPointStore())
-                .nodeStore(nodeStore).centerOfMassEnabled(state.isEnableCenterOfMass())
+                .nodeStore(nodeStore).centerOfMassEnabled(state.isCenterOfMassEnabled())
                 .outputAfter(state.getOutputAfter()).build();
         return tree;
     }
@@ -58,16 +59,16 @@ public class CompactRandomCutTreeFloatMapper implements
         model.reorderNodesInBreadthFirstOrder();
         state.setRoot(model.getRoot());
         state.setMaxSize(model.getMaxSize());
-        state.setPartialTreeInUse(model.storeSequenceIndexesEnabled || partialTreeInUse);
-        state.setStoreSequenceIndices(model.storeSequenceIndexesEnabled);
-        state.setEnableCenterOfMass(model.centerOfMassEnabled);
+        state.setPartialTreeState(model.storeSequenceIndexesEnabled || partialTreeStateEnabled);
+        state.setStoreSequenceIndexesEnabled(model.storeSequenceIndexesEnabled);
+        state.setCenterOfMassEnabled(model.centerOfMassEnabled);
         state.setBoundingBoxCacheFraction(model.getBoundingBoxCacheFraction());
         state.setOutputAfter(model.getOutputAfter());
 
         NodeStoreMapper nodeStoreMapper = new NodeStoreMapper();
-        nodeStoreMapper.setCompress(compress);
-        nodeStoreMapper.setUsePartialTrees(state.isPartialTreeInUse());
-        nodeStoreMapper.setSinglePrecisionSet(true);
+        nodeStoreMapper.setCompressionEnabled(compressed);
+        nodeStoreMapper.setPartialTreeStateEnabled(state.isPartialTreeState());
+        nodeStoreMapper.setPrecision(Precision.FLOAT_32);
         state.setNodeStoreState(nodeStoreMapper.toState((NodeStore) model.getNodeStore()));
 
         return state;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeState.java
@@ -27,11 +27,12 @@ public class CompactRandomCutTreeState {
     private int root;
     private int maxSize;
     private int outputAfter;
-    private boolean partialTreeInUse;
-    private boolean storeSequenceIndices;
-    private boolean enableCenterOfMass;
+    private boolean storeSequenceIndexesEnabled;
+    private boolean centerOfMassEnabled;
     private NodeStoreState nodeStoreState;
     private double boundingBoxCacheFraction;
+
+    private boolean partialTreeState;
 
     // to be used later
     private long seed;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
@@ -643,8 +643,8 @@ public class CompactRandomCutForestFunctionalTest {
 
             // serialize + deserialize
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveTreeState(true);
-            mapper.setSaveExecutorContext(true);
+            mapper.setSaveTreeStateEnabled(true);
+            mapper.setSaveExecutorContextEnabled(true);
             RandomCutForest forest2 = mapper.toModel(mapper.toState(forest));
 
             // update re-instantiated forest

--- a/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
@@ -452,8 +452,8 @@ public class ShinglingFunctionalTest {
         for (int i = 0; i < testData.length; i++) {
 
             RandomCutForestMapper mapper = new RandomCutForestMapper();
-            mapper.setSaveExecutorContext(true);
-            mapper.setSaveTreeState(true);
+            mapper.setSaveExecutorContextEnabled(true);
+            mapper.setSaveTreeStateEnabled(true);
 
             double score = forest.getAnomalyScore(testData[i]);
             forest.update(testData[i]);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
@@ -57,7 +57,7 @@ public class RandomCutForestMapperTest {
     @BeforeEach
     public void setUp() {
         mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
+        mapper.setSaveExecutorContextEnabled(true);
     }
 
     public void assertCompactForestEquals(RandomCutForest forest, RandomCutForest forest2) {
@@ -114,7 +114,7 @@ public class RandomCutForestMapperTest {
     @ParameterizedTest
     @MethodSource("compactForestProvider")
     public void testRoundTripForCompactForestSaveTreeState(RandomCutForest forest) {
-        mapper.setSaveTreeState(true);
+        mapper.setSaveTreeStateEnabled(true);
         testRoundTripForCompactForest(forest);
     }
 
@@ -125,7 +125,7 @@ public class RandomCutForestMapperTest {
         RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).sampleSize(sampleSize)
                 .precision(precision).build();
 
-        mapper.setSaveTreeState(true);
+        mapper.setSaveTreeStateEnabled(true);
         RandomCutForest forest2 = mapper.toModel(mapper.toState(forest));
 
         assertCompactForestEquals(forest, forest2);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
@@ -79,7 +79,7 @@ public class CompactSamplerMapperTest {
     @BeforeEach
     public void setUp() {
         mapper = new CompactSamplerMapper();
-        mapper.setValidateHeap(false);
+        mapper.setValidateHeapEnabled(false);
     }
 
     private void assertValidMapping(CompactSampler original, CompactSampler mapped) {
@@ -101,26 +101,9 @@ public class CompactSamplerMapperTest {
     }
 
     @ParameterizedTest
-    @MethodSource("samplerProvider")
-    public void testRoundTripWithCopy(String description, CompactSampler sampler) {
-        mapper.setCopy(true);
-        CompactSampler mapped = mapper.toModel(mapper.toState(sampler));
-        assertValidMapping(sampler, mapped);
-    }
-
-    @ParameterizedTest
-    @MethodSource("samplerProvider")
-    public void testRoundTripWithoutCopy(String description, CompactSampler sampler) {
-        mapper.setCopy(false);
-        CompactSampler mapped = mapper.toModel(mapper.toState(sampler));
-        assertValidMapping(sampler, mapped);
-    }
-
-    @ParameterizedTest
     @MethodSource("nonemptySamplerProvider")
     public void testRoundTripInvalidHeap(String description, CompactSampler sampler) {
-        mapper.setCopy(true);
-        mapper.setValidateHeap(true);
+        mapper.setValidateHeapEnabled(true);
         CompactSamplerState state = mapper.toState(sampler);
 
         // swap to weights in the weight array in order to violate the heap property
@@ -132,7 +115,7 @@ public class CompactSamplerMapperTest {
 
         assertThrows(IllegalStateException.class, () -> mapper.toModel(state));
 
-        mapper.setValidateHeap(false);
+        mapper.setValidateHeapEnabled(false);
         CompactSampler sampler2 = mapper.toModel(state);
         assertArrayEquals(sampler.getWeightArray(), sampler2.getWeightArray());
     }

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
@@ -87,7 +87,7 @@ public class DynamicSampling implements Example {
 
         first_anomalies = second_anomalies = 0;
         RandomCutForestMapper mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
+        mapper.setSaveExecutorContextEnabled(true);
         RandomCutForest copyForest = mapper.toModel(mapper.toState(forest));
         copyForest.setLambda(50 * forest.getLambda());
         // force an adjustment to catch up

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/JsonExample.java
@@ -64,7 +64,7 @@ public class JsonExample implements Example {
         // Convert to JSON and print the number of bytes
 
         RandomCutForestMapper mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
+        mapper.setSaveExecutorContextEnabled(true);
         ObjectMapper jsonMapper = new ObjectMapper();
 
         String json = jsonMapper.writeValueAsString(mapper.toState(forest));

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExample.java
@@ -67,7 +67,7 @@ public class ProtostuffExample implements Example {
         // Convert to an array of bytes and print the size
 
         RandomCutForestMapper mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
+        mapper.setSaveExecutorContextEnabled(true);
 
         Schema<RandomCutForestState> schema = RuntimeSchema.getSchema(RandomCutForestState.class);
         LinkedBuffer buffer = LinkedBuffer.allocate(512);

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
@@ -69,7 +69,7 @@ public class ProtostuffExampleWithDynamicLambda implements Example {
         // Convert to an array of bytes and print the size
 
         RandomCutForestMapper mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
+        mapper.setSaveExecutorContextEnabled(true);
 
         Schema<RandomCutForestState> schema = RuntimeSchema.getSchema(RandomCutForestState.class);
         LinkedBuffer buffer = LinkedBuffer.allocate(512);

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithShingles.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithShingles.java
@@ -69,8 +69,8 @@ public class ProtostuffExampleWithShingles implements Example {
         // Convert to an array of bytes and print the size
 
         RandomCutForestMapper mapper = new RandomCutForestMapper();
-        mapper.setSaveExecutorContext(true);
-        mapper.setSaveTreeState(false);
+        mapper.setSaveExecutorContextEnabled(true);
+        mapper.setSaveTreeStateEnabled(false);
 
         Schema<RandomCutForestState> schema = RuntimeSchema.getSchema(RandomCutForestState.class);
         LinkedBuffer buffer = LinkedBuffer.allocate(512);


### PR DESCRIPTION
- Match names in the corresponding model classes.
- Use the "Enabled" suffix for boolean flags where it improves
  readability.
- Use "compressed" in state classes versus "isCompressionEnabled" in
  mapper classes.
- Use "isPartialTreeState" in state classes versus
  "isPartialTreeStateEnabled" in mapper classes.
- Store precision as a String instead of a boolean.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
