### PR TITLE
Simplifying type declarations

### DIFF
--- a/Rust/src/imputevisitor.rs
+++ b/Rust/src/imputevisitor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    newnodestore::NodeStoreView,
+    nodestore::NodeStore,
     nodeview::NodeView,
     visitor::{UniqueMultiVisitor, Visitor, VisitorDescriptor},
 };

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -3,7 +3,7 @@ mod cut;
 mod imputevisitor;
 mod intervalstoremanager;
 mod multidimdatawithkey;
-mod newnodestore;
+mod nodestore;
 mod nodeview;
 mod pointstore;
 mod randomcuttree;

--- a/Rust/src/nodeview.rs
+++ b/Rust/src/nodeview.rs
@@ -1,6 +1,6 @@
 use crate::{
     boundingbox::BoundingBox,
-    newnodestore::NodeStoreView,
+    nodestore::NodeStore,
     pointstore::PointStore,
     visitor::{UniqueMultiVisitor, Visitor},
 };
@@ -82,7 +82,7 @@ impl BasicNodeView {
         &mut self,
         point: &[f32],
         point_store: &dyn PointStore,
-        node_store: &dyn NodeStoreView,
+        node_store: &dyn NodeStore,
     ) {
         self.leaf_index = node_store.get_leaf_point_index(self.current_node);
 
@@ -114,7 +114,7 @@ impl BasicNodeView {
         };
     }
 
