### PR TITLE
Remove alternative constructors from classes with builders

### DIFF
--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/ForestUpdateExecutorBenchmark.java
@@ -86,8 +86,8 @@ public class ForestUpdateExecutorBenchmark {
                 ComponentList<double[], double[]> components = new ComponentList<>();
                 for (int i = 0; i < numberOfTrees; i++) {
                     RandomCutTree tree = RandomCutTree.builder().build();
-                    SimpleStreamSampler<double[]> sampler = new SimpleStreamSampler<>(sampleSize, lambda,
-                            random.nextLong(), false);
+                    SimpleStreamSampler<double[]> sampler = SimpleStreamSampler.<double[]>builder().capacity(sampleSize)
+                            .timeDecay(lambda).randomSeed(random.nextLong()).build();
                     SamplerPlusTree<double[], double[]> samplingTree = new SamplerPlusTree<>(sampler, tree);
                     components.add(samplingTree);
                 }
@@ -105,8 +105,8 @@ public class ForestUpdateExecutorBenchmark {
                     CompactRandomCutTreeDouble tree = new CompactRandomCutTreeDouble.Builder().maxSize(sampleSize)
                             .randomSeed(random.nextLong()).pointStore(store).boundingBoxCacheFraction(1.0)
                             .centerOfMassEnabled(false).storeSequenceIndexesEnabled(false).build();
-                    SimpleStreamSampler<Integer> sampler = new SimpleStreamSampler<>(sampleSize, lambda,
-                            random.nextLong(), false);
+                    SimpleStreamSampler<Integer> sampler = SimpleStreamSampler.<Integer>builder().capacity(sampleSize)
+                            .timeDecay(lambda).randomSeed(random.nextLong()).build();
                     SamplerPlusTree<Integer, double[]> samplerTree = new SamplerPlusTree<>(sampler, tree);
                     components.add(samplerTree);
                 }

--- a/Java/benchmark/src/main/java/com/amazon/randomcutforest/SamplingTreeBenchmark.java
+++ b/Java/benchmark/src/main/java/com/amazon/randomcutforest/SamplingTreeBenchmark.java
@@ -61,8 +61,8 @@ public class SamplingTreeBenchmark {
 
         @Setup(Level.Invocation)
         public void setUpTree() {
-            SimpleStreamSampler<double[]> sampler = new SimpleStreamSampler(RandomCutForest.DEFAULT_SAMPLE_SIZE, lambda,
-                    99, storeSequenceIndexesEnabled);
+            SimpleStreamSampler<double[]> sampler = SimpleStreamSampler.<double[]>builder()
+                    .capacity(RandomCutForest.DEFAULT_SAMPLE_SIZE).timeDecay(lambda).randomSeed(99).build();
             RandomCutTree tree = RandomCutTree.builder().randomSeed(101)
                     .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).build();
             samplingTree = new SamplerPlusTree<>(sampler, tree);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -305,8 +305,10 @@ public class RandomCutForest {
                     .boundingBoxCacheFraction(boundingBoxCacheFraction).centerOfMassEnabled(centerOfMassEnabled)
                     .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).outputAfter(outputAfter).build();
 
-            IStreamSampler<Integer> sampler = new CompactSampler(sampleSize, timeDecay, random.nextLong(),
-                    storeSequenceIndexesEnabled, builder.initialAcceptFraction);
+            IStreamSampler<Integer> sampler = CompactSampler.builder().capacity(sampleSize).timeDecay(timeDecay)
+                    .randomSeed(random.nextLong()).storeSequenceIndexesEnabled(storeSequenceIndexesEnabled)
+                    .initialAcceptFraction(builder.initialAcceptFraction).build();
+
             components.add(new SamplerPlusTree<>(sampler, tree));
         }
         this.stateCoordinator = stateCoordinator;
@@ -330,8 +332,11 @@ public class RandomCutForest {
                     .randomSeed(random.nextLong()).pointStore(tempStore)
                     .boundingBoxCacheFraction(boundingBoxCacheFraction).centerOfMassEnabled(centerOfMassEnabled)
                     .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).outputAfter(outputAfter).build();
-            IStreamSampler<Integer> sampler = new CompactSampler(sampleSize, timeDecay, random.nextLong(),
-                    storeSequenceIndexesEnabled, builder.initialAcceptFraction);
+
+            IStreamSampler<Integer> sampler = CompactSampler.builder().capacity(sampleSize).timeDecay(timeDecay)
+                    .randomSeed(random.nextLong()).storeSequenceIndexesEnabled(storeSequenceIndexesEnabled)
+                    .initialAcceptFraction(builder.initialAcceptFraction).build();
+
             components.add(new SamplerPlusTree<>(sampler, tree));
         }
         this.stateCoordinator = stateCoordinator;
