### PR TITLE
sampler changes for initialFraction

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
@@ -84,7 +84,7 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
      * @param currentSize the current size of the sampler
      * @return the probability of admitting the next point
      */
-    protected double compute_fraction(int currentSize) {
+    protected double initialAcceptProbability(int currentSize) {
         if (currentSize < initialAcceptFraction * capacity) {
             return 1.0;
         } else if (initialAcceptFraction >= 1.0) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
@@ -67,6 +67,34 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
     protected final double initialAcceptFraction;
 
     /**
+     * a function that computes the probability of admittance of a new value when
+     * the sampler is not full Note that a value can always be admitted if it has a
+     * weight smaller than some sampled value
+     *
+     * this function provides a mechanism for different trees to smoothly diverge --
+     * most previous versions corresponded to initialFraction = 1, and the samplers
+     * only diverge after all of them store all the first sampleSize points. In
+     * contrast the method (which can be changed in a subclass) admits the first
+     * initialFraction * sampleSize number of points and then becomes a monotonic
+     * decreasing function.
+     *
+     * This function is supposed to be a parallel to the outputAfter() setting in
+     * the forest which controls how scores are emitted
+     * 
+     * @param currentSize the current size of the sampler
+     * @return the probability of admitting the next point
+     */
+    protected double compute_fraction(int currentSize) {
+        if (currentSize < initialAcceptFraction * capacity) {
+            return 1.0;
+        } else if (initialAcceptFraction >= 1.0) {
+            return 0;
+        } else {
+            return 1 - (1.0 * currentSize / capacity - initialAcceptFraction) / (1 - initialAcceptFraction);
+        }
+    }
+
+    /**
      * The number of points in the sample when full.
      */
     protected final int capacity;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -150,10 +150,11 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         checkState(sequenceIndex >= mostRecentTimeDecayUpdate, "incorrect sequences submitted to sampler");
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
-        if ((size < capacity && random.nextDouble() < initialAcceptFraction + 1 - 1.0 * size / capacity)
-                || (weight < this.weight[0])) {
+        double a = random.nextDouble();
+        boolean initial = (size < capacity && a < compute_fraction(size));
+        if (initial || (weight < this.weight[0])) {
             acceptPointState = new AcceptPointState(sequenceIndex, weight);
-            if (size == capacity) {
+            if (!initial) {
                 evictMax();
             }
             return true;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -150,8 +150,7 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
         checkState(sequenceIndex >= mostRecentTimeDecayUpdate, "incorrect sequences submitted to sampler");
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
-        double a = random.nextDouble();
-        boolean initial = (size < capacity && a < compute_fraction(size));
+        boolean initial = (size < capacity && random.nextDouble() < initialAcceptProbability(size));
         if (initial || (weight < this.weight[0])) {
             acceptPointState = new AcceptPointState(sequenceIndex, weight);
             if (!initial) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -91,9 +91,11 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
 
-        if ((sample.size() < capacity && random.nextDouble() < initialAcceptFraction + 1 - 1.0 * size() / capacity)
-                || weight < sample.element().getWeight()) {
-            if (isFull()) {
+        double a = random.nextDouble();
+        boolean initial = (size() < capacity && a < compute_fraction(size()));
+
+        if (initial || weight < sample.element().getWeight()) {
+            if (!initial) {
                 evictedPoint = sample.poll();
             }
             acceptPointState = new AcceptPointState(sequenceIndex, weight);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/SimpleStreamSampler.java
@@ -91,9 +91,7 @@ public class SimpleStreamSampler<P> extends AbstractStreamSampler<P> {
         evictedPoint = null;
         float weight = computeWeight(sequenceIndex);
 
-        double a = random.nextDouble();
-        boolean initial = (size() < capacity && a < compute_fraction(size()));
-
+        boolean initial = (size() < capacity && random.nextDouble() < initialAcceptProbability(size()));
         if (initial || weight < sample.element().getWeight()) {
             if (!initial) {
                 evictedPoint = sample.poll();

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/CompactSamplerTest.java
@@ -226,7 +226,6 @@ public class CompactSamplerTest {
             if (sampler.acceptPoint(i)) {
                 sampler.addPoint(i);
             }
-            ;
         }
 
         assertThrows(IllegalStateException.class, () -> sampler.addPoint(sampleSize));

--- a/Java/core/src/test/java/com/amazon/randomcutforest/sampler/StreamSamplerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/sampler/StreamSamplerTest.java
@@ -17,10 +17,8 @@ package com.amazon.randomcutforest.sampler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
-import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Stream;
 
@@ -67,45 +65,6 @@ public class StreamSamplerTest {
         assertFalse(sampler.isFull());
         assertEquals(sampleSize, sampler.getCapacity());
         assertEquals(0, sampler.size());
-    }
-
-    @ParameterizedTest
-    @ArgumentsSource(SamplerProvider.class)
-    public void testIsReadyIsFull(Random random, IStreamSampler<Integer> sampler) {
-        int i;
-        for (i = 1; i < sampleSize / 4; i++) {
-            assertTrue(sampler.update((int) Math.ceil(Math.random() * 100), i));
-            assertFalse(sampler.isReady());
-            assertFalse(sampler.isFull());
-            assertEquals(i, sampler.size());
-            assertFalse(sampler.getEvictedPoint().isPresent());
-        }
-
-        for (i = sampleSize / 4; i < sampleSize; i++) {
-            assertTrue(sampler.update((int) Math.ceil(Math.random() * 100), i));
-            assertTrue(sampler.isReady());
-            assertFalse(sampler.isFull());
-            assertEquals(i, sampler.size());
-            assertFalse(sampler.getEvictedPoint().isPresent());
-        }
-
-        assertTrue(sampler.update((int) Math.ceil(Math.random() * 100), sampleSize));
-        assertTrue(sampler.isReady());
-        assertTrue(sampler.isFull());
-        assertEquals(i, sampler.size());
-        assertFalse(sampler.getEvictedPoint().isPresent());
-
-        Optional<ISampled<double[]>> evicted;
-        for (i = sampleSize + 1; i < 2 * sampleSize; i++) {
-            // Either the sampling and the evicted point are both null or both non-null
-            assertTrue(
-                    sampler.update((int) Math.ceil(Math.random() * 100), i) == sampler.getEvictedPoint().isPresent());
-
-            assertTrue(sampler.isReady());
-            assertTrue(sampler.isFull());
-            assertEquals(sampleSize, sampler.size());
-
-        }
     }
 
     /**

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedInternalShinglingExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedInternalShinglingExample.java
@@ -54,7 +54,7 @@ public class ThresholdedInternalShinglingExample implements Example {
 
         // change this to try different number of attributes,
         // this parameter is not expected to be larger than 5 for this example
-        int baseDimensions = 4;
+        int baseDimensions = 2;
 
         long count = 0;
 
@@ -62,13 +62,10 @@ public class ThresholdedInternalShinglingExample implements Example {
         ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
                 .randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
                 .internalShinglingEnabled(true).precision(precision).anomalyRate(0.01).setMode(ForestMode.STANDARD)
-                .build();
+                .outputAfter(32).initialAcceptFraction(0.125).build();
 
-        long seed = 0;
-        new Random().nextLong();
-        long newSeed = 0;
-        new Random().nextLong();
-        Random noise = new Random(newSeed);
+        long seed = new Random().nextLong();
+        Random noise = new Random();
 
         System.out.println("seed = " + seed);
         // change the last argument seed for a different run
@@ -97,10 +94,12 @@ public class ThresholdedInternalShinglingExample implements Example {
                     System.out.print(result.getCurrentValues()[i] + ", ");
                 }
                 System.out.print("score " + result.getRcfScore() + ", grade " + result.getAnomalyGrade() + ", ");
-
+                if (result.getRelativeIndex() != 0 && result.isStartOfAnomaly()) {
+                    System.out.print(-result.getRelativeIndex() + " steps ago, ");
+                }
                 if (result.isExpectedValuesPresent()) {
                     if (result.getRelativeIndex() != 0 && result.isStartOfAnomaly()) {
-                        System.out.print(-result.getRelativeIndex() + " steps ago, instead of ");
+                        System.out.print("instead of ");
                         for (int i = 0; i < baseDimensions; i++) {
                             System.out.print(result.getOldValues()[i] + ", ");
                         }
@@ -123,6 +122,8 @@ public class ThresholdedInternalShinglingExample implements Example {
                             }
                         }
                     }
+                } else {
+                    System.out.print("insufficient data to provide expected values");
                 }
                 System.out.println();
             }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/ThresholdedRandomCutForest.java
@@ -733,10 +733,7 @@ public class ThresholdedRandomCutForest {
                     base);
             reference = oldValues;
             result.setOldValues(oldValues);
-            result.setRelativeIndex(index);
             result.setOldTimeStamp(previousTimeStamps[shingleSize - 1 + result.getRelativeIndex()]);
-        } else {
-            result.setRelativeIndex(0);
         }
 
         if (forestMode == ForestMode.TIME_AUGMENTED) {
@@ -961,6 +958,7 @@ public class ThresholdedRandomCutForest {
             }
         }
 
+        result.setRelativeIndex(index);
         result.setExpectedValuesPresent(reasonableForecast);
         if (reasonableForecast) {
             addExpectedAndUpdateState(inputPoint, point, newPoint, result, index);


### PR DESCRIPTION


*Description of changes:* currently samplers admit every point till they are full. However that may make all the samplers correlated and would indicate a change of behavior at sampleSize number of points. The behavior is now smoothed so that samplers could (potentially) diverge after initialFraction * sampleSize number of points and not store each of the first sampleSize points each. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
