### PR TITLE
Collapse PointStoreEdit and PointStoreView into a single PointStoreTrait

### DIFF
--- a/Rust/rustfmt.toml
+++ b/Rust/rustfmt.toml
@@ -1,0 +1,12 @@
+# This configuration uses unstable features from rustfmt nightly to format imports. Follow these steps to run `cargo fmt`:
+# 1. Install the nightly toolchain
+#     rustup toolchains install nightly
+# 2. Install or update the nightly build of rustfmt
+#     rustup component add rustfmt --toolchain nightly
+# 3. Run `cargo fmt` with the `+nightly` flag
+#     `cargo +nightly fmt`
+unstable_features = true
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_imports = true

--- a/Rust/src/boundingbox.rs
+++ b/Rust/src/boundingbox.rs
@@ -1,5 +1,3 @@
-
-
 #[repr(C)]
 pub struct BoundingBox {
     range_sum: f64,

--- a/Rust/src/imputevisitor.rs
+++ b/Rust/src/imputevisitor.rs
@@ -1,12 +1,8 @@
-
-
-use crate::newnodestore::NodeStoreView;
-use crate::nodeview::NodeView;
-
-
-use crate::visitor::{UniqueMultiVisitor, Visitor, VisitorDescriptor};
-
-
+use crate::{
+    newnodestore::NodeStoreView,
+    nodeview::NodeView,
+    visitor::{UniqueMultiVisitor, Visitor, VisitorDescriptor},
+};
 
 #[repr(C)]
 pub struct ImputeVisitor {

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -11,19 +11,11 @@ mod rcf;
 mod sampler;
 mod samplerplustree;
 mod scalarscorevisitor;
+mod types;
 mod visitor;
 
 extern crate rand;
-
-
-
-
-
 use crate::rcf::{create_rcf, RCF};
-
-
-
-
 extern crate rand_chacha;
 
 fn main() {

--- a/Rust/src/multidimdatawithkey.rs
+++ b/Rust/src/multidimdatawithkey.rs
@@ -1,10 +1,11 @@
 extern crate rand;
 use rand::SeedableRng;
 extern crate rand_chacha;
-use crate::multidimdatawithkey::rand::Rng;
-use crate::multidimdatawithkey::rand::RngCore;
-use rand_chacha::ChaCha20Rng;
 use std::f32::consts::PI;
+
+use rand_chacha::ChaCha20Rng;
+
+use crate::multidimdatawithkey::rand::{Rng, RngCore};
 
 pub struct MultiDimDataWithKey {
     pub data: Vec<Vec<f32>>,

--- a/Rust/src/newnodestore.rs
+++ b/Rust/src/newnodestore.rs
@@ -1,13 +1,9 @@
-use crate::boundingbox::BoundingBox;
-use crate::cut::Cut;
-use crate::intervalstoremanager::IntervalStoreManager;
-use crate::pointstore::PointStoreView;
-use crate::rcf::{Max};
+use std::{collections::HashMap, fmt::Debug, mem};
 
-
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::mem;
+use crate::{
+    boundingbox::BoundingBox, cut::Cut, intervalstoremanager::IntervalStoreManager,
+    pointstore::PointStore, types::Max,
+};
 
 /**
 * capacity is the number of leaves in the tree
@@ -47,25 +43,25 @@ const switch_threshold: f64 = 0.5;
 
 pub trait NodeStoreView {
     fn get_mass(&self, index: usize) -> usize;
-    fn get_box(&self, index: usize, point_store: &dyn PointStoreView) -> BoundingBox;
+    fn get_box(&self, index: usize, point_store: &dyn PointStore) -> BoundingBox;
     fn get_probability_of_cut(
         &self,
         index: usize,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> f64;
     fn grow_node_box_pair(
         &self,
         first: &mut BoundingBox,
         second: &mut BoundingBox,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node: usize,
         sibling: usize,
     );
     fn grow_node_box(
         &self,
         bounding_box: &mut BoundingBox,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node: usize,
         sibling: usize,
     );
@@ -217,7 +213,7 @@ where
         );
     }
 
-    pub fn reconstruct_box(&self, index: usize, point_store: &dyn PointStoreView) -> BoundingBox {
+    pub fn reconstruct_box(&self, index: usize, point_store: &dyn PointStore) -> BoundingBox {
         let idx: usize = (index - 1).try_into().unwrap();
         let mut mutated_bounding_box = self.get_box(self.left_index[idx].into(), point_store);
         self.grow_node_box(
@@ -233,7 +229,7 @@ where
         &mut self,
         index: usize,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> bool {
         let idx = self.translate(index.into());
         if idx != usize::MAX {
@@ -340,7 +336,7 @@ where
         &mut self,
         path: &mut Vec<(usize, usize)>,
         point: &[f32],
-        _point_store: &dyn PointStoreView,
+        _point_store: &dyn PointStore,
         box_resolved: bool,
     ) where
         <N as TryFrom<usize>>::Error: Debug,
@@ -360,7 +356,7 @@ where
         &mut self,
         path: &mut Vec<(usize, usize)>,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         box_resolved: bool,
     ) where
         <N as TryFrom<usize>>::Error: Debug,
@@ -412,7 +408,7 @@ where
         index: usize,
         dim: usize,
         value: f32,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> bool {
         if self.is_leaf(index) {
             let point = (self.project_to_tree)(point_store.get_copy(self.get_point_index(index)));
@@ -427,7 +423,7 @@ where
         index: usize,
         dim: usize,
         value: f32,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> bool {
         if self.is_leaf(index) {
             let point = (self.project_to_tree)(point_store.get_copy(self.get_point_index(index)));
@@ -504,7 +500,7 @@ where
         answer
     }
 
-    fn get_box(&self, index: usize, point_store: &dyn PointStoreView) -> BoundingBox {
+    fn get_box(&self, index: usize, point_store: &dyn PointStore) -> BoundingBox {
         if self.is_leaf(index) {
             return if self.using_transforms {
                 let point =
@@ -538,7 +534,7 @@ where
         &self,
         index: usize,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> f64 {
         let node_idx: usize = self.translate(index);
         if node_idx != usize::MAX {
@@ -571,7 +567,7 @@ where
     fn grow_node_box(
         &self,
         bounding_box: &mut BoundingBox,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         _node: usize,
         sibling: usize,
     ) {
@@ -617,7 +613,7 @@ where
         &self,
         first: &mut BoundingBox,
         second: &mut BoundingBox,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         _node: usize,
         sibling: usize,
     ) {

--- a/Rust/src/nodeview.rs
+++ b/Rust/src/nodeview.rs
@@ -1,10 +1,9 @@
-use crate::boundingbox::BoundingBox;
-
-use crate::newnodestore::NodeStoreView;
-use crate::pointstore::PointStoreView;
-use crate::rcf::Max;
-use crate::visitor::{UniqueMultiVisitor, Visitor};
-
+use crate::{
+    boundingbox::BoundingBox,
+    newnodestore::NodeStoreView,
+    pointstore::PointStore,
+    visitor::{UniqueMultiVisitor, Visitor},
+};
 
 pub trait NodeView {
     fn get_mass(&self) -> usize;
@@ -82,7 +81,7 @@ impl BasicNodeView {
     pub fn set_leaf_view(
         &mut self,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node_store: &dyn NodeStoreView,
     ) {
         self.leaf_index = node_store.get_leaf_point_index(self.current_node);
@@ -127,7 +126,7 @@ impl BasicNodeView {
         &mut self,
         parent: usize,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node_store: &dyn NodeStoreView,
     ) {
         let past_node = self.current_node;
@@ -185,7 +184,7 @@ impl BasicNodeView {
         &mut self,
         visitor: &mut dyn Visitor<T>,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node_store: &dyn NodeStoreView,
     ) {
         if node_store.is_leaf(self.current_node) {
@@ -207,7 +206,7 @@ impl BasicNodeView {
         &mut self,
         visitor: &mut dyn UniqueMultiVisitor<T, Q>,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         node_store: &dyn NodeStoreView,
     ) {
         if node_store.is_leaf(self.current_node) {

--- a/Rust/src/randomcuttree.rs
+++ b/Rust/src/randomcuttree.rs
@@ -1,24 +1,25 @@
-use crate::boundingbox::BoundingBox;
-use crate::cut::Cut;
-use crate::newnodestore::{NewNodeStore, NodeStoreView};
-
-use crate::rcf::{Max};
 use std::fmt::Debug;
+
+use crate::{
+    boundingbox::BoundingBox,
+    cut::Cut,
+    newnodestore::{NewNodeStore, NodeStoreView},
+};
 
 extern crate rand;
 use rand::SeedableRng;
 extern crate rand_chacha;
-use crate::imputevisitor::ImputeVisitor;
-use crate::nodeview::BasicNodeView;
-use crate::pointstore::PointStoreView;
-use crate::randomcuttree::rand::Rng;
-use crate::randomcuttree::rand::RngCore;
-
-
-
-use crate::scalarscorevisitor::ScalarScoreVisitor;
-use crate::visitor::{UniqueMultiVisitor, Visitor};
 use rand_chacha::ChaCha20Rng;
+
+use crate::{
+    imputevisitor::ImputeVisitor,
+    nodeview::BasicNodeView,
+    pointstore::PointStore,
+    randomcuttree::rand::{Rng, RngCore},
+    scalarscorevisitor::ScalarScoreVisitor,
+    types::Max,
+    visitor::{UniqueMultiVisitor, Visitor},
+};
 
 pub type StoreInUse = NewNodeStore<u8, u16, u8>;
 
@@ -76,7 +77,7 @@ where
         &mut self,
         point_index: usize,
         _point_attribute: usize,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> usize
     where
         <C as TryFrom<usize>>::Error: Debug,
@@ -116,7 +117,7 @@ where
 
                 let mut parent = saved_parent;
                 let mut saved_cut = Cut::new(usize::MAX, 0.0);
-                /** the loop has the execute once */
+                /* the loop has the execute once */
                 loop {
                     let factor: f64 = rng.gen();
                     let (new_cut, separation) =
@@ -188,7 +189,7 @@ where
         &mut self,
         point_index: usize,
         _point_attribute: usize,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> usize
     where
         <C as TryFrom<usize>>::Error: Debug,
@@ -257,7 +258,7 @@ where
     pub fn generic_score(
         &self,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         ignore_mass: usize,
         score_seen: fn(usize, usize) -> f64,
         score_unseen: fn(usize, usize) -> f64,
@@ -291,7 +292,7 @@ where
         &self,
         positions: &[usize],
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         centrality: f64,
         ignore_mass: usize,
         score_seen: fn(usize, usize) -> f64,

--- a/Rust/src/sampler.rs
+++ b/Rust/src/sampler.rs
@@ -1,6 +1,7 @@
-use crate::rcf::Max;
-
 use std::fmt::Debug;
+
+use crate::types::Max;
+
 #[repr(C)]
 pub struct Sampler<P> {
     capacity: usize,

--- a/Rust/src/samplerplustree.rs
+++ b/Rust/src/samplerplustree.rs
@@ -1,16 +1,16 @@
-use crate::pointstore::PointStoreView;
-use crate::randomcuttree::RCFTree;
-use crate::sampler::Sampler;
-
 use std::fmt::Debug;
+
+use crate::{pointstore::PointStore, randomcuttree::RCFTree, sampler::Sampler};
 extern crate rand;
 use rand::SeedableRng;
 extern crate rand_chacha;
 
-use crate::rcf::Max;
-use crate::samplerplustree::rand::Rng;
-use crate::samplerplustree::rand::RngCore;
 use rand_chacha::ChaCha20Rng;
+
+use crate::{
+    samplerplustree::rand::{Rng, RngCore},
+    types::Max,
+};
 
 #[repr(C)]
 pub struct SamplerPlusTree<C, P, N> {
@@ -71,7 +71,7 @@ where
         &mut self,
         point_index: usize,
         point_attribute: usize,
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
     ) -> (usize, usize)
     where
         <C as TryFrom<usize>>::Error: Debug,
@@ -132,7 +132,7 @@ where
     pub fn generic_score(
         &self,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         ignore_mass: usize,
         score_seen: fn(usize, usize) -> f64,
         score_unseen: fn(usize, usize) -> f64,
@@ -160,7 +160,7 @@ where
         positions: &[usize],
         centrality: f64,
         point: &[f32],
-        point_store: &dyn PointStoreView,
+        point_store: &dyn PointStore,
         ignore_mass: usize,
         score_seen: fn(usize, usize) -> f64,
         score_unseen: fn(usize, usize) -> f64,

--- a/Rust/src/scalarscorevisitor.rs
+++ b/Rust/src/scalarscorevisitor.rs
@@ -1,11 +1,8 @@
-
-
-use crate::newnodestore::NodeStoreView;
-use crate::nodeview::NodeView;
-
-use crate::rcf::Max;
-use crate::visitor::{Visitor, VisitorDescriptor};
-
+use crate::{
+    newnodestore::NodeStoreView,
+    nodeview::NodeView,
+    visitor::{Visitor, VisitorDescriptor},
+};
 
 #[repr(C)]
 pub struct ScalarScoreVisitor {

--- a/Rust/src/types.rs
+++ b/Rust/src/types.rs
@@ -1,0 +1,24 @@
+/// A trait that defines a maximum value constant.
+pub trait Max {
+    const MAX: Self;
+}
+
+impl Max for u8 {
+    const MAX: u8 = u8::MAX;
+}
+
+impl Max for u16 {
+    const MAX: u16 = u16::MAX;
+}
+
+impl Max for usize {
+    const MAX: usize = usize::MAX;
+}
+
+/// The Location trait is used as a shorthand for the various traits needed by store (e.g., point
+/// store, node store) locations. These are the values vended by stores to reference a stored
+/// value.
+pub trait Location: Copy + Max + std::cmp::PartialEq + Into<usize> + TryFrom<usize> + Sync {}
+
+impl Location for u16 {}
+impl Location for usize {}

--- a/Rust/src/visitor.rs
+++ b/Rust/src/visitor.rs
@@ -1,9 +1,4 @@
-
-
-
 use crate::nodeview::NodeView;
-
-
 
 pub trait Visitor<T> {
     fn accept_leaf(&mut self, point: &[f32], node_view: &dyn NodeView);


### PR DESCRIPTION
- Create a single PointStore trait with the methods from PointStoreEdit
  and PointStoreView combined. We can use mutable/non-mutable references
  to distinguish between read-only and read-write use cases.
- Create a new Location trait to simplify the type constraints used for
  store locations.
- Create a new types.rs file to define traits used in multiple other files.
- Create a rustfmt.toml file and configure rustfmt to organize imports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
