### PR TITLE
make transformIndices​ protected

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -623,7 +623,7 @@ public class RandomCutForest {
      * @param length    length of the input array
      * @return output array of missing values corresponding to shingle
      */
-    public int[] transformIndices(int[] indexList, int length) {
+    protected int[] transformIndices(int[] indexList, int length) {
         return (internalShinglingEnabled && length == inputDimensions)
                 ? stateCoordinator.getStore().transformIndices(indexList)
                 : indexList;


### PR DESCRIPTION
The transformIndices​ method is a helper in implementation. This PR moves it from the public interface to protected implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