@@ -347,8 +352,9 @@ public class RandomCutForest {
                     .boundingBoxCacheFraction(boundingBoxCacheFraction).centerOfMassEnabled(centerOfMassEnabled)
                     .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).outputAfter(outputAfter).build();
 
-            IStreamSampler<double[]> sampler = new SimpleStreamSampler<>(sampleSize, timeDecay, random.nextLong(),
-                    storeSequenceIndexesEnabled);
+            IStreamSampler<double[]> sampler = SimpleStreamSampler.<double[]>builder().capacity(sampleSize)
+                    .timeDecay(timeDecay).randomSeed(random.nextLong()).build();
+
             components.add(new SamplerPlusTree<>(sampler, tree));
         }
         this.stateCoordinator = stateCoordinator;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
-import java.util.Random;
 
 /**
  * <p>
@@ -66,22 +65,14 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
      */
     private final Queue<Weighted<P>> sample;
 
-    public SimpleStreamSampler(Builder<?> builder) {
+    public static <Q> Builder<Q> builder() {
+        return new Builder<>();
+    }
+
+    protected SimpleStreamSampler(Builder<P> builder) {
         super(builder);
         sample = new PriorityQueue<>(Comparator.comparingDouble(Weighted<P>::getWeight).reversed());
         this.timeDecay = builder.timeDecay;
-    }
-
-    public SimpleStreamSampler(int sampleSize, double timeDecay, long seed, boolean storeSequenceIndexesEnabled) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).randomSeed(seed));
-    }
-
-    public SimpleStreamSampler(int sampleSize, double timeDecay, Random random, boolean storeSequenceIndexesEnabled) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).random(random));
-    }
-
-    public SimpleStreamSampler(int sampleSize, double timeDecay, long seed) {
-        this(new Builder<>().capacity(sampleSize).timeDecay(timeDecay).randomSeed(seed));
     }
 
     /**
@@ -169,4 +160,9 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         return sample.size();
     }
 
+    public static class Builder<Q> extends AbstractStreamSampler.Builder<Builder<Q>> {
+        public SimpleStreamSampler<Q> build() {
+            return new SimpleStreamSampler<>(this);
+        }
+    }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
@@ -291,8 +291,9 @@ public class RandomCutForestMapper
             RandomCutTree tree = RandomCutTree.builder()
                     .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled())
                     .centerOfMassEnabled(state.isCenterOfMassEnabled()).randomSeed(random.nextLong()).build();
-            SimpleStreamSampler<double[]> sampler = new SimpleStreamSampler<>(state.getSampleSize(),
-                    state.getTimeDecay(), random.nextLong());
+            SimpleStreamSampler<double[]> sampler = SimpleStreamSampler.<double[]>builder()
+                    .capacity(state.getSampleSize()).timeDecay(state.getTimeDecay()).randomSeed(random.nextLong())
+                    .build();
             sampler.setMaxSequenceIndex(compactData.getMaxSequenceIndex());
             sampler.setMostRecentTimeDecayUpdate(compactData.getMostRecentTimeDecayUpdate());
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/AbstractRandomCutTree.java
@@ -63,27 +63,7 @@ public abstract class AbstractRandomCutTree<Point, NodeReference, PointReference
     Random cacheRandom = new Random(0);
     protected int outputAfter;
 
-    public AbstractRandomCutTree(Random random, double boundingBoxCacheFraction, boolean centerOfMassEnabled,
-            boolean storeSequenceIndexesEnabled) {
-        this.testRandom = random;
-        this.boundingBoxCacheFraction = boundingBoxCacheFraction;
-        this.centerOfMassEnabled = centerOfMassEnabled;
-        this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
-    }
-
-    public AbstractRandomCutTree(Random random, boolean boundingBoxCacheEnabled, boolean centerOfMassEnabled,
-            boolean storeSequenceIndexesEnabled) {
-        this.testRandom = random;
-        if (boundingBoxCacheEnabled) {
-            this.boundingBoxCacheFraction = RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION;
-        } else {
-            this.boundingBoxCacheFraction = 0;
-        }
-        this.centerOfMassEnabled = centerOfMassEnabled;
-        this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
-    }
-
-    public AbstractRandomCutTree(AbstractRandomCutTree.Builder<?> builder) {
+    protected AbstractRandomCutTree(AbstractRandomCutTree.Builder<?> builder) {
         if (builder.random != null) {
             this.testRandom = builder.random;
         } else {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeDouble.java
@@ -23,7 +23,11 @@ import com.amazon.randomcutforest.store.IPointStoreView;
 
 public class CompactRandomCutTreeDouble extends AbstractCompactRandomCutTree<double[]> {
 
-    public CompactRandomCutTreeDouble(CompactRandomCutTreeDouble.Builder builder) {
+    public static CompactRandomCutTreeDouble.Builder builder() {
+        return new Builder();
+    }
+
+    protected CompactRandomCutTreeDouble(CompactRandomCutTreeDouble.Builder builder) {
         super(builder);
         checkNotNull(builder.pointStoreView, "pointStore must not be null");
         super.pointStore = builder.pointStoreView;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/CompactRandomCutTreeFloat.java
@@ -26,7 +26,11 @@ import com.amazon.randomcutforest.store.IPointStoreView;
 
 public class CompactRandomCutTreeFloat extends AbstractCompactRandomCutTree<float[]> {
 
-    public CompactRandomCutTreeFloat(CompactRandomCutTreeFloat.Builder builder) {
+    public static CompactRandomCutTreeFloat.Builder builder() {
+        return new Builder();
+    }
+
+    protected CompactRandomCutTreeFloat(CompactRandomCutTreeFloat.Builder builder) {
         super(builder);
         checkNotNull(builder.pointStoreView, "pointStore must not be null");
         super.pointStore = builder.pointStoreView;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -20,7 +20,6 @@ import static com.amazon.randomcutforest.CommonUtils.checkState;
 import java.util.Arrays;
 import java.util.Random;
 
-import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.Visitor;
 
 /**
@@ -81,23 +80,6 @@ public class RandomCutTree extends AbstractRandomCutTree<double[], Node, double[
      */
     public boolean storeSequenceIndexesEnabled() {
         return super.storeSequenceIndexesEnabled;
-    }
-
-    public RandomCutTree(Random random, double cacheFraction, boolean enableCenterOfMass,
-            boolean enableSequenceIndices) {
-        super(random, cacheFraction, enableCenterOfMass, enableSequenceIndices);
-        root = null;
-    }
-
-    public RandomCutTree(long seed, boolean enableCache, boolean enableCenterOfMass, boolean enableSequenceIndices) {
-        this(new Random(seed), enableCache, enableCenterOfMass, enableSequenceIndices);
-    }
-
-    public RandomCutTree(Random random, boolean enableCache, boolean enableCenterOfMass,
-            boolean enableSequenceIndices) {
-        super(random, enableCache, enableCenterOfMass, enableSequenceIndices);
-        root = null;
-        setBoundingBoxCacheFraction(RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION);
     }
 
     protected RandomCutTree(Builder<?> builder) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
