### PR TITLE
pointstore fix

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
@@ -22,6 +22,7 @@ import java.util.List;
 import lombok.Getter;
 
 import com.amazon.randomcutforest.ComponentList;
+import com.amazon.randomcutforest.store.IPointStore;
 
 /**
  * The class transforms input points into the form expected by internal models,
@@ -59,7 +60,12 @@ public abstract class AbstractForestUpdateExecutor<PointReference, Point> {
      * @param point The point used to update the forest.
      */
     public void update(double[] point) {
-        update(point, updateCoordinator.getTotalUpdates());
+        long internalSequenceNumber = updateCoordinator.getTotalUpdates();
+        IPointStore<?> store = updateCoordinator.getStore();
+        if (store != null && store.isInternalShinglingEnabled()) {
+            internalSequenceNumber -= store.getShingleSize() - 1;
+        }
+        update(point, internalSequenceNumber);
     }
 
     public void update(double[] point, long sequenceNumber) {

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreDoubleMapper.java
@@ -72,9 +72,9 @@ public class PointStoreDoubleMapper implements IStateMapper<PointStoreDouble, Po
         state.setShingleSize(model.getShingleSize());
         state.setDirectLocationMap(model.isDirectLocationMap());
         state.setInternalShinglingEnabled(model.isInternalShinglingEnabled());
+        state.setLastTimeStamp(model.getNextSequenceIndex());
         if (model.isInternalShinglingEnabled()) {
             state.setInternalShingle(model.getInternalShingle());
-            state.setLastTimeStamp(model.getNextSequenceIndex());
             state.setRotationEnabled(model.isInternalRotationEnabled());
         }
         state.setDynamicResizingEnabled(model.isDynamicResizingEnabled());

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreFloatMapper.java
@@ -73,9 +73,9 @@ public class PointStoreFloatMapper implements IStateMapper<PointStoreFloat, Poin
         state.setShingleSize(model.getShingleSize());
         state.setDirectLocationMap(model.isDirectLocationMap());
         state.setInternalShinglingEnabled(model.isInternalShinglingEnabled());
+        state.setLastTimeStamp(model.getNextSequenceIndex());
         if (model.isInternalShinglingEnabled()) {
             state.setInternalShingle(model.getInternalShingle());
-            state.setLastTimeStamp(model.getNextSequenceIndex());
             state.setRotationEnabled(model.isInternalRotationEnabled());
         }
         state.setDynamicResizingEnabled(model.isDynamicResizingEnabled());

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
@@ -35,6 +35,10 @@ public interface IPointStoreView<Point> {
 
     boolean isInternalRotationEnabled();
 
+    boolean isInternalShinglingEnabled();
+
+    int getShingleSize();
+
     int[] transformIndices(int[] indexList);
 
     /**

--- a/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreDoubleTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreDoubleTest.java
@@ -257,4 +257,27 @@ public class PointStoreDoubleTest {
         store.add(new double[] { -6 * shinglesize }, 6 * shinglesize - 1);
         store.compact();
     }
+
+    @Test
+    void CompactionTest() {
+        int shinglesize = 2;
+        PointStoreDouble store = new PointStoreDouble.Builder().capacity(6).dimensions(shinglesize)
+                .shingleSize(shinglesize).indexCapacity(6).directLocationEnabled(false).internalShinglingEnabled(true)
+                .build();
+
+        store.add(new double[] { 0 }, 0L);
+        for (int i = 0; i < 5; i++) {
+            store.add(new double[] { i + 1 }, 0L);
+        }
+        int finalIndex = store.add(new double[] { 4 + 2 }, 0L);
+        assertArrayEquals(store.get(finalIndex), new double[] { 5, 6 });
+        store.decrementRefCount(1);
+        store.decrementRefCount(2);
+        int index = store.add(new double[] { 7 }, 0L);
+        assertArrayEquals(store.get(index), new double[] { 6, 7 });
+        store.decrementRefCount(index);
+        assertTrue(store.size() < store.capacity);
+        index = store.add(new double[] { 8 }, 0L);
+        assertArrayEquals(store.get(index), new double[] { 7, 8 });
+    }
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreFloatTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/store/PointStoreFloatTest.java
@@ -262,4 +262,26 @@ public class PointStoreFloatTest {
         store.compact();
     }
 
+    @Test
+    void CompactionTest() {
+        int shinglesize = 2;
+        PointStoreFloat store = new PointStoreFloat.Builder().capacity(6).dimensions(shinglesize)
+                .shingleSize(shinglesize).indexCapacity(6).directLocationEnabled(false).internalShinglingEnabled(true)
+                .build();
+
+        store.add(new double[] { 0 }, 0L);
+        for (int i = 0; i < 5; i++) {
+            store.add(new double[] { i + 1 }, 0L);
+        }
+        int finalIndex = store.add(new double[] { 4 + 2 }, 0L);
+        assertArrayEquals(store.get(finalIndex), new float[] { 5, 6 });
+        store.decrementRefCount(1);
+        store.decrementRefCount(2);
+        int index = store.add(new double[] { 7 }, 0L);
+        assertArrayEquals(store.get(index), new float[] { 6, 7 });
+        store.decrementRefCount(index);
+        assertTrue(store.size() < store.capacity);
+        index = store.add(new double[] { 8 }, 0L);
+        assertArrayEquals(store.get(index), new float[] { 7, 8 });
+    }
 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
@@ -39,7 +39,7 @@ public class ConsistencyTest {
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
 
-        int numTrials = 10;
+        int numTrials = 1; // just once since testing exact equality
         int length = 400 * sampleSize;
         for (int i = 0; i < numTrials; i++) {
 
@@ -71,7 +71,7 @@ public class ConsistencyTest {
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
 
-        int numTrials = 10;
+        int numTrials = 1; // just once since testing exact equality
         int length = 400 * sampleSize;
         for (int i = 0; i < numTrials; i++) {
 


### PR DESCRIPTION


*Description of changes:* While using internal shingling, if the size of the store is small compared to the number of updates, then a new unshingled point can be stored as an incorrect new shingled point. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
