### PR TITLE
delombok for javadoc

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -79,6 +79,7 @@
     </dependencyManagement>
 
     <build>
+        <sourceDirectory>target/generated-sources/delombok</sourceDirectory>
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -178,6 +179,24 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>1.18.20.0</version>
+                <executions>
+                    <execution>
+                        <id>delombok</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                        <configuration>
+                            <addOutputDirectory>false</addOutputDirectory>
+                            <sourceDirectory>src/main/java</sourceDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
java doc is not generated for lombok generated code. This PR adds delombok to build for tools such as javadoc and code analysis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