-    pub fn update_view_for_path(&mut self, node_store: &dyn NodeStoreView) {
+    pub fn update_view_for_path(&mut self, node_store: &dyn NodeStore) {
         let (a, b, c, d) = node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = a;
         self.cut_value = b;
@@ -127,7 +127,7 @@ impl BasicNodeView {
         parent: usize,
         point: &[f32],
         point_store: &dyn PointStore,
-        node_store: &dyn NodeStoreView,
+        node_store: &dyn NodeStore,
     ) {
         let past_node = self.current_node;
         self.current_node = parent;
@@ -185,7 +185,7 @@ impl BasicNodeView {
         visitor: &mut dyn Visitor<T>,
         point: &[f32],
         point_store: &dyn PointStore,
-        node_store: &dyn NodeStoreView,
+        node_store: &dyn NodeStore,
     ) {
         if node_store.is_leaf(self.current_node) {
             self.set_leaf_view(point, point_store, node_store);
@@ -207,7 +207,7 @@ impl BasicNodeView {
         visitor: &mut dyn UniqueMultiVisitor<T, Q>,
         point: &[f32],
         point_store: &dyn PointStore,
-        node_store: &dyn NodeStoreView,
+        node_store: &dyn NodeStore,
     ) {
         if node_store.is_leaf(self.current_node) {
             self.set_leaf_view(point, point_store, node_store);

--- a/Rust/src/pointstore.rs
+++ b/Rust/src/pointstore.rs
@@ -19,7 +19,7 @@ pub trait PointStore {
 }
 
 #[repr(C)]
-pub struct VectorPointStore<L>
+pub struct VectorizedPointStore<L>
 where
     L: Location,
 {
@@ -39,8 +39,10 @@ where
     entries_seen: i32,
 }
 
-impl<L: Location> VectorPointStore<L>
+impl<L> VectorizedPointStore<L>
 where
+    L: Location,
+    usize: From<L>,
     <L as TryFrom<usize>>::Error: Debug,
 {
     pub fn new(
@@ -51,7 +53,7 @@ where
         internal_shingling: bool,
         internal_rotation: bool,
     ) -> Self {
-        VectorPointStore {
+        VectorizedPointStore {
             internal_shingling,
             internal_rotation,
             dimensions,
@@ -86,8 +88,10 @@ where
     }
 }
 
-impl<L: Location> PointStore for VectorPointStore<L>
+impl<L> PointStore for VectorizedPointStore<L>
 where
+    L: Location,
+    usize: From<L>,
     <L as TryFrom<usize>>::Error: Debug,
 {
     fn get_shingled_point(&self, point: &[f32]) -> Vec<f32> {
@@ -131,7 +135,7 @@ where
             + self.location.len() * std::mem::size_of::<L>()
             + self.reference_count.len() * std::mem::size_of::<u8>()
             + self.index_manager.get_size()
-            + std::mem::size_of::<VectorPointStore<L>>()
+            + std::mem::size_of::<VectorizedPointStore<L>>()
     }
 
     fn get_missing_values(&self, values: &[usize]) -> Vec<usize> {

--- a/Rust/src/samplerplustree.rs
+++ b/Rust/src/samplerplustree.rs
@@ -9,11 +9,19 @@ use rand_chacha::ChaCha20Rng;
 
 use crate::{
     samplerplustree::rand::{Rng, RngCore},
-    types::Max,
+    types::{Location, Max},
 };
 
 #[repr(C)]
-pub struct SamplerPlusTree<C, P, N> {
+pub struct SamplerPlusTree<C, P, N>
+where
+    C: Location,
+    usize: From<C>,
+    P: Location,
+    usize: From<P>,
+    N: Location,
+    usize: From<N>,
+{
     tree: RCFTree<C, P, N>,
     sampler: Sampler<P>,
     using_transforms: bool,
@@ -23,14 +31,17 @@ pub struct SamplerPlusTree<C, P, N> {
     random_seed: u64,
 }
 
-impl<C: Max + Copy, P: Max + Copy + std::cmp::PartialEq, N: Max + Copy> SamplerPlusTree<C, P, N>
+impl<C, P, N> SamplerPlusTree<C, P, N>
 where
-    C: std::convert::TryFrom<usize>,
+    C: Location,
     usize: From<C>,
-    P: std::convert::TryFrom<usize>,
+    P: Location,
     usize: From<P>,
-    N: std::convert::TryFrom<usize>,
+    N: Location,
     usize: From<N>,
+    <C as TryFrom<usize>>::Error: Debug,
+    <P as TryFrom<usize>>::Error: Debug,
+    <N as TryFrom<usize>>::Error: Debug,
 {
     pub fn new(
         dimensions: usize,
@@ -41,12 +52,7 @@ where
         time_decay: f64,
         initial_accept_fraction: f64,
         bounding_box_cache_fraction: f64,
-    ) -> Self
-    where
-        <C as TryFrom<usize>>::Error: Debug,
-        <P as TryFrom<usize>>::Error: Debug,
-        <N as TryFrom<usize>>::Error: Debug,
-    {
+    ) -> Self {
         let mut rng = ChaCha20Rng::seed_from_u64(random_seed);
         let self_seed = rng.next_u64();
 
@@ -72,12 +78,7 @@ where
         point_index: usize,
         point_attribute: usize,
         point_store: &dyn PointStore,
-    ) -> (usize, usize)
-    where
-        <C as TryFrom<usize>>::Error: Debug,
-        <P as TryFrom<usize>>::Error: Debug,
-        <N as TryFrom<usize>>::Error: Debug,
-    {
+    ) -> (usize, usize) {
         if point_index != usize::MAX {
             let mut initial = false;
             let mut rng = ChaCha20Rng::seed_from_u64(self.random_seed);
@@ -138,12 +139,7 @@ where
         score_unseen: fn(usize, usize) -> f64,
         damp: fn(usize, usize) -> f64,
         normalizer: fn(f64, usize) -> f64,
-    ) -> f64
-    where
-        <C as TryFrom<usize>>::Error: Debug,
-        <P as TryFrom<usize>>::Error: Debug,
-        <N as TryFrom<usize>>::Error: Debug,
-    {
+    ) -> f64 {
         self.tree.generic_score(
             point,
             point_store,
@@ -166,12 +162,7 @@ where
         score_unseen: fn(usize, usize) -> f64,
         damp: fn(usize, usize) -> f64,
         normalizer: fn(f64, usize) -> f64,
-    ) -> usize
-    where
-        <C as TryFrom<usize>>::Error: Debug,
-        <P as TryFrom<usize>>::Error: Debug,
-        <N as TryFrom<usize>>::Error: Debug,
-    {
+    ) -> usize {
         self.tree.conditional_field(
             positions,
             point,

--- a/Rust/src/scalarscorevisitor.rs
+++ b/Rust/src/scalarscorevisitor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    newnodestore::NodeStoreView,
+    nodestore::NodeStore,
     nodeview::NodeView,
     visitor::{Visitor, VisitorDescriptor},
 };

--- a/Rust/src/types.rs
+++ b/Rust/src/types.rs
@@ -18,7 +18,11 @@ impl Max for usize {
 /// The Location trait is used as a shorthand for the various traits needed by store (e.g., point
 /// store, node store) locations. These are the values vended by stores to reference a stored
 /// value.
-pub trait Location: Copy + Max + std::cmp::PartialEq + Into<usize> + TryFrom<usize> + Sync {}
+pub trait Location:
+    Copy + Max + std::cmp::PartialEq + TryFrom<usize> + std::marker::Send + Sync
+{
+}
 
+impl Location for u8 {}
 impl Location for u16 {}
 impl Location for usize {}


### PR DESCRIPTION
Use the Location trait to simplify the struct and method definitions in node store, random cut tree, etc. Renamed VectorPointStore and NodeStoreView for clarity.

- Use the Location trait consistently where applicable in all files
- Rename VectorPointStore to VectorizedPointStore
- Rename NodeStoreView to NodeStore


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
