### PR TITLE
enabling projections

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/RandomCutForestBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/RandomCutForestBenchmark.java
@@ -33,8 +33,8 @@ import com.amazon.randomcutforest.returntypes.DensityOutput;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
 
-@Warmup(iterations = 5)
-@Measurement(iterations = 10)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
 @Fork(value = 1)
 @State(Scope.Thread)
 public class RandomCutForestBenchmark {
@@ -43,14 +43,14 @@ public class RandomCutForestBenchmark {
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
-        @Param({ "10", "20" })
+        @Param({ "10" })
         int dimensions;
 
-        @Param({ "100" })
+        @Param({ "50" })
         int numberOfTrees;
 
-        @Param({ "false" })
-        boolean parallelExecutionEnabled;
+        @Param({ "false", "true" })
+        boolean compact;
 
         double[][] data;
         RandomCutForest forest;
@@ -64,7 +64,7 @@ public class RandomCutForestBenchmark {
         @Setup(Level.Invocation)
         public void setUpForest() {
             forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).dimensions(dimensions)
-                    .parallelExecutionEnabled(parallelExecutionEnabled).compact(true).randomSeed(99).build();
+                    .parallelExecutionEnabled(false).compact(compact).randomSeed(99).build();
         }
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/DynamicScoringRandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/DynamicScoringRandomCutForest.java
@@ -91,8 +91,8 @@ public class DynamicScoringRandomCutForest extends RandomCutForest {
             return 0.0;
         }
 
-        VisitorFactory<Double> visitorFactory = tree -> new DynamicScoreVisitor(point, tree.getMass(),
-                ignoreLeafMassThreshold, seen, unseen, damp);
+        VisitorFactory<Double> visitorFactory = new VisitorFactory<>((tree, y) -> new DynamicScoreVisitor(
+                tree.projectToTree(y), tree.getMass(), ignoreLeafMassThreshold, seen, unseen, damp));
         BinaryOperator<Double> accumulator = Double::sum;
 
         Function<Double, Double> finisher = sum -> sum / numberOfTrees;
@@ -130,8 +130,9 @@ public class DynamicScoringRandomCutForest extends RandomCutForest {
             return 0.0;
         }
 
-        VisitorFactory<Double> visitorFactory = tree -> new SimulatedTransductiveScalarScoreVisitor(point,
-                tree.getMass(), seen, unseen, damp, CommonUtils::defaultRCFgVecFunction, vecSep);
+        VisitorFactory<Double> visitorFactory = new VisitorFactory<>(
+                (tree, y) -> new SimulatedTransductiveScalarScoreVisitor(tree.projectToTree(y), tree.getMass(), seen,
+                        unseen, damp, CommonUtils::defaultRCFgVecFunction, vecSep));
         BinaryOperator<Double> accumulator = Double::sum;
 
         Function<Double, Double> finisher = sum -> sum / numberOfTrees;
@@ -170,8 +171,8 @@ public class DynamicScoringRandomCutForest extends RandomCutForest {
             return 0.0;
         }
 
-        VisitorFactory<Double> visitorFactory = tree -> new DynamicScoreVisitor(point, tree.getMass(),
-                ignoreLeafMassThreshold, seen, unseen, damp);
+        VisitorFactory<Double> visitorFactory = new VisitorFactory<>((tree, y) -> new DynamicScoreVisitor(
+                tree.projectToTree(y), tree.getMass(), ignoreLeafMassThreshold, seen, unseen, damp));
 
         ConvergingAccumulator<Double> accumulator = new OneSidedConvergingDoubleAccumulator(highIsCritical, precision,
                 DEFAULT_APPROXIMATE_DYNAMIC_SCORE_MIN_VALUES_ACCEPTED, numberOfTrees);
@@ -201,8 +202,10 @@ public class DynamicScoringRandomCutForest extends RandomCutForest {
             return new DiVector(dimensions);
         }
 
-        VisitorFactory<DiVector> visitorFactory = tree -> new DynamicAttributionVisitor(point, tree.getMass(),
-                ignoreLeafMassThreshold, seen, unseen, newDamp);
+        VisitorFactory<DiVector> visitorFactory = new VisitorFactory<>(
+                (tree, y) -> new DynamicAttributionVisitor(tree.projectToTree(y), tree.getMass(),
+                        ignoreLeafMassThreshold, seen, unseen, newDamp),
+                (tree, x) -> x.lift(tree::liftFromTree));
         BinaryOperator<DiVector> accumulator = DiVector::addToLeft;
         Function<DiVector, DiVector> finisher = x -> x.scale(1.0 / numberOfTrees);
 
@@ -234,8 +237,9 @@ public class DynamicScoringRandomCutForest extends RandomCutForest {
             return new DiVector(dimensions);
         }
 
-        VisitorFactory<DiVector> visitorFactory = tree -> new DynamicAttributionVisitor(point, tree.getMass(),
-                ignoreLeafMassThreshold, seen, unseen, newDamp);
+        VisitorFactory<DiVector> visitorFactory = new VisitorFactory<>((tree, y) -> new DynamicAttributionVisitor(y,
+                tree.getMass(), ignoreLeafMassThreshold, seen, unseen, newDamp),
+                (tree, x) -> x.lift(tree::liftFromTree));
 
         ConvergingAccumulator<DiVector> accumulator = new OneSidedConvergingDiVectorAccumulator(dimensions,
                 highIsCritical, precision, DEFAULT_APPROXIMATE_DYNAMIC_SCORE_MIN_VALUES_ACCEPTED, numberOfTrees);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/MultiVisitorFactory.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/MultiVisitorFactory.java
@@ -15,7 +15,7 @@
 
 package com.amazon.randomcutforest;
 
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import com.amazon.randomcutforest.tree.ITree;
 
@@ -27,6 +27,19 @@ import com.amazon.randomcutforest.tree.ITree;
  * The results from both visitors are combined before returning back up the
  * tree.
  */
-@FunctionalInterface
-public interface MultiVisitorFactory<R> extends Function<ITree<?, ?>, MultiVisitor<R>> {
+
+public class MultiVisitorFactory<R> {
+    public BiFunction<ITree<?, ?>, double[], MultiVisitor<R>> create;
+    public BiFunction<ITree<?, ?>, R, R> liftResult;
+
+    public MultiVisitorFactory(BiFunction<ITree<?, ?>, double[], MultiVisitor<R>> create,
+            BiFunction<ITree<?, ?>, R, R> liftResult) {
+        this.create = create;
+        this.liftResult = liftResult;
+    }
+
+    public MultiVisitorFactory(BiFunction<ITree<?, ?>, double[], MultiVisitor<R>> create) {
+        this.create = create;
+        this.liftResult = (tree, x) -> x;
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/VisitorFactory.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/VisitorFactory.java
@@ -15,13 +15,26 @@
 
 package com.amazon.randomcutforest;
 
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import com.amazon.randomcutforest.tree.ITree;
 
 /**
- * This is the interface for a visitor factory
+ * This is the interface for a visitor factory the factory corresponds to
+ * mapping a (tree,point) pair to a visitor and a mapping for the inverse result
  */
-@FunctionalInterface
-public interface VisitorFactory<R> extends Function<ITree<?, ?>, Visitor<R>> {
+public class VisitorFactory<R> {
+    public BiFunction<ITree<?, ?>, double[], Visitor<R>> create;
+    public BiFunction<ITree<?, ?>, R, R> liftResult;
+
+    public VisitorFactory(BiFunction<ITree<?, ?>, double[], Visitor<R>> create,
+            BiFunction<ITree<?, ?>, R, R> liftResult) {
+        this.create = create;
+        this.liftResult = liftResult;
+    }
+
+    public VisitorFactory(BiFunction<ITree<?, ?>, double[], Visitor<R>> create) {
+        this.create = create;
+        this.liftResult = (tree, x) -> x;
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestTraversalExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestTraversalExecutor.java
@@ -23,7 +23,6 @@ import com.amazon.randomcutforest.ComponentList;
 import com.amazon.randomcutforest.MultiVisitorFactory;
 import com.amazon.randomcutforest.VisitorFactory;
 import com.amazon.randomcutforest.returntypes.ConvergingAccumulator;
-import com.amazon.randomcutforest.tree.RandomCutTree;
 
 public abstract class AbstractForestTraversalExecutor {
 
@@ -60,10 +59,9 @@ public abstract class AbstractForestTraversalExecutor {
     /**
      * Visit each of the trees in the forest and combine the individual results into
      * an aggregate result. A visitor is constructed for each tree using the visitor
-     * factory, and then submitted to
-     * {@link RandomCutTree#traverse(double[], Function)}. The results from
-     * individual trees are collected using the {@link java.util.stream.Collector}
-     * and returned. Trees are visited in parallel using
+     * factory, and then submitted to each tree. The results from individual trees
+     * are collected using the {@link java.util.stream.Collector} and returned.
+     * Trees are visited in parallel using
      * {@link java.util.Collection#parallelStream()}.
      *
      * @param point          The point that defines the traversal path.
@@ -84,11 +82,10 @@ public abstract class AbstractForestTraversalExecutor {
     /**
      * Visit each of the trees in the forest sequentially and combine the individual
      * results into an aggregate result. A visitor is constructed for each tree
-     * using the visitor factory, and then submitted to
-     * {@link RandomCutTree#traverse(double[], Function)}. The results from all the
-     * trees are combined using the {@link ConvergingAccumulator}, and the method
-     * stops visiting trees after convergence is reached. The result is transformed
-     * using the finisher before being returned.
+     * using the visitor factory, and then submitted to each tree. The results from
+     * all the trees are combined using the {@link ConvergingAccumulator}, and the
+     * method stops visiting trees after convergence is reached. The result is
+     * transformed using the finisher before being returned.
      *
      * @param point          The point that defines the traversal path.
      * @param visitorFactory A factory method which is invoked for each tree to

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/ITraversable.java
@@ -15,10 +15,10 @@
 
 package com.amazon.randomcutforest.executor;
 
-import java.util.function.Function;
-
 import com.amazon.randomcutforest.MultiVisitor;
+import com.amazon.randomcutforest.MultiVisitorFactory;
 import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.VisitorFactory;
 import com.amazon.randomcutforest.tree.ITree;
 
 /**
@@ -42,7 +42,7 @@ public interface ITraversable {
      * @return the value of {@link Visitor#getResult()} after visiting each node in
      *         the path.
      */
-    <R> R traverse(double[] point, Function<ITree<?, ?>, Visitor<R>> visitorFactory);
+    <R> R traverse(double[] point, VisitorFactory<R> visitorFactory);
 
     /**
      * Traverse the paths defined by {@code point} and the multi-visitor, and invoke
@@ -65,7 +65,7 @@ public interface ITraversable {
      * @return the value of {@link MultiVisitor#getResult()} after traversing all
      *         paths.
      */
-    <R> R traverseMulti(double[] point, Function<ITree<?, ?>, MultiVisitor<R>> visitorFactory);
+    <R> R traverseMulti(double[] point, MultiVisitorFactory<R> visitorFactory);
 
     /**
      * After a new traversable model is initialized, it will not be able to return

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SamplerPlusTree.java
@@ -18,13 +18,12 @@ package com.amazon.randomcutforest.executor;
 import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import lombok.Getter;
 
 import com.amazon.randomcutforest.IComponentModel;
-import com.amazon.randomcutforest.MultiVisitor;
-import com.amazon.randomcutforest.Visitor;
+import com.amazon.randomcutforest.MultiVisitorFactory;
+import com.amazon.randomcutforest.VisitorFactory;
 import com.amazon.randomcutforest.config.Config;
 import com.amazon.randomcutforest.sampler.ISampled;
 import com.amazon.randomcutforest.sampler.IStreamSampler;
@@ -99,12 +98,12 @@ public class SamplerPlusTree<P, Q> implements IComponentModel<P, Q> {
     }
 
     @Override
-    public <R> R traverse(double[] point, Function<ITree<?, ?>, Visitor<R>> visitorFactory) {
+    public <R> R traverse(double[] point, VisitorFactory<R> visitorFactory) {
         return tree.traverse(point, visitorFactory);
     }
 
     @Override
-    public <R> R traverseMulti(double[] point, Function<ITree<?, ?>, MultiVisitor<R>> visitorFactory) {
+    public <R> R traverseMulti(double[] point, MultiVisitorFactory<R> visitorFactory) {
         return tree.traverseMulti(point, visitorFactory);
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/inspect/NearNeighborVisitor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/inspect/NearNeighborVisitor.java
@@ -79,7 +79,7 @@ public class NearNeighborVisitor implements Visitor<Optional<Neighbor>> {
      */
     @Override
     public void acceptLeaf(INodeView leafNode, int depthOfNode) {
-        double[] leafPoint = leafNode.getLeafPoint();
+        double[] leafPoint = leafNode.getLiftedLeafPoint();
         double distanceSquared = 0.0;
         for (int i = 0; i < leafPoint.length; i++) {
             double diff = queryPoint[i] - leafPoint[i];

--- a/Java/core/src/main/java/com/amazon/randomcutforest/returntypes/DiVector.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/returntypes/DiVector.java
@@ -57,6 +57,20 @@ public class DiVector {
     }
 
     /**
+     * Construct a new DiVector with the given number of spatial dimensions. In the
+     * result, {@link #high} and {@link #low} will each contain this many variates.
+     *
+     * @param high the high vector
+     * @param low  the low vector.
+     */
+    public DiVector(double[] high, double[] low) {
+        checkArgument(high.length == low.length, "dimensions must be equal");
+        this.dimensions = high.length;
+        this.high = Arrays.copyOf(high, high.length);
+        this.low = Arrays.copyOf(low, low.length);
+    }
+
+    /**
      * Create a deep copy of the base DiVector.
      *
      * @param base The DiVector to copy.
@@ -168,5 +182,9 @@ public class DiVector {
             score += high[i] + low[i];
         }
         return score;
+    }
+
+    public DiVector lift(Function<double[], double[]> projection) {
+        return new DiVector(projection.apply(high), projection.apply(low));
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/returntypes/InterpolationMeasure.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/returntypes/InterpolationMeasure.java
@@ -18,6 +18,7 @@ package com.amazon.randomcutforest.returntypes;
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 
+import java.util.function.Function;
 import java.util.stream.Collector;
 
 /**
@@ -144,5 +145,10 @@ public class InterpolationMeasure {
      */
     public InterpolationMeasure scale(double z) {
         return new InterpolationMeasure(sampleSize, measure.scale(z), distances.scale(z), probMass.scale(z));
+    }
+
+    public InterpolationMeasure lift(Function<double[], double[]> projection) {
+        return new InterpolationMeasure(sampleSize, measure.lift(projection), distances.lift(projection),
+                probMass.lift(projection));
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactNodeView.java
@@ -77,6 +77,11 @@ public class CompactNodeView<Point> implements INode<Integer> {
         return tree.getPoint(currentNodeOffset);
     }
 
+    @Override
+    public double[] getLiftedLeafPoint() {
+        return tree.liftFromTree(tree.getPoint(currentNodeOffset));
+    }
+
     public Set<Long> getSequenceIndexes() {
         checkArgument(nodeStore.isLeaf(currentNodeOffset), " not a leaf node");
         return tree.sequenceIndexes[nodeStore.computeLeafIndex(currentNodeOffset)].keySet();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/INodeView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/INodeView.java
@@ -32,6 +32,10 @@ public interface INodeView {
 
     double[] getLeafPoint();
 
+    default double[] getLiftedLeafPoint() {
+        return getLeafPoint();
+    };
+
     Set<Long> getSequenceIndexes();
 
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/ITree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/ITree.java
@@ -28,6 +28,12 @@ import com.amazon.randomcutforest.executor.ITraversable;
 public interface ITree<PointReference, Point> extends ITraversable, IDynamicConfig {
     int getMass();
 
+    double[] projectToTree(double[] point);
+
+    double[] liftFromTree(double[] result);
+
+    public int[] projectMissingIndices(int[] list);
+
     PointReference addPoint(PointReference point, long sequenceIndex);
 
     PointReference deletePoint(PointReference point, long sequenceIndex);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -126,7 +126,7 @@ public class RandomCutForestTest {
         Function<Double, Double> finisher = x -> x / numberOfTrees;
 
         components.forEach(c -> {
-            doReturn(0.0).when(c).traverse(aryEq(point), any(Function.class));
+            doReturn(0.0).when(c).traverse(aryEq(point), any(VisitorFactory.class));
         });
 
         forest.traverseForest(point, TestUtils.DUMMY_GENERIC_VISITOR_FACTORY, accumulator, finisher);
@@ -160,7 +160,7 @@ public class RandomCutForestTest {
         double[] point = { 2.2, -1.1 };
 
         components.forEach(c -> {
-            doReturn(0.0).when(c).traverse(aryEq(point), any(Function.class));
+            doReturn(0.0).when(c).traverse(aryEq(point), any(VisitorFactory.class));
         });
 
         forest.traverseForest(point, TestUtils.DUMMY_GENERIC_VISITOR_FACTORY, TestUtils.SORTED_LIST_COLLECTOR);
@@ -196,7 +196,7 @@ public class RandomCutForestTest {
         Function<Double, Double> finisher = x -> x / accumulator.getValuesAccepted();
 
         components.forEach(c -> {
-            doReturn(0.0).when(c).traverse(aryEq(point), any(Function.class));
+            doReturn(0.0).when(c).traverse(aryEq(point), any(VisitorFactory.class));
         });
 
         forest.traverseForest(point, TestUtils.DUMMY_GENERIC_VISITOR_FACTORY, accumulator, finisher);
@@ -235,7 +235,7 @@ public class RandomCutForestTest {
         Function<Double, Double> finisher = x -> x / numberOfTrees;
 
         components.forEach(c -> {
-            doReturn(0.0).when(c).traverseMulti(aryEq(point), any(Function.class));
+            doReturn(0.0).when(c).traverseMulti(aryEq(point), any(MultiVisitorFactory.class));
         });
 
         forest.traverseForestMulti(point, TestUtils.DUMMY_GENERIC_MULTI_VISITOR_FACTORY, accumulator, finisher);
@@ -269,7 +269,7 @@ public class RandomCutForestTest {
         double[] point = { 2.2, -1.1 };
 
         components.forEach(c -> {
-            doReturn(0.0).when(c).traverseMulti(aryEq(point), any(Function.class));
+            doReturn(0.0).when(c).traverseMulti(aryEq(point), any(MultiVisitorFactory.class));
         });
 
         forest.traverseForestMulti(point, TestUtils.DUMMY_GENERIC_MULTI_VISITOR_FACTORY,
@@ -310,7 +310,7 @@ public class RandomCutForestTest {
             SamplerPlusTree<double[], double[]> component = (SamplerPlusTree<double[], double[]>) components.get(i);
             ITree<double[], double[]> tree = component.getTree();
             double treeResult = Math.random();
-            when(tree.traverse(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverse(aryEq(point), any(VisitorFactory.class))).thenReturn(treeResult);
 
             when(tree.getMass()).thenReturn(256);
 
@@ -339,7 +339,7 @@ public class RandomCutForestTest {
             SamplerPlusTree<double[], double[]> component = (SamplerPlusTree<double[], double[]>) components.get(i);
             ITree<double[], double[]> tree = component.getTree();
             double treeResult = Math.random();
-            when(tree.traverse(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverse(aryEq(point), any(VisitorFactory.class))).thenReturn(treeResult);
 
             when(tree.getMass()).thenReturn(256);
 
@@ -374,7 +374,7 @@ public class RandomCutForestTest {
 
             SamplerPlusTree<double[], double[]> component = (SamplerPlusTree<double[], double[]>) components.get(i);
             ITree<double[], double[]> tree = component.getTree();
-            when(tree.traverse(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverse(aryEq(point), any(VisitorFactory.class))).thenReturn(treeResult);
 
             when(tree.getMass()).thenReturn(256);
 
@@ -414,7 +414,7 @@ public class RandomCutForestTest {
                 treeResult.low[j] = Math.random();
             }
 
-            when(tree.traverse(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverse(aryEq(point), any(VisitorFactory.class))).thenReturn(treeResult);
 
             when(tree.getMass()).thenReturn(256);
 
@@ -453,7 +453,7 @@ public class RandomCutForestTest {
 
             SamplerPlusTree<double[], double[]> component = (SamplerPlusTree<double[], double[]>) components.get(i);
             ITree<double[], double[]> tree = component.getTree();
-            when(tree.traverse(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverse(aryEq(point), any(VisitorFactory.class))).thenReturn(treeResult);
             intermediateResults.add(treeResult);
         }
 
@@ -520,7 +520,7 @@ public class RandomCutForestTest {
             ITree<double[], double[]> tree = component.getTree();
             double[] treeResult = Arrays.copyOf(point, point.length);
             treeResult[missingIndexes[0]] = returnValues.get(i);
-            when(tree.traverseMulti(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverseMulti(aryEq(point), any(MultiVisitorFactory.class))).thenReturn(treeResult);
         }
 
         doReturn(true).when(forest).isOutputReady();
@@ -555,7 +555,7 @@ public class RandomCutForestTest {
             SamplerPlusTree<double[], double[]> component = (SamplerPlusTree<double[], double[]>) components.get(i);
             ITree<double[], double[]> tree = component.getTree();
             double[] treeResult = { Math.random(), Math.random() };
-            when(tree.traverseMulti(aryEq(point), any(Function.class))).thenReturn(treeResult);
+            when(tree.traverseMulti(aryEq(point), any(MultiVisitorFactory.class))).thenReturn(treeResult);
 
             double anomalyScore = anomalyScores.get(i);
             doReturn(anomalyScore).when(forest).getAnomalyScore(aryEq(treeResult));
@@ -703,27 +703,27 @@ public class RandomCutForestTest {
         indexes5.add(4L);
 
         Neighbor neighbor1 = new Neighbor(new double[] { 1, 2 }, 5, indexes1);
-        when(((SamplerPlusTree<?, ?>) components.get(0)).getTree().traverse(any(double[].class), any(Function.class)))
-                .thenReturn(Optional.of(neighbor1));
+        when(((SamplerPlusTree<?, ?>) components.get(0)).getTree().traverse(any(double[].class),
+                any(VisitorFactory.class))).thenReturn(Optional.of(neighbor1));
 
         Neighbor neighbor2 = new Neighbor(new double[] { 1, 2 }, 5, indexes2);
-        when(((SamplerPlusTree<?, ?>) components.get(1)).getTree().traverse(any(double[].class), any(Function.class)))
-                .thenReturn(Optional.of(neighbor2));
+        when(((SamplerPlusTree<?, ?>) components.get(1)).getTree().traverse(any(double[].class),
+                any(VisitorFactory.class))).thenReturn(Optional.of(neighbor2));
 
-        when(((SamplerPlusTree<?, ?>) components.get(2)).getTree().traverse(any(double[].class), any(Function.class)))
-                .thenReturn(Optional.empty());
+        when(((SamplerPlusTree<?, ?>) components.get(2)).getTree().traverse(any(double[].class),
+                any(VisitorFactory.class))).thenReturn(Optional.empty());
 
         Neighbor neighbor4 = new Neighbor(new double[] { 2, 3 }, 4, indexes4);
-        when(((SamplerPlusTree<?, ?>) components.get(3)).getTree().traverse(any(double[].class), any(Function.class)))
-                .thenReturn(Optional.of(neighbor4));
+        when(((SamplerPlusTree<?, ?>) components.get(3)).getTree().traverse(any(double[].class),
+                any(VisitorFactory.class))).thenReturn(Optional.of(neighbor4));
 
         Neighbor neighbor5 = new Neighbor(new double[] { 2, 3 }, 4, indexes5);
-        when(((SamplerPlusTree<?, ?>) components.get(4)).getTree().traverse(any(double[].class), any(Function.class)))
-                .thenReturn(Optional.of(neighbor5));
+        when(((SamplerPlusTree<?, ?>) components.get(4)).getTree().traverse(any(double[].class),
+                any(VisitorFactory.class))).thenReturn(Optional.of(neighbor5));
 
         for (int i = 5; i < components.size(); i++) {
             when(((SamplerPlusTree<?, ?>) components.get(i)).getTree().traverse(any(double[].class),
-                    any(Function.class))).thenReturn(Optional.empty());
+                    any(VisitorFactory.class))).thenReturn(Optional.empty());
         }
 
         Whitebox.setInternalState(forest, "storeSequenceIndexesEnabled", true);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/TestUtils.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/TestUtils.java
@@ -30,30 +30,17 @@ public class TestUtils {
     /**
      * Return a visitor that does nothing.
      */
-    public static final Function<RandomCutTree, Visitor<Double>> DUMMY_VISITOR_FACTORY = tree -> new Visitor<Double>() {
-        @Override
-        public void accept(INodeView node, int depthOfNode) {
-        }
+    public static final VisitorFactory<Double> DUMMY_GENERIC_VISITOR_FACTORY = new VisitorFactory<Double>(
+            (tree, x) -> new Visitor<Double>() {
+                @Override
+                public void accept(INodeView node, int depthOfNode) {
+                }
 
-        @Override
-        public Double getResult() {
-            return Double.NaN;
-        }
-    };
-
-    /**
-     * Return a visitor that does nothing.
-     */
-    public static final VisitorFactory<Double> DUMMY_GENERIC_VISITOR_FACTORY = tree -> new Visitor<Double>() {
-        @Override
-        public void accept(INodeView node, int depthOfNode) {
-        }
-
-        @Override
-        public Double getResult() {
-            return Double.NaN;
-        }
-    };
+                @Override
+                public Double getResult() {
+                    return Double.NaN;
+                }
+            });
 
     /**
      * Return a multi-visitor that does nothing.
@@ -135,28 +122,29 @@ public class TestUtils {
     /**
      * Return a multi-visitor that does nothing.
      */
-    public static final MultiVisitorFactory<Double> DUMMY_GENERIC_MULTI_VISITOR_FACTORY = tree -> new MultiVisitor<Double>() {
-        @Override
-        public void accept(INodeView node, int depthOfNode) {
-        }
+    public static final MultiVisitorFactory<Double> DUMMY_GENERIC_MULTI_VISITOR_FACTORY = new MultiVisitorFactory<>(
+            (tree, y) -> new MultiVisitor<Double>() {
+                @Override
+                public void accept(INodeView node, int depthOfNode) {
+                }
 
-        @Override
-        public Double getResult() {
-            return Double.NaN;
-        }
+                @Override
+                public Double getResult() {
+                    return Double.NaN;
+                }
 
-        @Override
-        public boolean trigger(INodeView node) {
-            return false;
-        }
+                @Override
+                public boolean trigger(INodeView node) {
+                    return false;
+                }
 
-        @Override
-        public MultiVisitor<Double> newCopy() {
-            return null;
-        }
+                @Override
+                public MultiVisitor<Double> newCopy() {
+                    return null;
+                }
 
-        @Override
-        public void combine(MultiVisitor<Double> other) {
-        }
-    };
+                @Override
+                public void combine(MultiVisitor<Double> other) {
+                }
+            });
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/TransductiveHyperForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/TransductiveHyperForestFunctionalTest.java
@@ -32,7 +32,6 @@ import com.amazon.randomcutforest.anomalydetection.TransductiveScalarScoreVisito
 import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
 import com.amazon.randomcutforest.tree.HyperTree;
 import com.amazon.randomcutforest.tree.IBoundingBoxView;
-import com.amazon.randomcutforest.tree.ITree;
 
 @Tag("functional")
 public class TransductiveHyperForestFunctionalTest {
@@ -160,8 +159,9 @@ public class TransductiveHyperForestFunctionalTest {
 
             checkArgument(dimensions == point.length, "incorrect dimensions");
 
-            Function<ITree<?, ?>, Visitor<Double>> visitorFactory = tree -> new TransductiveScalarScoreVisitor(point,
-                    tree.getMass(), seen, unseen, newDamp, ((HyperTree) tree).getgVec());
+            VisitorFactory<Double> visitorFactory = new VisitorFactory<>(
+                    (tree, y) -> new TransductiveScalarScoreVisitor(tree.projectToTree(y), tree.getMass(), seen, unseen,
+                            newDamp, ((HyperTree) tree).getgVec()));
             BinaryOperator<Double> accumulator = Double::sum;
 
             Function<Double, Double> finisher = sum -> sum / numberOfTrees;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/imputation/ImputeVisitorTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/imputation/ImputeVisitorTest.java
@@ -18,7 +18,10 @@ package com.amazon.randomcutforest.imputation;
 import static com.amazon.randomcutforest.CommonUtils.defaultScoreSeenFunction;
 import static com.amazon.randomcutforest.CommonUtils.defaultScoreUnseenFunction;
 import static com.amazon.randomcutforest.TestUtils.EPSILON;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -169,7 +172,7 @@ public class ImputeVisitorTest {
     @Test
     public void testMerge() {
         double[] otherPoint = new double[] { 99, 100, 101 };
-        ImputeVisitor other = new ImputeVisitor(otherPoint, 0, null);
+        ImputeVisitor other = new ImputeVisitor(otherPoint, 0, new int[0]);
 
         // set other.rank to a small value
         Node node = new Node(new double[] { 0, 0, 0 });


### PR DESCRIPTION


*Description of changes:* fixing the evaluation pipeline to have visitors based on both the tree and the point to be evaluated. This enables different trees to be able to operate on different projections of data