@@ -52,10 +52,12 @@ public class CompactSamplerTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             Random random1 = spy(new Random(seed));
-            CompactSampler sampler1 = new CompactSampler(sampleSize, lambda, random1, false);
+            CompactSampler sampler1 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).random(random1)
+                    .storeSequenceIndexesEnabled(false).build();
 
             Random random2 = spy(new Random(seed));
-            CompactSampler sampler2 = new CompactSampler(sampleSize, lambda, random2, true);
+            CompactSampler sampler2 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).random(random2)
+                    .storeSequenceIndexesEnabled(true).build();
             return Stream.of(Arguments.of(random1, sampler1), Arguments.of(random2, sampler2));
         }
     }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/SimpleStreamSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/SimpleStreamSamplerTest.java
@@ -50,7 +50,7 @@ public class SimpleStreamSamplerTest {
         lambda = 0.01;
         seed = 42L;
         random = spy(new Random(seed));
-        sampler = new SimpleStreamSampler<>(sampleSize, lambda, random, false);
+        sampler = SimpleStreamSampler.<double[]>builder().capacity(sampleSize).timeDecay(lambda).random(random).build();
     }
 
     @Test
@@ -59,7 +59,8 @@ public class SimpleStreamSamplerTest {
         // IStreamSampler interface
         assertEquals(lambda, sampler.getTimeDecay());
 
-        SimpleStreamSampler<double[]> uniformSampler = new SimpleStreamSampler<>(11, 0, 14, false);
+        SimpleStreamSampler<double[]> uniformSampler = SimpleStreamSampler.<double[]>builder().capacity(11).timeDecay(0)
+                .randomSeed(14).build();
         assertFalse(uniformSampler.getEvictedPoint().isPresent());
         assertFalse(uniformSampler.isReady());
         assertFalse(uniformSampler.isFull());

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/StreamSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/StreamSamplerTest.java
@@ -43,19 +43,19 @@ public class StreamSamplerTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             Random random1 = spy(new Random(seed));
-            CompactSampler sampler1 = new CompactSampler(sampleSize, lambda, random1, false);
+            CompactSampler sampler1 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).random(random1)
+                    .storeSequenceIndexesEnabled(false).build();
 
             Random random2 = spy(new Random(seed));
