### PR TITLE
make transformToShingledPoint private

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -608,7 +608,7 @@ public class RandomCutForest {
      * @return a shingled copy or a clean copy
      */
 
-    public double[] transformToShingledPoint(double[] point) {
+    protected double[] transformToShingledPoint(double[] point) {
         checkNotNull(point, "point must not be null");
         return (internalShinglingEnabled && point.length == inputDimensions)
                 ? stateCoordinator.getStore().transformToShingledPoint(point)


### PR DESCRIPTION
RandomCutForest::transformToShingledPoint is a helper method for implementation. This PR moves it from public interface to protected implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
