### PR TITLE
Change field visibility in BoxCache and NodeStore

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/NodeStoreMapper.java
@@ -92,8 +92,8 @@ public class NodeStoreMapper implements IStateMapper<NodeStore, NodeStoreState> 
         state.setPartialTreeStateEnabled(partialTreeStateEnabled);
         state.setPrecision(precision.name());
 
-        int[] leftIndex = Arrays.copyOf(model.leftIndex, model.leftIndex.length);
-        int[] rightIndex = Arrays.copyOf(model.rightIndex, model.rightIndex.length);
+        int[] leftIndex = Arrays.copyOf(model.getLeftIndex(), model.getLeftIndex().length);
+        int[] rightIndex = Arrays.copyOf(model.getRightIndex(), model.getRightIndex().length);
         boolean check = state.isCompressed() && model.isCanonicalAndNotALeaf();
         state.setCanonicalAndNotALeaf(check);
         if (check) { // can have a canonical representation saving a lot of space
@@ -102,15 +102,15 @@ public class NodeStoreMapper implements IStateMapper<NodeStore, NodeStoreState> 
             state.setRightIndex(ArrayPacking.pack(rightIndex, state.isCompressed()));
             state.setSize(model.size());
         } else { // the temporary array leftIndex and rightIndex may be corrupt in reduceToBits()
-            state.setLeftIndex(ArrayPacking.pack(model.leftIndex, state.isCompressed()));
-            state.setRightIndex(ArrayPacking.pack(model.rightIndex, state.isCompressed()));
+            state.setLeftIndex(ArrayPacking.pack(model.getLeftIndex(), state.isCompressed()));
+            state.setRightIndex(ArrayPacking.pack(model.getRightIndex(), state.isCompressed()));
         }
 
