### PR TITLE
fix for issue 318

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/RandomCutTreeMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/RandomCutTreeMapper.java
@@ -40,9 +40,21 @@ public class RandomCutTreeMapper
         int dimension = (state.getDimensions() != 0) ? state.getDimensions() : context.getPointStore().getDimensions();
         // boundingBoxcache is not set deliberately;
         // it should be set after the partial tree is complete
+        // likewise all the leaves, including the root, should be set to
+        // nodeStore.getCapacity()
+        // such that when the partial tree is filled, the correct mass is computed
+        // note that this has no effect on the cuts -- since a single node tree has no
+        // cuts
+        // uncommenting and using the following line would result in such an incorrect
+        // computation
+        // in testRoundTripForSingleNodeForest() where the masses of the trees would be
+        // different by 1
+        // and thus outputAfter() would be triggered differently.
+        // int newRoot = state.getRoot();
+        int newRoot = nodeStore.isLeaf(state.getRoot()) ? nodeStore.getCapacity() : state.getRoot();
         RandomCutTree tree = new RandomCutTree.Builder().dimension(dimension)
                 .storeSequenceIndexesEnabled(state.isStoreSequenceIndexesEnabled()).capacity(state.getMaxSize())
-                .setRoot(state.getRoot()).randomSeed(state.getSeed()).pointStoreView(context.getPointStore())
+                .setRoot(newRoot).randomSeed(state.getSeed()).pointStoreView(context.getPointStore())
                 .nodeStore(nodeStore).centerOfMassEnabled(state.isCenterOfMassEnabled())
                 .outputAfter(state.getOutputAfter()).build();
         return tree;

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapperTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapperTest.java
@@ -95,6 +95,7 @@ public class ThresholdedRandomCutForestMapperTest {
         for (int trials = 0; trials < 10; trials++) {
 
             long seed = new Random().nextLong();
+            System.out.println("Seed " + seed);
             RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
                     .precision(Precision.FLOAT_32).internalShinglingEnabled(false).randomSeed(seed).build();
 
@@ -103,8 +104,8 @@ public class ThresholdedRandomCutForestMapperTest {
                     .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
                     .internalShinglingEnabled(false).anomalyRate(0.01).build();
 
-            Random r = new Random();
-            for (int i = 0; i < new Random().nextInt(1000); i++) {
+            Random r = new Random(seed + 1);
+            for (int i = 0; i < new Random(seed + 2).nextInt(1000); i++) {
                 double[] point = r.ints(dimensions, 0, 50).asDoubleStream().toArray();
                 first.process(point, 0L);
                 forest.update(point);
@@ -119,7 +120,7 @@ public class ThresholdedRandomCutForestMapperTest {
             ThresholdedRandomCutForest second = new ThresholdedRandomCutForest(copyForest, 0.01, null);
 
             //
-            for (int i = 0; i < new Random().nextInt(1000); i++) {
+            for (int i = 0; i < new Random(seed + 3).nextInt(1000); i++) {
                 double[] point = r.ints(dimensions, 0, 50).asDoubleStream().toArray();
                 AnomalyDescriptor firstResult = first.process(point, 0L);
                 AnomalyDescriptor secondResult = second.process(point, 0L);


### PR DESCRIPTION
*Issue #, if available:* 318

*Description of changes:* Fixes the off by 1 computation of the mass of forests which consist of exactly one node -- which can be multiple copies of the same point.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
