### PR TITLE
handling models created via rc1 in rc2

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/store/PointStoreMapper.java
@@ -15,20 +15,21 @@
 
 package com.amazon.randomcutforest.state.store;
 
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
-import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
-import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
-
-import lombok.Getter;
-import lombok.Setter;
-
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.IStateMapper;
 import com.amazon.randomcutforest.state.Version;
 import com.amazon.randomcutforest.store.PointStore;
 import com.amazon.randomcutforest.store.PointStoreLarge;
 import com.amazon.randomcutforest.util.ArrayPacking;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
+import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
 
 @Getter
 @Setter
@@ -53,6 +54,7 @@ public class PointStoreMapper implements IStateMapper<PointStore, PointStoreStat
         int startOfFreeSegment = state.getStartOfFreeSegment();
         int[] refCount = ArrayPacking.unpackInts(state.getRefCount(), indexCapacity, state.isCompressed());
         int[] locationList = new int[indexCapacity];
+        Arrays.fill(locationList,PointStore.INFEASIBLE_LOCN);
         int[] tempList = ArrayPacking.unpackInts(state.getLocationList(), state.isCompressed());
         if (!state.getVersion().equals(Version.V3_0)) {
             int shingleSize = state.getShingleSize();

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/V2TRCFToV3StateConverterTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/V2TRCFToV3StateConverterTest.java
@@ -15,8 +15,15 @@
 
 package com.amazon.randomcutforest.parkservices.state;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.protostuff.ProtostuffIOUtil;
+import io.protostuff.Schema;
+import io.protostuff.runtime.RuntimeSchema;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -24,18 +31,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Random;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-
-import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.protostuff.ProtostuffIOUtil;
-import io.protostuff.Schema;
-import io.protostuff.runtime.RuntimeSchema;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class V2TRCFToV3StateConverterTest {
 
@@ -50,6 +49,11 @@ public class V2TRCFToV3StateConverterTest {
         mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         ThresholdedRandomCutForestState state = mapper.readValue(json, ThresholdedRandomCutForestState.class);
         ThresholdedRandomCutForest forest = trcfMapper.toModel(state);
+        Random r = new Random(0);
+        for (int i = 0; i < 200000; i++) {
+            double[] point = r.ints(forest.getForest().getDimensions(), 0, 50).asDoubleStream().toArray();
+            forest.process(point, 0L);
+        }
         assertNotNull(forest);
     }
 


### PR DESCRIPTION
*Issue #, if available:* 321

*Description of changes:* If a model is created using 3.0- rc-1 then the initialization of unused part of the pointstore array is 0. Whereas in the newer encoding the unused part if INFEASIBLE_LOCN (-1). This causes models created using 3.0-rc1 to generate errors when used with 3.0-rc2. We recommend using the most recent models for efficiency of size and compute. 
