### PR TITLE
Rename remaining occurrences of lambda to timeDecay

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
@@ -77,7 +77,7 @@ public class ForestUpdateExecutorBenchmark {
         public void setUpExecutor() {
 
             int sampleSize = RandomCutForest.DEFAULT_SAMPLE_SIZE;
-            double lambda = 1.0 / (sampleSize * RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_LAMBDA);
+            double lambda = 1.0 / (sampleSize * RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_TIME_DECAY);
             int threadPoolSize = 4;
             Random random = new Random();
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/runner/ArgumentParser.java
@@ -215,9 +215,9 @@ public class ArgumentParser {
     }
 
     /**
-     * @return the user-specified value of the lambda parameter
+     * @return the user-specified value of the time-decay parameter
      */
-    public double getLambda() {
+    public double getTimeDecay() {
         if (getWindowSize() > 0) {
             return 1.0 / getWindowSize();
         } else {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/runner/SimpleRunner.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/runner/SimpleRunner.java
@@ -122,7 +122,7 @@ public class SimpleRunner {
 
         RandomCutForest forest = RandomCutForest.builder().numberOfTrees(argumentParser.getNumberOfTrees())
                 .sampleSize(argumentParser.getSampleSize()).dimensions(shingleBuilder.getShingledPointSize())
-                .lambda(argumentParser.getLambda()).randomSeed(argumentParser.getRandomSeed()).build();
+                .timeDecay(argumentParser.getTimeDecay()).randomSeed(argumentParser.getRandomSeed()).build();
 
         algorithm = algorithmInitializer.apply(forest);
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
@@ -27,7 +27,7 @@ import com.amazon.randomcutforest.config.Config;
 public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
     /**
      * The decay factor used for generating the weight of the point. For greater
-     * values of lambda we become more biased in favor of recent points.
+     * values of timeDecay we become more biased in favor of recent points.
      */
     protected double timeDecay;
 
@@ -38,12 +38,12 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
     protected long mostRecentTimeDecayUpdate = 0;
 
     /**
-     * most recent timestamp, used to determine lastUpdateOfLambda
+     * most recent timestamp, used to determine lastUpdateOfTimeDecay
      */
     protected long maxSequenceIndex = 0;
 
     /**
-     * The accumulated sum of lambda before the last update
+     * The accumulated sum of timeDecay before the last update
      */
     protected double accumuluatedTimeDecay = 0;
 
@@ -99,7 +99,7 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
      * Weight is computed as <code>-log(w(i)) + log(-log(u(i))</code>, where
      *
      * <ul>
-     * <li><code>w(i) = exp(lambda * sequenceIndex)</code></li>
+     * <li><code>w(i) = exp(timeDecay * sequenceIndex)</code></li>
      * <li><code>u(i)</code> is chosen uniformly from (0, 1)</li>
      * </ul>
      * <p>
@@ -121,26 +121,26 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
     }
 
     /**
-     * sets the lambda on the fly. Note that the assumption is that the times stamps
-     * corresponding to changes to lambda and sequenceIndexes are non-decreasing --
-     * the sequenceIndexes can be out of order among themselves within two different
-     * times when lambda was changed.
+     * Sets the timeDecay on the fly. Note that the assumption is that the times
+     * stamps corresponding to changes to timeDecay and sequenceIndexes are
+     * non-decreasing -- the sequenceIndexes can be out of order among themselves
+     * within two different times when timeDecay was changed.
      * 
-     * @param newLambda the new sampling rate
+     * @param newTimeDecay the new sampling rate
      */
-    public void setTimeDecay(double newLambda) {
-        // accumulatedLambda keeps track of adjustments and is zeroed out when the
-        // arrays are
-        // exported for some reason
+    public void setTimeDecay(double newTimeDecay) {
+        // accumulatedTimeDecay keeps track of adjustments and is zeroed out when the
+        // arrays are exported for some reason
         accumuluatedTimeDecay += (maxSequenceIndex - mostRecentTimeDecayUpdate) * timeDecay;
-        timeDecay = newLambda;
+        timeDecay = newTimeDecay;
         mostRecentTimeDecayUpdate = maxSequenceIndex;
     }
 
     /**
-     * @return the lambda value that determines the rate of decay of previously seen
-     *         points. Larger values of lambda indicate a greater bias toward recent
-     *         points. A value of 0 corresponds to a uniform sample over the stream.
+     * @return the time decay value that determines the rate of decay of previously
+     *         seen points. Larger values of time decay indicate a greater bias
+     *         toward recent points. A value of 0 corresponds to a uniform sample
+     *         over the stream.
      */
     public double getTimeDecay() {
         return timeDecay;
@@ -233,7 +233,7 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
         protected Random random = null;
         protected long randomSeed = new Random().nextLong();
         protected long maxSequenceIndex = 0;
-        protected long sequenceIndexOfMostRecentLambdaUpdate = 0;
+        protected long sequenceIndexOfMostRecentTimeDecayUpdate = 0;
         protected double initialAcceptFraction = DEFAULT_INITIAL_ACCEPT_FRACTION;
 
         public T capacity(int capacity) {
@@ -257,7 +257,7 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
         }
 
         public T mostRecentTimeDecayUpdate(long sequenceIndexOfMostRecentTimeDecayUpdate) {
-            this.sequenceIndexOfMostRecentLambdaUpdate = sequenceIndexOfMostRecentTimeDecayUpdate;
+            this.sequenceIndexOfMostRecentTimeDecayUpdate = sequenceIndexOfMostRecentTimeDecayUpdate;
             return (T) this;
         }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -51,7 +51,7 @@ import java.util.stream.Stream;
  * </ol>
  * <p>
  * The coefficient function used by CompactSampler is:
- * <code>c(i) = exp(lambda * sequenceIndex(i))</code>.
+ * <code>c(i) = exp(timeDecay * sequenceIndex(i))</code>.
  * </p>
  * <p>
  * Note that the sampling algorithm used is the same as for
@@ -228,8 +228,8 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
     }
 
     /**
-     * removes the adjustments to weight in accumulated lambda and resets the
-     * updates to lambda
+     * removes the adjustments to weight in accumulated timeDecay and resets the
+     * updates to timeDecay
      */
     private void reset_weights() {
         if (accumuluatedTimeDecay == 0)
@@ -345,7 +345,7 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         this.storeSequenceIndexesEnabled = builder.storeSequenceIndexesEnabled;
         this.timeDecay = builder.timeDecay;
         this.maxSequenceIndex = builder.maxSequenceIndex;
-        this.mostRecentTimeDecayUpdate = builder.sequenceIndexOfMostRecentLambdaUpdate;
+        this.mostRecentTimeDecayUpdate = builder.sequenceIndexOfMostRecentTimeDecayUpdate;
 
         if (builder.weight != null || builder.pointIndex != null || builder.sequenceIndex != null
                 || builder.validateHeap) {
@@ -372,18 +372,18 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         }
     }
 
-    public CompactSampler(int sampleSize, double lambda, Random random, boolean storeSequences) {
-        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(lambda)
+    public CompactSampler(int sampleSize, double timeDecay, Random random, boolean storeSequences) {
+        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(timeDecay)
                 .random(random));
     };
 
-    public CompactSampler(int sampleSize, double lambda, long randomSeed, boolean storeSequences) {
-        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(lambda)
+    public CompactSampler(int sampleSize, double timeDecay, long randomSeed, boolean storeSequences) {
+        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(timeDecay)
                 .randomSeed(randomSeed));
     };
 
-    public CompactSampler(int sampleSize, double lambda, long randomSeed, boolean storeSequences, double fraction) {
-        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(lambda)
+    public CompactSampler(int sampleSize, double timeDecay, long randomSeed, boolean storeSequences, double fraction) {
+        this(new Builder<>().capacity(sampleSize).storeSequenceIndexesEnabled(storeSequences).timeDecay(timeDecay)
                 .randomSeed(randomSeed).initialAcceptFraction(fraction));
     };
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -50,7 +50,7 @@ import java.util.Random;
  * </ol>
  * <p>
  * The coefficient function used by SimpleStreamSampler is:
- * <code>c(i) = exp(lambda * sequenceIndex(i))</code>.
+ * <code>c(i) = exp(timeDecay * sequenceIndex(i))</code>.
  * </p>
  * <p>
  * For a specialized version of this algorithm that uses less runtime memory,
@@ -72,16 +72,16 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         this.timeDecay = builder.timeDecay;
     }
 
-    public SimpleStreamSampler(int sampleSize, double lambda, long seed, boolean storeSequenceIndexesEnabled) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(lambda).randomSeed(seed));
+    public SimpleStreamSampler(int sampleSize, double timeDecay, long seed, boolean storeSequenceIndexesEnabled) {
+        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).randomSeed(seed));
     }
 
-    public SimpleStreamSampler(int sampleSize, double lambda, Random random, boolean storeSequenceIndexesEnabled) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(lambda).random(random));
+    public SimpleStreamSampler(int sampleSize, double timeDecay, Random random, boolean storeSequenceIndexesEnabled) {
+        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).random(random));
     }
 
-    public SimpleStreamSampler(int sampleSize, double lambda, long seed) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(lambda).randomSeed(seed));
+    public SimpleStreamSampler(int sampleSize, double timeDecay, long seed) {
+        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).randomSeed(seed));
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
@@ -131,7 +131,7 @@ public class RandomCutForestMapper
 
         state.setNumberOfTrees(forest.getNumberOfTrees());
         state.setDimensions(forest.getDimensions());
