### PR TITLE
Implement a thresholded random cut forest runner

### DIFF
--- a/Java/parkservices/README.md
+++ b/Java/parkservices/README.md
@@ -1,0 +1,74 @@
+# Park Services
+
+Park services includes tools for perfoming thresholded anomaly detection. The
+random cut forest model outputs an anomaly score, such that the larger the score
+the more anomalous the data point. By contrast, a thresholded random cut forest
+classifies data points as anomalous or not. It also outputs detailed information
+about an anomaly such as its severity.
+
+## Command-line (CLI) Usage
+
+> **Important.** The CLI applications use `String::split` to read delimited data
+> and as such are **not intended for production use**.
+
+For ease of use, begin by building park services with dependencies included. Otherwise,
+you will have to explicitly link to the other packages in this library.
+
+```
+$ mvn clean
+$ mvn -pl parkservices package assembly:single
+```
+
+Then, run the thresholded random cut forest runner on input data. The data is
+provided via STDIN similar to the usage of `AnomalyScoreRunner` and other runners
+in the `core` package.
+
+```
+$ java -cp parkservices/target/randomcutforest-parkservices-2.0.1-jar-with-dependencies.jar com.amazon.randomcutforest.parkservices.runner.ThresholdedRandomCutForestRunner < ../example-data/rcf-paper.csv > ./example_output.csv
+$ tail example_output.csv
+-5.0074,-0.0038,-0.0237,1.05251420280967,0.0
+-5.0029,0.0170,-0.0057,0.779527152203384,0.0
+-4.9975,-0.0102,-0.0065,0.6555765135757349,0.0
+4.9878,0.0136,-0.0087,0.7926342873023955,0.0
+5.0118,0.0098,-0.0057,0.7398851897159503,0.0
+0.0158,0.0061,0.0091,2.757692377161313,1.0
+5.0167,0.0041,0.0054,0.7490870040523756,0.0
+-4.9947,0.0126,-0.0010,0.6807435706579732,0.0
+-5.0209,0.0004,-0.0033,0.8978880069845551,0.0
+4.9923,-0.0142,0.0030,0.7360101409592287,0.0
+
+```
+
+The thresholded random cut forest appends two columns to the original data. The
+first column is the anomaly score determined by the random cut forest model. The
+second column is the anomaly grade: a non-zero grade indicates that the thresholder
+detected an anomaly.
+
+Note that there is one data point that is not like the others. The large anomaly
+score and non-zero anomaly grade indicate this! You can read additional usage
+instructions, including options for setting model hyperparameters, using the
+`--help` flag. There are several thresholding-specific hyperparameters that can
+be set in addition to the usual random cut forest hyperparameters.
+
+```
+$ java -cp parkservices/target/randomcutforest-parkservices-2.0.1-jar-with-dependencies.jar com.amazon.randomcutforest.parkservices.runner.ThresholdedRandomCutForestRunner --help
+Usage: java -cp randomcutforest-core-1.0.jar com.amazon.randomcutforest.parkservices.threshold.ThresholdedRandomCutForest [options] < input_file > output_file
+
+Streaming anomaly detection on input rows. Appends anomaly score and anomaly grade to output rows.
+
+Options:
+        --anomaly-rate: Approximate expected anomaly rate. Controls anomaly threshold decay rate. (default: 0.01)
+        --delimiter, -d: The character or string used as a field delimiter. (default: ,)
+        --header-row: Set to 'true' if the data contains a header row. (default: false)
+        --horizon: Mixture factor between using scores and score differences for thresholding. Value of 1.0 means the thresholder only uses score values. Value of 0.0 means the thresholder only uses score differences. (default: 0.5)
+        --lower-threshold: Anomaly score threshold for marking a potential anomaly. Affects thresholder sensitivity. (default: 1.0)
+        --number-of-trees, -n: Number of trees to use in the forest. (default: 100)
+        --random-seed: Random seed to use in the Random Cut Forest (default: 42)
+        --sample-size, -s: Number of points to keep in sample for each tree. (default: 256)
+        --shingle-cyclic, -c: Set to 'true' to use cyclic shingles instead of linear shingles. (default: false)
+        --shingle-size, -g: Shingle size to use. (default: 1)
+        --window-size, -w: Window size of the sample or 0 for no window. (default: 0)
+        --zfactor: Z-score threshold for marking a potential anomaly. Affects thresholder sensitivity. (default: 2.5)
+
+        --help, -h: Print this help message and exit.
+```

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -50,4 +50,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.amazon.randomcutforest.parkservices.runner.ThresholdedRandomCutForestRunner</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/runner/ThresholdedArgumentParser.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/runner/ThresholdedArgumentParser.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.runner;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+
+import com.amazon.randomcutforest.runner.ArgumentParser;
+
+/**
+ * An argument parser for ThresholdedRandomCutForests.
+ * 
+ * A ThresholdedRandomCutForest takes all of the same initialization arguments
+ * as a RandomCutForest plus several additional thresholding-specific
+ * parameters. This ArgumentParser includes several of these additional
+ * parameters.
+ */
+public class ThresholdedArgumentParser extends ArgumentParser {
+    private final DoubleArgument anomalyRate;
+    private final DoubleArgument horizon;
+    private final DoubleArgument lowerThreshold;
+    private final DoubleArgument zFactor;
+
+    public ThresholdedArgumentParser(String runnerClass, String runnerDescription) {
+        super(runnerClass, runnerDescription);
+
+        anomalyRate = new DoubleArgument(null, "--anomaly-rate",
+                "Approximate expected anomaly rate. Controls anomaly threshold decay rate.", 0.01);
+        addArgument(anomalyRate);
+
+        horizon = new DoubleArgument(null, "--horizon",
+                "Mixture factor between using scores and score differences for thresholding. Value of 1.0 means the thresholder only uses score values. Value of 0.0 means the thresholder only uses score differences.",
+                0.5, n -> checkArgument(n >= 0.0 && n <= 1.0, "Horizon should be between 0.0 and 1.0"));
+        addArgument(horizon);
+
+        lowerThreshold = new DoubleArgument(null, "--lower-threshold",
+                "Anomaly score threshold for marking a potential anomaly. Affects thresholder sensitivity.", 1.0,
+                n -> checkArgument(n > 0.0, "Lower threshold must be greater than 0.0"));
+        addArgument(lowerThreshold);
+
+        zFactor = new DoubleArgument(null, "--zfactor",
+                "Z-score threshold for marking a potential anomaly. Affects thresholder sensitivity.", 2.5,
+                n -> checkArgument(n > 0.0, "Zfactor must be greater than 0.0"));
+        addArgument(zFactor);
+    }
+
+    /**
+     * @return the user-specified value of the anomaly rate
+     */
+    public double getAnomalyRate() {
+        return anomalyRate.getValue();
+    }
+
+    /**
+     * @return the user-specified value of the horizon
+     */
+    public double getHorizon() {
+        return horizon.getValue();
+    }
+
+    /**
+     * @return the user-specified value of the lower threshold
+     */
+    public double getLowerThreshold() {
+        return lowerThreshold.getValue();
+    }
+
+    /**
+     * @return the user-specified value of the zFactor
+     */
+    public double getZfactor() {
+        return zFactor.getValue();
+    }
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/runner/ThresholdedRandomCutForestRunner.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/runner/ThresholdedRandomCutForestRunner.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.runner;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Function;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.parkservices.AnomalyDescriptor;
+import com.amazon.randomcutforest.parkservices.threshold.ThresholdedRandomCutForest;
+import com.amazon.randomcutforest.runner.LineTransformer;
+import com.amazon.randomcutforest.runner.SimpleRunner;
+import com.amazon.randomcutforest.util.ShingleBuilder;
+
+/**
+ * A simple command line application for performing thresholded anomaly
+ * detection on multi-dimensional data. Creates an instance of a
+ * ThresholdedRandomCutForest, reads values from STDIN, and writes results to
+ * STDOUT.
+ */
+public class ThresholdedRandomCutForestRunner extends SimpleRunner {
+
+    // overwrite the base class initializer to use a ThresholdedRandomCutForest
+    protected final Function<ThresholdedRandomCutForest, LineTransformer> thresholdedAlgorithmInitializer;
+    protected final ThresholdedArgumentParser thresholdedArgumentParser;
+
+    public ThresholdedRandomCutForestRunner() {
+        // modify the default argument parser to accept additional,
+        // thresholding-specific arguments
+        // before instantiating the runner
+        super(new ThresholdedArgumentParser(ThresholdedRandomCutForest.class.getName(),
+                "Streaming anomaly detection on input rows. Appends anomaly score and anomaly grade to output rows."),
+                null);
+
+        thresholdedAlgorithmInitializer = AnomalyDescriptorTransformer::new;
+        thresholdedArgumentParser = (ThresholdedArgumentParser) argumentParser;
+    }
+
+    public static void main(String... args) throws IOException {
+        ThresholdedRandomCutForestRunner runner = new ThresholdedRandomCutForestRunner();
+        runner.parse(args);
+        runner.run(new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8)),
+                new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Set up the internal ThresholdedRandomCutForest instance and line transformer.
+     * 
+     * The SimpleRunner class assumes that the input algorithm is a RandomCutForest.
+     * This method needs to be overwritten so that we initialize a
+     * ThresholdedRandomCutForest, instead.
+     * 
+     * @param dimensions The number of dimensions in the input data.
+     */
+    @Override
+    protected void prepareAlgorithm(int dimensions) {
+        pointBuffer = new double[dimensions];
+        shingleBuilder = new ShingleBuilder(dimensions, argumentParser.getShingleSize(),
+                argumentParser.getShingleCyclic());
+        shingleBuffer = new double[shingleBuilder.getShingledPointSize()];
+
+        // need to set internal shingling to false for SimpleRunner compatibility
+        ThresholdedRandomCutForest model = ThresholdedRandomCutForest.builder()
+                .numberOfTrees(argumentParser.getNumberOfTrees()).sampleSize(argumentParser.getSampleSize())
+                .dimensions(dimensions).internalShinglingEnabled(false).shingleSize(argumentParser.getShingleSize())
+                .timeDecay(argumentParser.getTimeDecay()).randomSeed(argumentParser.getRandomSeed())
+                .anomalyRate(thresholdedArgumentParser.getAnomalyRate()).build();
+
+        model.getThresholder().setHorizon(thresholdedArgumentParser.getHorizon());
+        model.getThresholder().setLowerThreshold(thresholdedArgumentParser.getLowerThreshold());
+        model.getThresholder().setZfactor(thresholdedArgumentParser.getZfactor());
+
+        algorithm = thresholdedAlgorithmInitializer.apply(model);
+    }
+
+    public static class AnomalyDescriptorTransformer implements LineTransformer {
+        private final ThresholdedRandomCutForest model;
+        private long timestamp;
+
+        public AnomalyDescriptorTransformer(ThresholdedRandomCutForest model) {
+            this.model = model;
+            this.timestamp = 0;
+        }
+
+        @Override
+        public List<String> getResultValues(double... point) {
+            // assumes that every input point is consecutive
+            AnomalyDescriptor result = model.process(point, timestamp);
+            String score = Double.toString(result.getRcfScore());
+            String grade = Double.toString(result.getAnomalyGrade());
+            timestamp += 1;
+            return List.of(score, grade);
+        }
+
+        @Override
+        public List<String> getEmptyResultValue() {
+            return List.of("NA", "NA");
+        }
+
+        @Override
+        public List<String> getResultColumnNames() {
+            return List.of("anomaly score", "anomaly grade");
+        }
+
+        @Override
+        public RandomCutForest getForest() {
+            return model.getForest();
+        }
+    }
+}


### PR DESCRIPTION
A thresholded random cut forest runner is similar to the anomaly score runners of the core package. In addition to showing the anomaly score associated with a given input point, this new runner outputs the anomaly grade.

*Issue #, if available:*

n/a

*Description of changes:*

* Add a `ThresholdedRandomCutForestRunner` class. Similar to `AnomalyScoreRunner` and others.
* Add a `ThresholdedArgumentParser` class for allowing configuration of thresholder hyperparameters.
* Provide usage example (and external test) in a package-level README.
* Edited parkservices's pom file to allow compilation to a single jar file with dependencies.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
