### PR TITLE
Multiple small changes

### DIFF
--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>1.0-alpha</version>
+    <version>2.0</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.randomcutforest</groupId>
-      <artifactId>randomcutforest-serialization-json</artifactId>
+      <artifactId>randomcutforest-serialization</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/Java/core/pom.xml
+++ b/Java/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>1.0-alpha</version>
+    <version>2.0</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -110,7 +110,7 @@ public class RandomCutForest {
     /**
      * By default, trees will not create indexed references.
      */
-    public static final boolean DEFAULT_COMPACT = false;
+    public static final boolean DEFAULT_COMPACT = true;
 
     /**
      * By default, trees will accept every point until full.
@@ -237,6 +237,11 @@ public class RandomCutForest {
      * Number of threads to use in the thread pool if parallel execution is enabled.
      */
     protected final int threadPoolSize;
+    /**
+     * A string to define an "execution mode" that can be used to set multiple
+     * configuration options. This field is not currently in use.
+     */
+    protected String mode;
 
     protected IStateCoordinator<?, ?> stateCoordinator;
     protected ComponentList<?, ?> components;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/ExecutionContext.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/ExecutionContext.java
@@ -22,7 +22,9 @@ public class ExecutionContext {
     private boolean parallelExecutionEnabled;
     private int threadPoolSize;
 
-    // A placeholder field representing an execution mode that can be used to group
-    // together runtime configuration options.
+    /**
+     * A string to define an "execution mode" that can be used to set multiple
+     * configuration options. This field is not currently in use.
+     */
     private String mode;
 }

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>1.0-alpha</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>randomcutforest-examples</artifactId>

--- a/Java/license-header
+++ b/Java/license-header
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>1.0-alpha</version>
+    <version>2.0</version>
     <packaging>pom</packaging>
 
     <name>software.amazon.randomcutforest:randomcutforest</name>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>1.0-alpha</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>randomcutforest-serialization</artifactId>

--- a/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV2StateConverter.java
+++ b/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV2StateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,6 +15,13 @@
 
 package com.amazon.randomcutforest.serialize.json.v1;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.ExecutionContext;
 import com.amazon.randomcutforest.state.RandomCutForestState;
@@ -24,13 +31,6 @@ import com.amazon.randomcutforest.state.store.PointStoreState;
 import com.amazon.randomcutforest.store.PointStoreDouble;
 import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class V1JsonToV2StateConverter {
 
@@ -93,7 +93,6 @@ public class V1JsonToV2StateConverter {
         private final PointStoreDouble pointStore;
         private final List<CompactSamplerState> compactSamplerStates;
 
-
         public SamplerConverter(int dimensions, int capacity) {
             pointStore = new PointStoreDouble(dimensions, capacity);
             compactSamplerStates = new ArrayList<>();
@@ -106,7 +105,8 @@ public class V1JsonToV2StateConverter {
         public void addSampler(V1SerializedRandomCutForest.Sampler sampler) {
             V1SerializedRandomCutForest.WeightedSamples[] samples = sampler.getWeightedSamples();
             CompactRandomCutTreeDouble tree = new CompactRandomCutTreeDouble.Builder().pointStore(pointStore)
-                    .storeSequenceIndexesEnabled(false).centerOfMassEnabled(false).boundingBoxCacheFraction(1.0).build();
+                    .storeSequenceIndexesEnabled(false).centerOfMassEnabled(false).boundingBoxCacheFraction(1.0)
+                    .build();
             int[] pointIndex = new int[samples.length];
             float[] weight = new float[samples.length];
             long[] sequenceIndex = new long[samples.length];
@@ -115,8 +115,8 @@ public class V1JsonToV2StateConverter {
                 V1SerializedRandomCutForest.WeightedSamples sample = samples[i];
                 double[] point = sample.getPoint();
                 int index = pointStore.add(point, sample.getSequenceIndex());
-                pointIndex[i] = tree.addPoint(index,0L);
-                if (pointIndex[i] != index){
+                pointIndex[i] = tree.addPoint(index, 0L);
+                if (pointIndex[i] != index) {
                     pointStore.incrementRefCount(pointIndex[i]);
                     pointStore.decrementRefCount(index);
                 }

--- a/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1SerializedRandomCutForest.java
+++ b/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1SerializedRandomCutForest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/Java/serialization/src/test/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonResource.java
+++ b/Java/serialization/src/test/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/Java/serialization/src/test/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV2StateConverterTest.java
+++ b/Java/serialization/src/test/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV2StateConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,12 +15,9 @@
 
 package com.amazon.randomcutforest.serialize.json.v1;
 
-import com.amazon.randomcutforest.RandomCutForest;
-import com.amazon.randomcutforest.state.RandomCutForestMapper;
-import com.amazon.randomcutforest.state.RandomCutForestState;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,9 +26,13 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.state.RandomCutForestMapper;
+import com.amazon.randomcutforest.state.RandomCutForestState;
 
 public class V1JsonToV2StateConverterTest {
 
@@ -61,17 +62,18 @@ public class V1JsonToV2StateConverterTest {
             assertEquals(jsonResource.getDimensions(), state.getDimensions());
             assertEquals(jsonResource.getNumberOfTrees(), state.getNumberOfTrees());
             assertEquals(jsonResource.getSampleSize(), state.getSampleSize());
-            RandomCutForest forest = new RandomCutForestMapper().toModel(state,0);
+            RandomCutForest forest = new RandomCutForestMapper().toModel(state, 0);
 
             assertEquals(jsonResource.getDimensions(), forest.getDimensions());
             assertEquals(jsonResource.getNumberOfTrees(), forest.getNumberOfTrees());
             assertEquals(jsonResource.getSampleSize(), forest.getSampleSize());
 
-            // perform a simple validation of the deserialized forest by update and scoring with a few points
+            // perform a simple validation of the deserialized forest by update and scoring
+            // with a few points
 
             Random random = new Random(0);
             for (int i = 0; i < 10; i++) {
-                double[] point = getPoint(jsonResource.getDimensions(),random);
+                double[] point = getPoint(jsonResource.getDimensions(), random);
                 double score = forest.getAnomalyScore(point);
                 assertTrue(score > 0);
                 forest.update(point);

--- a/Java/testutils/pom.xml
+++ b/Java/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>1.0-alpha</version>
+    <version>2.0</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION
- Update version number to 2.0
- Make compact mode the default
- Add a placeholder "mode" string to RandomCutForest for forward
  compatibility.
- Change license header back to using 2020 until we decide what to do
  about spotless configuration. We don't want to update every existing
  source fill to 2021.

Closes #130
Closes #209
Closes #212


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
