### PR TITLE
[Rust] Add output_after threshold to RCF

### DIFF
--- a/Rust/src/random_cut_forest.rs
+++ b/Rust/src/random_cut_forest.rs
@@ -390,4 +390,27 @@ mod tests {
         assert!(anomalous_score > scores_mean);
         assert!(anomalous_score > scores_max);
     }
+
+    #[test]
+    fn output_after() {
+        let num_points = 20;
+        let output_after = 10;
+        let dimension = 3;
+        let mut forest: RandomCutForest<f32> = RandomCutForestBuilder::new(dimension)
+            .output_after(output_after).build();
+
+        let points = randn(num_points, dimension);
+        let anomaly = vec![0.0; dimension];
+        for (i, point) in points.iter().enumerate() {
+            forest.update(point.clone());
+
+            if i < output_after {
+                let anomalous_score = forest.anomaly_score(&anomaly);
+                assert!(anomalous_score == 0.0);
+            }
+        }
+
+        let anomalous_score = forest.anomaly_score(&anomaly);
+        assert!(anomalous_score != 0.0);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#221 

*Description of changes:*
Initially, the anomaly score that RCF outputs may not have very much meaning. For instance, given two points in the tree, can it really be said that there is enough information to determine if the third point is anomalous? This may cause a lot of false positives at the beginning of the stream.

This PR adds an "output_after" parameter to the RandomCutForest. If the number of observations against this RCF is less than or equal to this value, the RCF will simply return 0. By default, the builder sets this parameter to 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
