### PR TITLE
move utility cleancopy method

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -63,6 +63,7 @@ import com.amazon.randomcutforest.tree.CompactRandomCutTreeDouble;
 import com.amazon.randomcutforest.tree.CompactRandomCutTreeFloat;
 import com.amazon.randomcutforest.tree.ITree;
 import com.amazon.randomcutforest.tree.RandomCutTree;
+import com.amazon.randomcutforest.util.ArrayUtils;
 import com.amazon.randomcutforest.util.ShingleBuilder;
 
 /**
@@ -584,23 +585,6 @@ public class RandomCutForest {
     }
 
     /**
-     * Returns a clean deep copy of the point. Current clean-ups include changing
-     * negative zero -0.0 to positive zero 0.0.
-     *
-     * @param point The original data point.
-     * @return a clean deep copy of the original point.
-     */
-    public static double[] cleanCopy(double[] point) {
-        double[] pointCopy = Arrays.copyOf(point, point.length);
-        for (int i = 0; i < point.length; i++) {
-            if (pointCopy[i] == 0.0) {
-                pointCopy[i] = 0.0;
-            }
-        }
-        return pointCopy;
-    }
-
-    /**
      * used for scoring and other function, expands to a shingled point in either
      * case performs a clean copy
      * 
@@ -612,7 +596,7 @@ public class RandomCutForest {
         checkNotNull(point, "point must not be null");
         return (internalShinglingEnabled && point.length == inputDimensions)
                 ? stateCoordinator.getStore().transformToShingledPoint(point)
-                : cleanCopy(point);
+                : ArrayUtils.cleanCopy(point);
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayUtils.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/util/ArrayUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.util;
+
+import java.util.Arrays;
+
+/**
+ * A utility class for data arrays.
+ */
+public class ArrayUtils {
+
+    /**
+     * Returns a clean deep copy of the point. Current clean-ups include changing
+     * negative zero -0.0 to positive zero 0.0.
+     *
+     * @param point The original data point.
+     * @return a clean deep copy of the original point.
+     */
+    public static double[] cleanCopy(double[] point) {
+        double[] pointCopy = Arrays.copyOf(point, point.length);
+        for (int i = 0; i < point.length; i++) {
+            if (pointCopy[i] == 0.0) {
+                pointCopy[i] = 0.0;
+            }
+        }
+        return pointCopy;
+    }
+
+}

--- a/Java/core/src/test/java/com/amazon/randomcutforest/util/ArrayUtilsTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/util/ArrayUtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class ArrayUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({ "-0.0,0.0", "0.0,0.0", "-0.0:0.0:1.0,0.0:0.0:1.0" })
+    public void cleanCopy(String input, String expected) {
+        double[] inputArray = array(input);
+        double[] cleanCopy = ArrayUtils.cleanCopy(inputArray);
+        assertNotSame(inputArray, cleanCopy);
+        assertArrayEquals(array(expected), cleanCopy);
+    }
+
+    private double[] array(String arrayString) {
+        return Arrays.stream(arrayString.split(":")).mapToDouble(Double::valueOf).toArray();
+    }
+}


### PR DESCRIPTION
The cleancopy method is part of implementation that should be hidden from RandomCutForest class clients. This PR moves it to a separate utility class to make RandomCutForest interface cleaner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