-        state.setCutDimension(ArrayPacking.pack(model.cutDimension, state.isCompressed()));
+        state.setCutDimension(ArrayPacking.pack(model.getCutDimension(), state.isCompressed()));
         if (state.getPrecisionEnumValue() == Precision.FLOAT_32) {
-            state.setCutValueData(ArrayPacking.pack(CommonUtils.toFloatArray(model.cutValue)));
+            state.setCutValueData(ArrayPacking.pack(CommonUtils.toFloatArray(model.getCutValue())));
         } else {
-            state.setCutValueData(ArrayPacking.pack(model.cutValue, model.cutValue.length));
+            state.setCutValueData(ArrayPacking.pack(model.getCutValue(), model.getCutValue().length));
         }
         state.setNodeFreeIndexes(ArrayPacking.pack(model.getNodeFreeIndexes(), state.isCompressed()));
         state.setNodeFreeIndexPointer(model.getNodeFreeIndexPointer());

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/INodeStore.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/INodeStore.java
@@ -70,7 +70,7 @@ public interface INodeStore {
      * @param index  node
      * @param parent parent of the node (can be NULL)
      */
-    void setParent(int index, int parent);
+    void setParentIndex(int index, int parent);
 
     /**
      * gets the parent of a node
@@ -78,7 +78,7 @@ public interface INodeStore {
      * @param index node
      * @return indef of parent
      */
-    int getParent(int index);
+    int getParentIndex(int index);
 
     /**
      * deletes a node

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/NodeStore.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/NodeStore.java
@@ -41,16 +41,17 @@ import java.util.Arrays;
  */
 public class NodeStore implements INodeStore {
 
-    public final int capacity;
-    public final int[] parentIndex;
-    public final int[] leftIndex;
-    public final int[] rightIndex;
-    public final int[] cutDimension;
-    public final double[] cutValue;
-    public final int[] mass;
-    public final int[] leafPointIndex;
-    public IndexManager freeNodeManager;
-    public IndexManager freeLeafManager;
+    private final int capacity;
+    private final int[] parentIndex;
+    private final int[] leftIndex;
+    private final int[] rightIndex;
+    private final int[] cutDimension;
+    private final double[] cutValue;
+    private final int[] mass;
+    private final int[] leafPointIndex;
+
+    protected IndexManager freeNodeManager;
+    protected IndexManager freeLeafManager;
 
     /**
      * Create a new NodeStore with the given capacity.
@@ -81,7 +82,7 @@ public class NodeStore implements INodeStore {
         this.capacity = capacity;
         this.freeNodeManager = new IndexManager(capacity, freeNodeIndexes, freeNodeIndexPointer);
         this.freeLeafManager = new IndexManager(capacity + 1, freeLeafIndexes, freeLeafIndexPointer);
-        this.parentIndex = getParentIndex(leftIndex, rightIndex);
+        this.parentIndex = deriveParentIndex(leftIndex, rightIndex);
         this.leftIndex = leftIndex;
         this.rightIndex = rightIndex;
         this.cutDimension = cutDimension;
@@ -144,12 +145,12 @@ public class NodeStore implements INodeStore {
     }
 
     @Override
-    public void setParent(int index, int parent) {
+    public void setParentIndex(int index, int parent) {
         parentIndex[index] = parent;
     }
 
     @Override
-    public int getParent(int index) {
+    public int getParentIndex(int index) {
         return parentIndex[index];
     }
 
@@ -183,6 +184,10 @@ public class NodeStore implements INodeStore {
         return rightIndex[index];
     }
 
+    public int[] getRightIndex() {
+        return rightIndex;
+    }
+
     @Override
     public void setRightIndex(int index, int child) {
         rightIndex[index] = child;
@@ -191,6 +196,10 @@ public class NodeStore implements INodeStore {
     @Override
     public int getLeftIndex(int index) {
         return leftIndex[index];
+    }
+
+    public int[] getLeftIndex() {
+        return leftIndex;
     }
 
     @Override
@@ -213,9 +222,17 @@ public class NodeStore implements INodeStore {
         return cutDimension[index];
     }
 
+    public int[] getCutDimension() {
+        return cutDimension;
+    }
+
     @Override
     public double getCutValue(int index) {
         return cutValue[index];
+    }
+
+    public double[] getCutValue() {
+        return cutValue;
     }
 
     @Override
@@ -248,7 +265,7 @@ public class NodeStore implements INodeStore {
         return leftIndex[parent] == node ? rightIndex[parent] : leftIndex[parent];
     }
 
-    int[] getParentIndex(int[] leftIndex, int[] rightIndex) {
+    int[] deriveParentIndex(int[] leftIndex, int[] rightIndex) {
         int capacity = leftIndex.length;
         checkState(rightIndex.length == capacity, "incorrect function call, arrays should be equal");
         int[] parentIndex = new int[2 * capacity + 1];

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractCompactRandomCutTree.java
@@ -404,12 +404,12 @@ public abstract class AbstractCompactRandomCutTree<Point> extends AbstractRandom
     }
 
     protected int getParent(int node) {
-        return nodeStore.getParent(node);
+        return nodeStore.getParentIndex(node);
     }
 
     @Override
     protected void setParent(Integer child, Integer parent) {
-        nodeStore.setParent(intValue(child), intValue(parent));
+        nodeStore.setParentIndex(intValue(child), intValue(parent));
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCache.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCache.java
@@ -21,13 +21,13 @@ import java.util.Random;
 
 public abstract class BoxCache<Point> implements IBoxCache<Point> {
 
-    double cacheFraction;
-    Random cacheRandom;
-    long randomSeed;
-    AbstractBoundingBox<Point>[] cachedBoxes;
-    HashMap<Integer, Integer> cacheMap;
-    BitSet bitSet;
-    int maxSize;
+    protected double cacheFraction;
+    protected Random rng;
+    protected long randomSeed;
+    protected AbstractBoundingBox<Point>[] cachedBoxes;
+    protected HashMap<Integer, Integer> cacheMap;
+    protected BitSet bitSet;
+    protected int maxSize;
 
     protected BoxCache(long seed, double cacheFraction, int maxSize) {
         randomSeed = seed;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCacheDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCacheDouble.java
@@ -28,14 +28,14 @@ public class BoxCacheDouble extends BoxCache<double[]> {
     }
 
     void initialize() {
-        cacheRandom = new Random(randomSeed);
+        rng = new Random(randomSeed);
         if (cacheFraction < 1.0 && cacheFraction > 0.0) {
             if (isDirectMap()) {
                 bitSet = new BitSet(maxSize);
                 cachedBoxes = new BoundingBox[maxSize];
                 int exclude = (int) Math.floor((1.0 - cacheFraction) * maxSize);
                 for (int i = 0; i < exclude; i++) {
-                    bitSet.set(cacheRandom.nextInt(maxSize));
+                    bitSet.set(rng.nextInt(maxSize));
                 }
             } else {
                 cacheMap = new HashMap<>();
@@ -43,7 +43,7 @@ public class BoxCacheDouble extends BoxCache<double[]> {
                 cachedBoxes = new BoundingBox[include];
                 int count = 0;
                 for (int i = 0; i < include; i++) {
-                    cacheMap.put(cacheRandom.nextInt(maxSize), count++);
+                    cacheMap.put(rng.nextInt(maxSize), count++);
                 }
             }
         } else if (cacheFraction == 1.0) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCacheFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoxCacheFloat.java
@@ -28,14 +28,14 @@ public class BoxCacheFloat extends BoxCache<float[]> {
     }
 
     void initialize() {
-        cacheRandom = new Random(randomSeed);
+        rng = new Random(randomSeed);
         if (cacheFraction < 1.0 && cacheFraction > 0.0) {
             if (isDirectMap()) {
                 bitSet = new BitSet(maxSize);
                 cachedBoxes = new BoundingBoxFloat[maxSize];
                 int exclude = (int) Math.floor((1.0 - cacheFraction) * maxSize);
                 for (int i = 0; i < exclude; i++) {
-                    bitSet.set(cacheRandom.nextInt(maxSize));
+                    bitSet.set(rng.nextInt(maxSize));
                 }
             } else {
                 cacheMap = new HashMap<>();
@@ -43,7 +43,7 @@ public class BoxCacheFloat extends BoxCache<float[]> {
                 cachedBoxes = new BoundingBoxFloat[include];
                 int count = 0;
                 for (int i = 0; i < include; i++) {
-                    cacheMap.put(cacheRandom.nextInt(maxSize), count++);
+                    cacheMap.put(rng.nextInt(maxSize), count++);
                 }
             }
         } else if (cacheFraction == 1.0) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeView.java
@@ -99,7 +99,7 @@ public class CompactNodeView<Point> implements INode<Integer> {
 
     @Override
     public INode<Integer> getParent() {
-        return new CompactNodeView<>(tree, nodeStore.getParent(currentNodeOffset));
+        return new CompactNodeView<>(tree, nodeStore.getParentIndex(currentNodeOffset));
     }
 
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/store/NodeStoreTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/store/NodeStoreTest.java
@@ -49,12 +49,12 @@ public class NodeStoreTest {
 
         int index1 = store.addNode(parentIndex1, leftIndex1, rightIndex1, cutDimension1, cutValue1, mass1);
         assertEquals(1, store.size());
-        assertEquals(mass1, store.mass[index1]);
-        assertEquals(parentIndex1, store.parentIndex[index1]);
-        assertEquals(leftIndex1, store.leftIndex[index1]);
-        assertEquals(rightIndex1, store.rightIndex[index1]);
-        assertEquals(cutDimension1, store.cutDimension[index1]);
-        assertEquals(cutValue1, store.cutValue[index1]);
+        assertEquals(mass1, store.getMass(index1));
+        assertEquals(parentIndex1, store.getParentIndex(index1));
+        assertEquals(leftIndex1, store.getLeftIndex(index1));
+        assertEquals(rightIndex1, store.getRightIndex(index1));
+        assertEquals(cutDimension1, store.getCutDimension(index1));
+        assertEquals(cutValue1, store.getCutValue(index1));
 
         int mass2 = 11;
         short parentIndex2 = 11;
@@ -65,20 +65,20 @@ public class NodeStoreTest {
 
         int index2 = store.addNode(parentIndex2, leftIndex2, rightIndex2, cutDimension2, cutValue2, mass2);
         assertEquals(2, store.size());
-        assertEquals(mass2, store.mass[index2]);
-        assertEquals(parentIndex2, store.parentIndex[index2]);
-        assertEquals(leftIndex2, store.leftIndex[index2]);
-        assertEquals(rightIndex2, store.rightIndex[index2]);
-        assertEquals(cutDimension2, store.cutDimension[index2]);
-        assertEquals(cutValue2, store.cutValue[index2]);
+        assertEquals(mass2, store.getMass(index2));
+        assertEquals(parentIndex2, store.getParentIndex(index2));
+        assertEquals(leftIndex2, store.getLeftIndex(index2));
+        assertEquals(rightIndex2, store.getRightIndex(index2));
+        assertEquals(cutDimension2, store.getCutDimension(index2));
+        assertEquals(cutValue2, store.getCutValue(index2));
 
         // validate that previous values did not change
-        assertEquals(mass1, store.mass[index1]);
-        assertEquals(parentIndex1, store.parentIndex[index1]);
-        assertEquals(leftIndex1, store.leftIndex[index1]);
-        assertEquals(rightIndex1, store.rightIndex[index1]);
-        assertEquals(cutDimension1, store.cutDimension[index1]);
-        assertEquals(cutValue1, store.cutValue[index1]);
+        assertEquals(mass1, store.getMass(index1));
+        assertEquals(parentIndex1, store.getParentIndex(index1));
+        assertEquals(leftIndex1, store.getLeftIndex(index1));
+        assertEquals(rightIndex1, store.getRightIndex(index1));
+        assertEquals(cutDimension1, store.getCutDimension(index1));
+        assertEquals(cutValue1, store.getCutValue(index1));
     }
 
     @Test
@@ -122,12 +122,12 @@ public class NodeStoreTest {
         assertEquals(1, store.size());
 
         // validate that the values at index2 did not change
-        assertEquals(mass2, store.mass[index2]);
-        assertEquals(parentIndex2, store.parentIndex[index2]);
-        assertEquals(leftIndex2, store.leftIndex[index2]);
-        assertEquals(rightIndex2, store.rightIndex[index2]);
-        assertEquals(cutDimension2, store.cutDimension[index2]);
-        assertEquals(cutValue2, store.cutValue[index2]);
+        assertEquals(mass2, store.getMass(index2));
+        assertEquals(parentIndex2, store.getParentIndex(index2));
+        assertEquals(leftIndex2, store.getLeftIndex(index2));
+        assertEquals(rightIndex2, store.getRightIndex(index2));
+        assertEquals(cutDimension2, store.getCutDimension(index2));
+        assertEquals(cutValue2, store.getCutValue(index2));
     }
 
     @Test


### PR DESCRIPTION
- Lower the visibility of fields in BoxCache and NodeStore to private or
  protected
- Rename methods in the NodeStore class: change `getParentIndex` to
  `deriveParentIndex`, and change `getParent` to `getParentIndex`.

Closes #190 and #194

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