-            CompactSampler sampler2 = new CompactSampler(sampleSize, lambda, random2, true);
+            CompactSampler sampler2 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).random(random2)
+                    .storeSequenceIndexesEnabled(true).build();
 
             Random random3 = spy(new Random(seed));
-            SimpleStreamSampler<Integer> sampler3 = new SimpleStreamSampler<>(sampleSize, lambda, random3, false);
-
-            Random random4 = spy(new Random(seed));
-            SimpleStreamSampler<Integer> sampler4 = new SimpleStreamSampler<>(sampleSize, lambda, random4, true);
+            SimpleStreamSampler<Integer> sampler3 = SimpleStreamSampler.<Integer>builder().capacity(sampleSize)
+                    .timeDecay(lambda).random(random3).build();
 
             return Stream.of(Arguments.of(random1, sampler1), Arguments.of(random2, sampler2),
-                    Arguments.of(random3, sampler3), Arguments.of(random4, sampler4));
+                    Arguments.of(random3, sampler3));
         }
     }
 
@@ -114,8 +114,10 @@ public class StreamSamplerTest {
      */
     @Test
     public void testCompareSampling() {
-        CompactSampler compact = new CompactSampler(10, 0.001, 10, false);
-        SimpleStreamSampler<double[]> simple = new SimpleStreamSampler<>(10, 0.001, 10, false);
+        CompactSampler compact = CompactSampler.builder().capacity(10).timeDecay(0.001).randomSeed(10)
+                .storeSequenceIndexesEnabled(false).build();
+        SimpleStreamSampler<double[]> simple = SimpleStreamSampler.<double[]>builder().capacity(10).timeDecay(0.001)
+                .randomSeed(10).build();
 
         for (int i = 0; i < 100000; i++) {
             boolean accepted1 = compact.acceptPoint(i);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/state/sampler/CompactSamplerMapperTest.java
@@ -39,8 +39,10 @@ public class CompactSamplerMapperTest {
     private static long seed = 4444;
 
     public static Stream<Arguments> nonemptySamplerProvider() {
-        CompactSampler fullSampler1 = new CompactSampler(sampleSize, lambda, seed, false);
-        CompactSampler fullSampler2 = new CompactSampler(sampleSize, lambda, seed, true);
+        CompactSampler fullSampler1 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).randomSeed(seed)
+                .storeSequenceIndexesEnabled(false).build();
+        CompactSampler fullSampler2 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).randomSeed(seed)
+                .storeSequenceIndexesEnabled(true).build();
 
         Random random = new Random();
         long baseIndex = 10_000;
@@ -50,8 +52,10 @@ public class CompactSamplerMapperTest {
             fullSampler2.update(pointReference, baseIndex + i);
         }
 
-        CompactSampler partiallyFullSampler1 = new CompactSampler(sampleSize, lambda, seed, false);
-        CompactSampler partiallyFullSampler2 = new CompactSampler(sampleSize, lambda, seed, true);
+        CompactSampler partiallyFullSampler1 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda)
+                .randomSeed(seed).storeSequenceIndexesEnabled(false).build();
+        CompactSampler partiallyFullSampler2 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda)
+                .randomSeed(seed).storeSequenceIndexesEnabled(true).build();
 
         for (int i = 0; i < sampleSize / 2; i++) {
             int pointReference = random.nextInt();
@@ -66,8 +70,10 @@ public class CompactSamplerMapperTest {
     }
 
     public static Stream<Arguments> samplerProvider() {
-        CompactSampler emptySampler1 = new CompactSampler(sampleSize, lambda, seed, false);
-        CompactSampler emptySampler2 = new CompactSampler(sampleSize, lambda, seed, true);
+        CompactSampler emptySampler1 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).randomSeed(seed)
+                .storeSequenceIndexesEnabled(false).build();
+        CompactSampler emptySampler2 = CompactSampler.builder().capacity(sampleSize).timeDecay(lambda).randomSeed(seed)
+                .storeSequenceIndexesEnabled(true).build();
 
         return Stream.concat(nonemptySamplerProvider(),
                 Stream.of(Arguments.of("empty sampler without sequence indexes", emptySampler1),


### PR DESCRIPTION
Closes #189

Remove alternative constructors from classes where we've added builders (trees and samplers) to simplify the public API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