-        state.setTimeDecay(forest.getLambda());
+        state.setTimeDecay(forest.getTimeDecay());
         state.setSampleSize(forest.getSampleSize());
         state.setShingleSize(forest.getShingleSize());
         state.setCenterOfMassEnabled(forest.isCenterOfMassEnabled());
@@ -263,7 +263,7 @@ public class RandomCutForestMapper
         }
 
         RandomCutForest.Builder<?> builder = RandomCutForest.builder().numberOfTrees(state.getNumberOfTrees())
-                .dimensions(state.getDimensions()).lambda(state.getTimeDecay()).sampleSize(state.getSampleSize())
+                .dimensions(state.getDimensions()).timeDecay(state.getTimeDecay()).sampleSize(state.getSampleSize())
                 .centerOfMassEnabled(state.isCenterOfMassEnabled()).outputAfter(state.getOutputAfter())
                 .parallelExecutionEnabled(ec.isParallelExecutionEnabled()).threadPoolSize(ec.getThreadPoolSize())
                 .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled()).shingleSize(state.getShingleSize())

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/sampler/CompactSamplerState.java
@@ -64,7 +64,7 @@ public class CompactSamplerState {
      */
     private double timeDecay;
     /**
-     * Last update of lambda
+     * Last update of timeDecay
      */
     private long sequenceIndexOfMostRecentTimeDecayUpdate;
     /**

--- a/Java/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/AttributionExamplesFunctionalTest.java
@@ -162,7 +162,7 @@ public class AttributionExamplesFunctionalTest {
         sampleSize = 256;
         DynamicScoringRandomCutForest newForest = DynamicScoringRandomCutForest.builder().numberOfTrees(100)
                 .sampleSize(sampleSize).dimensions(newDimensions).randomSeed(randomSeed).compact(true)
-                .boundingBoxCacheFraction(1.0).lambda(1e-5).build();
+                .boundingBoxCacheFraction(1.0).timeDecay(1e-5).build();
 
         dataSize = 2000 + 5;
 

--- a/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/CompactRandomCutForestFunctionalTest.java
@@ -503,7 +503,7 @@ public class CompactRandomCutForestFunctionalTest {
         randomSeed = 123;
 
         RandomCutForest newForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).compact(true).lambda(1e-5).build();
+                .dimensions(dimensions).randomSeed(randomSeed).compact(true).timeDecay(1e-5).build();
 
         dataSize = 10_000;
 

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
@@ -45,7 +45,7 @@ public class RandomCutForestBuilderTest {
         threadPoolSize = 9;
 
         forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize).outputAfter(outputAfter)
-                .dimensions(dimensions).lambda(lambda).randomSeed(randomSeed).storeSequenceIndexesEnabled(true)
+                .dimensions(dimensions).timeDecay(lambda).randomSeed(randomSeed).storeSequenceIndexesEnabled(true)
                 .centerOfMassEnabled(true).parallelExecutionEnabled(true).threadPoolSize(threadPoolSize).build();
     }
 
@@ -55,7 +55,7 @@ public class RandomCutForestBuilderTest {
         assertEquals(sampleSize, forest.getSampleSize());
         assertEquals(outputAfter, forest.getOutputAfter());
         assertEquals(dimensions, forest.getDimensions());
-        assertEquals(lambda, forest.getLambda());
+        assertEquals(lambda, forest.getTimeDecay());
         assertTrue(forest.isStoreSequenceIndexesEnabled());
         assertTrue(forest.isCenterOfMassEnabled());
         assertTrue(forest.isParallelExecutionEnabled());
@@ -101,13 +101,13 @@ public class RandomCutForestBuilderTest {
     @Test
     public void testForestBuilderWithDefaultParallelExecutionThreadPoolSize() {
         RandomCutForest forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .outputAfter(outputAfter).dimensions(dimensions).lambda(lambda).randomSeed(randomSeed)
+                .outputAfter(outputAfter).dimensions(dimensions).timeDecay(lambda).randomSeed(randomSeed)
                 .storeSequenceIndexesEnabled(true).centerOfMassEnabled(true).parallelExecutionEnabled(true).build();
         assertEquals(numberOfTrees, forest.getNumberOfTrees());
         assertEquals(sampleSize, forest.getSampleSize());
         assertEquals(outputAfter, forest.getOutputAfter());
         assertEquals(dimensions, forest.getDimensions());
-        assertEquals(lambda, forest.getLambda());
+        assertEquals(lambda, forest.getTimeDecay());
         assertTrue(forest.isStoreSequenceIndexesEnabled());
         assertTrue(forest.isCenterOfMassEnabled());
         assertTrue(forest.isParallelExecutionEnabled());
@@ -117,44 +117,44 @@ public class RandomCutForestBuilderTest {
     @Test
     public void testForestBuilderWithDefaultLambdaValue() {
         RandomCutForest forest = RandomCutForest.builder().dimensions(4).sampleSize(sampleSize).build();
-        assertEquals(1.0 / (RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_LAMBDA * sampleSize),
-                forest.getLambda());
+        assertEquals(1.0 / (RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_TIME_DECAY * sampleSize),
+                forest.getTimeDecay());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenNumberOfTreesIsZero() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(0)
-                .sampleSize(sampleSize).dimensions(dimensions).lambda(lambda).build());
+                .sampleSize(sampleSize).dimensions(dimensions).timeDecay(lambda).build());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenSampleSizeIsZero() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(0).dimensions(dimensions).lambda(lambda).build());
+                .sampleSize(0).dimensions(dimensions).timeDecay(lambda).build());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenOutputAfterIsNegative() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(sampleSize).outputAfter(-10).dimensions(dimensions).lambda(lambda).build());
+                .sampleSize(sampleSize).outputAfter(-10).dimensions(dimensions).timeDecay(lambda).build());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenOutputAfterIsGreaterThanSample() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(sampleSize).outputAfter(sampleSize + 1).dimensions(dimensions).lambda(lambda).build());
+                .sampleSize(sampleSize).outputAfter(sampleSize + 1).dimensions(dimensions).timeDecay(lambda).build());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenDimensionIsNotProvided() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(sampleSize).lambda(lambda).build());
+                .sampleSize(sampleSize).timeDecay(lambda).build());
     }
 
     @Test
     public void testIllegalExceptionIsThrownWhenLambdaIsNegative() {
         assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(sampleSize).dimensions(dimensions).lambda(-0.1).build());
+                .sampleSize(sampleSize).dimensions(dimensions).timeDecay(-0.1).build());
     }
 
     @Test

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestFunctionalTest.java
@@ -452,7 +452,7 @@ public class RandomCutForestFunctionalTest {
         randomSeed = 123;
 
         RandomCutForest newForest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(dimensions).randomSeed(randomSeed).centerOfMassEnabled(true).lambda(1e-5)
+                .dimensions(dimensions).randomSeed(randomSeed).centerOfMassEnabled(true).timeDecay(1e-5)
                 .storeSequenceIndexesEnabled(true).build();
 
         dataSize = 10_000;
@@ -682,11 +682,11 @@ public class RandomCutForestFunctionalTest {
         // subsequent inputs and test adaptation to stream evolution
 
         RandomCutForest newforestC = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).centerOfMassEnabled(true).lambda(1.0 / 300)
+                .dimensions(shinglesize).randomSeed(randomSeed).centerOfMassEnabled(true).timeDecay(1.0 / 300)
                 .storeSequenceIndexesEnabled(true).build();
 
         RandomCutForest newforestD = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).centerOfMassEnabled(true).lambda(1.0 / 300)
+                .dimensions(shinglesize).randomSeed(randomSeed).centerOfMassEnabled(true).timeDecay(1.0 / 300)
                 .storeSequenceIndexesEnabled(true).build();
 
         double amplitude = 50.0;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -770,7 +770,7 @@ public class RandomCutForestTest {
     public void testUpdateOnSmallBoundingBox() {
         // verifies on small bounding boxes random cuts and tree updates are functional
         RandomCutForest.Builder forestBuilder = RandomCutForest.builder().dimensions(1).numberOfTrees(1).sampleSize(3)
-                .lambda(0.5).randomSeed(0).parallelExecutionEnabled(false);
+                .timeDecay(0.5).randomSeed(0).parallelExecutionEnabled(false);
 
         RandomCutForest forest = forestBuilder.build();
         double[][] data = new double[][] { { 48.08 }, { 48.08000000000001 } };

--- a/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/ShinglingFunctionalTest.java
@@ -295,10 +295,10 @@ public class ShinglingFunctionalTest {
         // subsequent inputs and test adaptation to stream evolution
 
         RandomCutForest newforestC = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).lambda(1.0 / 300).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).timeDecay(1.0 / 300).build();
 
         RandomCutForest newforestD = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
-                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).lambda(1.0 / 300).build();
+                .dimensions(shinglesize).randomSeed(randomSeed).compact(true).timeDecay(1.0 / 300).build();
 
         double amplitude = 50.0;
         double noise = 2.0;

--- a/Java/core/src/test/java/com/amazon/randomcutforest/runner/ArgumentParserTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/runner/ArgumentParserTest.java
@@ -36,7 +36,7 @@ public class ArgumentParserTest {
         assertEquals(100, parser.getNumberOfTrees());
         assertEquals(256, parser.getSampleSize());
         assertEquals(0, parser.getWindowSize());
-        assertEquals(0.0, parser.getLambda());
+        assertEquals(0.0, parser.getTimeDecay());
         assertEquals(1, parser.getShingleSize());
         assertFalse(parser.getShingleCyclic());
         assertEquals(",", parser.getDelimiter());
@@ -51,7 +51,7 @@ public class ArgumentParserTest {
         assertEquals(222, parser.getNumberOfTrees());
         assertEquals(123, parser.getSampleSize());
         assertEquals(50, parser.getWindowSize());
-        assertEquals(0.02, parser.getLambda());
+        assertEquals(0.02, parser.getTimeDecay());
         assertEquals(4, parser.getShingleSize());
         assertTrue(parser.getShingleCyclic());
         assertEquals("\t", parser.getDelimiter());
@@ -65,7 +65,7 @@ public class ArgumentParserTest {
         assertEquals(222, parser.getNumberOfTrees());
         assertEquals(123, parser.getSampleSize());
         assertEquals(50, parser.getWindowSize());
-        assertEquals(0.02, parser.getLambda());
+        assertEquals(0.02, parser.getTimeDecay());
         assertEquals(4, parser.getShingleSize());
         assertEquals("\t", parser.getDelimiter());
     }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/RandomCutForestMapperTest.java
@@ -65,7 +65,7 @@ public class RandomCutForestMapperTest {
         assertEquals(forest.getSampleSize(), forest2.getSampleSize());
         assertEquals(forest.getOutputAfter(), forest2.getOutputAfter());
         assertEquals(forest.getNumberOfTrees(), forest2.getNumberOfTrees());
-        assertEquals(forest.getLambda(), forest2.getLambda());
+        assertEquals(forest.getTimeDecay(), forest2.getTimeDecay());
         assertEquals(forest.isStoreSequenceIndexesEnabled(), forest2.isStoreSequenceIndexesEnabled());
         assertEquals(forest.isCompact(), forest2.isCompact());
         assertEquals(forest.getPrecision(), forest2.getPrecision());

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/dynamicconfiguration/DynamicSampling.java
@@ -55,7 +55,7 @@ public class DynamicSampling implements Example {
 
         int first_anomalies = 0;
         int second_anomalies = 0;
-        forest2.setLambda(10 * forest2.getLambda());
+        forest2.setTimeDecay(10 * forest2.getTimeDecay());
 
         for (double[] point : testData.generateTestData(dataSize, dimensions)) {
             if (forest.getAnomalyScore(point) > 1.0) {
@@ -89,7 +89,7 @@ public class DynamicSampling implements Example {
         RandomCutForestMapper mapper = new RandomCutForestMapper();
         mapper.setSaveExecutorContextEnabled(true);
         RandomCutForest copyForest = mapper.toModel(mapper.toState(forest));
-        copyForest.setLambda(50 * forest.getLambda());
+        copyForest.setTimeDecay(50 * forest.getTimeDecay());
         // force an adjustment to catch up
         testData = new NormalMixtureTestData(-10, -40);
         int forced_change_anomalies = 0;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/serialization/ProtostuffExampleWithDynamicLambda.java
@@ -92,9 +92,9 @@ public class ProtostuffExampleWithDynamicLambda implements Example {
         ProtostuffIOUtil.mergeFrom(bytes, state2, schema);
         RandomCutForest forest2 = mapper.toModel(state2);
 
-        double saveLambda = forest.getLambda();
-        forest.setLambda(10 * forest.getLambda());
-        forest2.setLambda(10 * forest2.getLambda());
+        double saveLambda = forest.getTimeDecay();
+        forest.setTimeDecay(10 * forest.getTimeDecay());
+        forest2.setTimeDecay(10 * forest2.getTimeDecay());
 
         for (int i = 0; i < numberOfTrees; i++) {
             CompactSampler sampler = (CompactSampler) ((SamplerPlusTree) forest.getComponents().get(i)).getSampler();


### PR DESCRIPTION
Rename the remaining occurrences of `lambda` to the more self-explanatory `timeDecay`. The files to change were identified by running `grep -nH '[Ll]ambda' core/src/main/**/*.java`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
