### PR TITLE
version bump to 3.0-rc2

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -135,7 +135,7 @@ vector data point, scores the data point, and then updates the model with this
 point. The program output appends a column of anomaly scores to the input:
 
 ```text
-$ java -cp core/target/randomcutforest-core-2.0.1.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
+$ java -cp core/target/randomcutforest-core-3.0-rc2.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
 $ tail example_output.csv
 -5.0029,0.0170,-0.0057,0.8129401629464965
 -4.9975,-0.0102,-0.0065,0.6591046054520615
@@ -154,8 +154,8 @@ read additional usage instructions, including options for setting model
 hyperparameters, using the `--help` flag:
 
 ```text
-$ java -cp core/target/randomcutforest-core-2.0.1.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
-Usage: java -cp target/random-cut-forest-2.0.1.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
+$ java -cp core/target/randomcutforest-core-3.0-rc2.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
+Usage: java -cp target/random-cut-forest-3.0-rc2.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
 
 Compute scalar anomaly scores from the input rows and append them to the output rows.
 
@@ -217,14 +217,14 @@ framework. Build an executable jar containing the benchmark code by running
 To invoke the full benchmark suite:
 
 ```text
-% java -jar benchmark/target/randomcutforest-benchmark-2.0.1-jar-with-dependencies.jar
+% java -jar benchmark/target/randomcutforest-benchmark-3.0-rc2-jar-with-dependencies.jar
 ```
 
 The full benchmark suite takes a long time to run. You can also pass a regex at the command-line, then only matching
 benchmark methods will be executed.
 
 ```text
-% java -jar benchmark/target/randomcutforest-benchmark-2.0.1-jar-with-dependencies.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
+% java -jar benchmark/target/randomcutforest-benchmark-3.0-rc2-jar-with-dependencies.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
 ```
 
 [rcf-paper]: http://proceedings.mlr.press/v48/guha16.pdf

--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>2.0.1</version>
+    <version>3.0-rc2</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>

--- a/Java/core/pom.xml
+++ b/Java/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>2.0.1</version>
+    <version>3.0-rc2</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>2.0.1</version>
+        <version>3.0-rc2</version>
     </parent>
 
     <artifactId>randomcutforest-examples</artifactId>

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>2.0.1</version>
+    <version>3.0-rc2</version>
   </parent>
 
   <artifactId>randomcutforest-parkservices</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>2.0.1</version>
+    <version>3.0-rc2</version>
     <packaging>pom</packaging>
 
     <name>software.amazon.randomcutforest:randomcutforest</name>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>2.0.1</version>
+        <version>3.0-rc2</version>
     </parent>
 
     <artifactId>randomcutforest-serialization</artifactId>

--- a/Java/testutils/pom.xml
+++ b/Java/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>2.0.1</version>
+    <version>3.0-rc2</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

*Issue #, if available:*
#304 
*Description of changes:*
This PR will version bump main to RCF 3.0-rc2. This doesn't mean current latest commit is good for stable release but we are preemptively bumping the current version to reflect next release. Once a RCF 3.0-rc2 is ready for release a 3.0 branch will be cut and the latest commit for the release will be tagged appropriately. This will also make it possible to implement a CICD that will upload snapshots of RCF on merge to main that will be labeled as 3.0-rc2-SNAPSHOT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
