### PR TITLE
rust: enabling dynamic directional density

### DIFF
--- a/Rust/src/common/directionaldensity.rs
+++ b/Rust/src/common/directionaldensity.rs
@@ -1,0 +1,128 @@
+
+use crate::common::divector::DiVector;
+use crate::samplerplustree::boundingbox::BoundingBox;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct InterpolationMeasure {
+    pub measure: DiVector,
+    pub distance: DiVector,
+    pub probability_mass: DiVector,
+    pub sample_size: f32
+}
+
+impl InterpolationMeasure {
+    pub fn empty(dimension: usize, sample_size: f32)  -> Self {
+        InterpolationMeasure {
+            measure: DiVector::empty(dimension),
+            distance: DiVector::empty(dimension),
+            probability_mass: DiVector::empty(dimension),
+            sample_size,
+        }
+    }
+
+    pub fn new(measure : DiVector, distance: DiVector, prob_mass:DiVector,sample_size: f32) -> Self{
+        assert!(measure.dimension() == distance.dimension(), " incorrect lengths");
+        assert!(measure.dimension() == prob_mass.dimension(), " incorrect lengths");
+        InterpolationMeasure{
+            measure: measure.clone(),
+            distance: distance.clone(),
+            probability_mass: prob_mass.clone(),
+            sample_size
+        }
+    }
+
+    pub fn add_to(&self, other: &mut InterpolationMeasure) {
+        self.probability_mass.add_to(&mut other.probability_mass);
+        self.distance.add_to(& mut other.distance);
+        self.measure.add_to(&mut other.measure);
+        other.sample_size += self.sample_size;
+    }
+
+    pub fn divide(&mut self, num: usize){
+        self.scale(1.0/num as f64);
+        self.scale_samples(1.0/num as f64);
+    }
+
+
+    pub fn scale(&mut self, factor : f64) {
+        self.distance.scale(factor);
+        self.probability_mass.scale(factor);
+        self.measure.scale(factor);
+    }
+
+    pub fn scale_samples(&mut self, factor : f64) {
+        self.sample_size =  (self.sample_size as f64 * factor) as f32;
+    }
+
+    pub fn update(&mut self, point: &[f32], bounding_box: &BoundingBox, measure: f64) -> f64{
+        let min_values = bounding_box.get_min_values();
+        let max_values = bounding_box.get_max_values();
+        let minsum: f32 = min_values
+            .iter()
+            .zip(point)
+            .map(|(&x, &y)| if x - y > 0.0 { x - y } else { 0.0 })
+            .sum();
+        let maxsum: f32 = point
+            .iter()
+            .zip(max_values)
+            .map(|(&x, &y)| if x - y > 0.0 { x - y } else { 0.0 })
+            .sum();
+        let sum = maxsum + minsum;
+        let new_range = sum as f64 + bounding_box.get_range_sum();
+        let prob = sum as f64/(new_range);
+        if prob > 0.0 {
+            self.scale( 1.0 - prob);
+            for i in 0.. point.len() {
+                if point[i] > max_values[i] {
+                    let t = (point[i] - max_values[i]) as f64/new_range;
+                    self.distance.high[i] += t * (point[i] - min_values[i]) as f64;
+                    self.probability_mass.high[i] += t;
+                    self.measure.high[i] += measure * t;
+                } else if point[i] < min_values[i] {
+                    let t = (min_values[i] - point[i]) as f64/new_range;
+                    self.distance.low[i] += t * (max_values[i] - point[i]) as f64;
+                    self.probability_mass.low[i] += t;
+                    self.measure.low[i] += measure * t;
+                }
+            }
+        }
+        prob
+    }
+
+    pub fn directional_measure(&self, threshold: f64, manifold_dimension: f64) -> DiVector{
+        assert!(self.sample_size >= 0.0 && self.measure.total() >= 0.0, " cannot have negative samples or measure");
+        if self.sample_size == 0.0f32 || self.measure.total() == 0.0{
+            return DiVector::empty(self.measure.dimension());
+        }
+
+        let mut sum_of_factors = 0.0;
+
+        for i in 0..self.measure.dimension() {
+            let mut t = if self.probability_mass.high_low_sum(i) > 0.0 {
+                self.distance.high_low_sum(i) / self.probability_mass.high_low_sum(i)
+            } else {
+                0.0
+            };
+
+            if t > 0.0 {
+                t = f64::exp(f64::ln(t) * manifold_dimension)
+                    * self.probability_mass.high_low_sum(i);
+            }
+            sum_of_factors += t;
+        }
+
+        let density_factor = 1.0 / (threshold + sum_of_factors);
+        let mut answer = self.measure.clone();
+        answer.scale(density_factor);
+        answer
+    }
+
+    pub fn directional_density(&self) -> DiVector {
+        self.directional_measure(1e-3, self.measure.dimension() as f64)
+    }
+
+    pub fn density(&self) -> f64 {
+       self.directional_density().total()
+    }
+}

--- a/Rust/src/common/directionaldensity.rs
+++ b/Rust/src/common/directionaldensity.rs
@@ -22,12 +22,12 @@ impl InterpolationMeasure {
     }
 
     pub fn new(measure : DiVector, distance: DiVector, prob_mass:DiVector,sample_size: f32) -> Self{
-        assert!(measure.dimension() == distance.dimension(), " incorrect lengths");
-        assert!(measure.dimension() == prob_mass.dimension(), " incorrect lengths");
+        assert!(measure.dimensions() == distance.dimensions(), " incorrect lengths");
+        assert!(measure.dimensions() == prob_mass.dimensions(), " incorrect lengths");
         InterpolationMeasure{
-            measure: measure.clone(),
-            distance: distance.clone(),
-            probability_mass: prob_mass.clone(),
+            measure: measure,
+            distance: distance,
+            probability_mass: prob_mass,
             sample_size
         }
     }
@@ -93,12 +93,12 @@ impl InterpolationMeasure {
     pub fn directional_measure(&self, threshold: f64, manifold_dimension: f64) -> DiVector{
         assert!(self.sample_size >= 0.0 && self.measure.total() >= 0.0, " cannot have negative samples or measure");
         if self.sample_size == 0.0f32 || self.measure.total() == 0.0{
-            return DiVector::empty(self.measure.dimension());
+            return DiVector::empty(self.measure.dimensions());
         }
 
         let mut sum_of_factors = 0.0;
 
-        for i in 0..self.measure.dimension() {
+        for i in 0..self.measure.dimensions() {
             let mut t = if self.probability_mass.high_low_sum(i) > 0.0 {
                 self.distance.high_low_sum(i) / self.probability_mass.high_low_sum(i)
             } else {
@@ -119,7 +119,7 @@ impl InterpolationMeasure {
     }
 
     pub fn directional_density(&self) -> DiVector {
-        self.directional_measure(1e-3, self.measure.dimension() as f64)
+        self.directional_measure(1e-3, self.measure.dimensions() as f64)
     }
 
     pub fn density(&self) -> f64 {

--- a/Rust/src/common/divector.rs
+++ b/Rust/src/common/divector.rs
@@ -163,4 +163,12 @@ impl DiVector {
         }
     }
 
+    pub fn dimension(&self) -> usize {
+        self.high.len()
+    }
+
+    pub fn high_low_sum(&self, index: usize) -> f64 {
+        self.high[index] + self.low[index]
+    }
+
 }

--- a/Rust/src/common/divector.rs
+++ b/Rust/src/common/divector.rs
@@ -163,7 +163,7 @@ impl DiVector {
         }
     }
 
-    pub fn dimension(&self) -> usize {
+    pub fn dimensions(&self) -> usize {
         self.high.len()
     }
 

--- a/Rust/src/common/mod.rs
+++ b/Rust/src/common/mod.rs
@@ -4,3 +4,4 @@ pub mod conditionalfieldsummarizer;
 pub mod intervalstoremanager;
 pub mod multidimdatawithkey;
 pub mod cluster;
+pub(crate) mod directionaldensity;

--- a/Rust/src/common/multidimdatawithkey.rs
+++ b/Rust/src/common/multidimdatawithkey.rs
@@ -81,7 +81,7 @@ impl MultiDimDataWithKey {
         let mut rng = ChaCha20Rng::seed_from_u64(seed);
         assert!(num > 0, " number of elements cannot be 0");
         assert!(mean.len() > 0, " cannot be null");
-        let base_dimension = mean[1].len();
+        let base_dimension = mean[0].len();
         assert!(mean.len() == scale.len(), " need scales and means to be 1-1");
         assert!(weight.len() == mean.len(), " need weights and means to be 1-1");
         for i in 0..mean.len() {

--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -3,7 +3,7 @@ mod pointstore;
 pub mod rcf;
 mod samplerplustree;
 mod types;
-mod visitor;
+pub mod visitor;
 mod util;
 
 extern crate rand;

--- a/Rust/src/samplerplustree/cut.rs
+++ b/Rust/src/samplerplustree/cut.rs
@@ -58,7 +58,7 @@ impl Cut {
             };
 
             let gap: f32 = maxv - minv;
-            if gap > range as f32 {
+            if gap > range as f32 || (gap == range as f32 && dim == point.len()-1) {
                 new_cut = minv + range as f32; // precision lost here
                 if new_cut <= minv || new_cut >= maxv {
                     new_cut = minv;

--- a/Rust/src/samplerplustree/cut.rs
+++ b/Rust/src/samplerplustree/cut.rs
@@ -58,7 +58,7 @@ impl Cut {
             };
 
             let gap: f32 = maxv - minv;
-            if gap > range as f32 || (gap == range as f32 && dim == point.len()-1) {
+            if gap > range as f32 || (gap == range as f32 && gap > 0.0) {
                 new_cut = minv + range as f32; // precision lost here
                 if new_cut <= minv || new_cut >= maxv {
                     new_cut = minv;

--- a/Rust/src/samplerplustree/nodeview.rs
+++ b/Rust/src/samplerplustree/nodeview.rs
@@ -354,7 +354,8 @@ impl LargeNodeView {
     pub fn get_cut_dimension(&self) -> usize {self.cut_dimension}
     pub fn get_cut_value(&self) -> f32 {self.cut_value}
     pub fn get_leaf_point(&self) -> Vec<f32> {self.point_at_leaf.clone()}
-    pub fn get_bounding_box(&self) -> BoundingBox {self.current_box.as_ref().unwrap().copy()}
+    pub fn bounding_box(&self) -> BoundingBox {self.current_box.as_ref().unwrap().copy()}
+    pub fn shadow_box(&self) -> BoundingBox {self.shadow_box.as_ref().unwrap().copy()}
     pub fn assign_probability_of_cut(&self,di_vector:&mut DiVector, point : &[f32]) {
         di_vector.assign_as_probability_of_cut(self.current_box.as_ref().unwrap(),point)
     }

--- a/Rust/src/visitor/interpolationvisitor.rs
+++ b/Rust/src/visitor/interpolationvisitor.rs
@@ -1,0 +1,104 @@
+use num::abs;
+use crate::common::divector::DiVector;
+use crate::common::directionaldensity::InterpolationMeasure;
+use crate::samplerplustree::nodeview::LargeNodeView;
+use crate::visitor::visitor::{Visitor, VisitorInfo};
+
+
+#[repr(C)]
+pub struct InterpolationVisitor {
+    converged: bool,
+    leaf_index: usize,
+    score: f64,
+    tree_mass: usize,
+    hit_duplicate: bool,
+    use_shadow_box: bool,
+    interpolation_measure: InterpolationMeasure
+}
+
+impl InterpolationVisitor {
+    pub fn new(
+        tree_mass: usize,
+        dimension : usize,
+        visitor_info : &VisitorInfo
+    ) -> Self {
+        InterpolationVisitor {
+            tree_mass,
+            leaf_index: usize::MAX,
+            converged: false,
+            score: 0.0,
+            hit_duplicate : false,
+            use_shadow_box : false,
+            interpolation_measure : InterpolationMeasure::empty(dimension,tree_mass as f32)
+        }
+    }
+
+    pub fn create_visitor(
+        tree_mass: usize,
+        parameters: &[usize],
+        visitor_info : &VisitorInfo
+    ) -> InterpolationVisitor {
+        let dimension = parameters[0];
+        InterpolationVisitor::new(tree_mass,dimension,visitor_info)
+    }
+}
+
+impl Visitor<LargeNodeView,InterpolationMeasure> for InterpolationVisitor {
+    fn accept_leaf(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
+        let mass = node_view.get_mass();
+        let leaf_point = node_view.get_leaf_point();
+        self.leaf_index = node_view.get_leaf_index();
+        if mass > visitor_info.ignore_mass {
+            if node_view.is_duplicate() {
+                self.score =
+                    (visitor_info.damp)(mass, self.tree_mass) * (visitor_info.score_seen)(node_view.get_depth(), mass);
+                self.hit_duplicate = true;
+                self.use_shadow_box = true;
+            } else {
+                let t = (visitor_info.score_unseen)(node_view.get_depth(), mass);
+                self.score = t;
+                let bounding_box = node_view.bounding_box();
+                self.interpolation_measure.update(point,&bounding_box,t);
+            }
+        } else {
+            self.score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
+            self.use_shadow_box = true;
+        }
+    }
+
+    fn accept(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
+        if !self.converged {
+            let bounding_box =
+            if !self.use_shadow_box {
+                node_view.bounding_box()
+            } else {
+                node_view.shadow_box()
+            };
+            let new_value = (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
+            let prob = self.interpolation_measure.update(point,&bounding_box,new_value);
+            if prob == 0.0 {
+                self.converged = true;
+            } else {
+                if !self.hit_duplicate {
+                    self.score = (1.0 - prob) * self.score + prob * new_value;
+                }
+            }
+        }
+    }
+
+    fn result(&self, visitor_info:&VisitorInfo) -> InterpolationMeasure {
+        let t = (visitor_info.normalizer)(self.score,self.tree_mass);
+        let mut answer = self.interpolation_measure.clone();
+        answer.measure.normalize(t);
+        answer
+    }
+
+    fn is_converged(&self) -> bool {
+        self.converged
+    }
+
+    fn use_shadow_box(&self) -> bool {
+        self.use_shadow_box
+    }
+
+}

--- a/Rust/src/visitor/mod.rs
+++ b/Rust/src/visitor/mod.rs
@@ -2,3 +2,4 @@ pub mod visitor;
 pub mod scalarscorevisitor;
 pub mod imputevisitor;
 pub mod attributionvisitor;
+pub mod interpolationvisitor;

--- a/Rust/src/visitor/visitor.rs
+++ b/Rust/src/visitor/visitor.rs
@@ -1,5 +1,5 @@
 use crate::l1distance;
-use crate::rcf::{damp, normalizer, score_seen, score_unseen};
+use crate::rcf::{damp, displacement_normalizer, identity, normalizer, score_seen, score_seen_displacement, score_unseen, score_unseen_displacement};
 
 #[repr(C)]
 pub struct VisitorInfo {
@@ -42,6 +42,26 @@ impl VisitorInfo {
             score_unseen,
             damp,
             normalizer,
+            distance : l1distance
+        }
+    }
+    pub fn displacement() -> Self {
+        VisitorInfo {
+            ignore_mass: 0,
+            score_seen : score_seen_displacement,
+            score_unseen : score_unseen_displacement,
+            damp,
+            normalizer : displacement_normalizer,
+            distance : l1distance
+        }
+    }
+    pub fn density() -> Self {
+        VisitorInfo {
+            ignore_mass: 0,
+            score_seen : score_unseen_displacement,
+            score_unseen : score_unseen_displacement,
+            damp,
+            normalizer : identity,
             distance : l1distance
         }
     }

--- a/Rust/tests/basicrcftest.rs
+++ b/Rust/tests/basicrcftest.rs
@@ -146,8 +146,10 @@ fn two_distribution_test_static() {
     assert!(forest.density(&vec1) > capacity as f64 * forest.density(&anomaly));
     assert!(forest.density(&vec2) > capacity as f64 * forest.density(&anomaly));
 
-    // but now, unlike displacement the  calibration if awry at anomalies
-    // and moreiver in the other direction; larger samplesize gives larger densities because
-    // of spurious points coming closer
+    // but now, unlike displacement, the  calibration is awry at potential anomalies
+    // and moreover is in the other direction; larger samplesize gives larger densities because
+    // of spurious points coming closer. This is a core intuition of observations/observability; the
+    // calibration of central tendency (often used in forecast, also densities of dense regions)
+    // has different requirements compared to callibration at extremeties (anomalies, sparse regions)
     assert!(another_forest.density(&anomaly) > 1.5 *forest.density(&anomaly));
     }

--- a/Rust/tests/basicrcftest.rs
+++ b/Rust/tests/basicrcftest.rs
@@ -3,10 +3,12 @@ extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
+
 use num::abs;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
+use rcflib::visitor::visitor::VisitorInfo;
 use rcflib::rcf::{create_rcf, RCF};
 
 
@@ -17,14 +19,15 @@ use rcflib::rcf::{create_rcf, RCF};
 #[test]
 fn two_distribution_test_static() {
 
-    let data_size = 100000;
+    let data_size = 1000;
     let dimensions = 20;
+    let yard_stick =5.0;
     let mut vec1 = vec![0.0f32;dimensions];
     let mut vec2 = vec![0.0f32;dimensions];
-    vec1[0] = 5.0;
-    vec2[0] = - 5.0;
+    vec1[0] = yard_stick;
+    vec2[0] = - yard_stick;
     let scale = vec![vec![0.1f32;dimensions],vec![0.1f32;dimensions]];
-    let mean = vec![vec1,vec2];
+    let mean = vec![vec1.clone(),vec2.clone()].clone();
     let data_with_key = MultiDimDataWithKey::mixture(
         data_size,
         &mean,
@@ -41,7 +44,7 @@ fn two_distribution_test_static() {
     let time_decay = 0.1 / capacity as f64;
     let bounding_box_cache_fraction = 1.0;
     let random_seed = 17;
-    let parallel_enabled: bool = false;
+    let parallel_enabled: bool = true;
     let store_attributes: bool = false;
     let internal_shingling: bool = false;
     let internal_rotation = false;
@@ -61,11 +64,90 @@ fn two_distribution_test_static() {
         bounding_box_cache_fraction,
     );
 
+    let mut another_forest: Box<dyn RCF> = create_rcf(
+        dimensions,
+        shingle_size,
+        capacity*2,
+        number_of_trees,
+        random_seed,
+        store_attributes,
+        parallel_enabled,
+        internal_shingling,
+        internal_rotation,
+        time_decay,
+        initial_accept_fraction,
+        bounding_box_cache_fraction,
+    );
+
     for i in 0..data_with_key.data.len() {
          forest.update(&data_with_key.data[i],0);
+        another_forest.update(&data_with_key.data[i],0);
     }
 
     let anomaly = vec![0.0f32;dimensions];
+
     assert!(forest.score(&anomaly) > 1.5);
-    assert!(abs(forest.score(&anomaly) - forest.attribution(&anomaly).total()) < 1e-6);
+    assert!(forest.displacement_score(&anomaly) * f64::log2(capacity as f64)> 1.5 );
+    let interpolant = forest.interpolation_visitor_traversal(&anomaly,&VisitorInfo::default());
+    let attribution = forest.attribution(&anomaly);
+    assert!(attribution.high[0] > 0.75);
+    assert!(attribution.low[0] > 0.75);
+    for i in 1..dimensions {
+        assert!(attribution.high[i] < 0.1);
+        assert!(attribution.low[i] < 0.1);
+        assert!(abs(attribution.low[i] - interpolant.measure.low[i]) < 1e-6);
+        assert!(abs(attribution.high[i] - interpolant.measure.high[i]) < 1e-6);
+    }
+    assert!(abs(attribution.low[0] - interpolant.measure.low[0]) < 1e-6);
+    assert!(abs(attribution.high[0] - interpolant.measure.high[0]) < 1e-6);
+
+    // a three signma radius
+    assert!(abs(interpolant.distance.high[0] - yard_stick as f64 * interpolant.probability_mass.high[0]) < 0.3);
+    assert!(abs(interpolant.distance.low[0] - yard_stick as f64 * interpolant.probability_mass.low[0]) < 0.3);
+    assert!(interpolant.distance.high[1] < 0.1);
+    assert!(interpolant.distance.low[1] < 0.1);
+    assert!(interpolant.probability_mass.high[1] < 0.1);
+    assert!(interpolant.probability_mass.low[1] < 0.1);
+    assert!(interpolant.probability_mass.high[0] > 0.4);
+    assert!(interpolant.probability_mass.low[0] > 0.4);
+    let score = forest.score(&anomaly);
+
+    assert!(abs(score - attribution.total()) < 1e-6);
+    // score is calibrated for clear cut anomalies, even if sample size doubles ...
+    assert!(abs(score - another_forest.score(&anomaly)) < 0.1 * score);
+
+    // scores of non-anomalies are not calibrated to be he same but
+    // are below 1 and should be close
+
+    assert!(abs(forest.score(&vec1) - another_forest.score(&vec1)) < 0.1);
+    assert!(abs(forest.score(&vec2) - another_forest.score(&vec2)) < 0.1);
+    assert!(forest.score(&vec1) < 0.8);
+    assert!(forest.score(&vec2) < 0.8);
+
+    let displacement_score = forest.displacement_score(&anomaly);
+    // displacement is calibrated for clear cut anomalies
+    // samplesize did not matter for such
+    assert!(abs(displacement_score - another_forest.displacement_score(&anomaly)) < 0.1 * displacement_score);
+
+    // displacement is NOT the same for dense regions; larger samplesize
+    // leads to lower score; in fact the gap is close to the ratio of samplesize
+    // due to normalization
+    assert!(forest.displacement_score(&vec1) > 1.5 * another_forest.displacement_score(&vec1));
+    assert!(forest.displacement_score(&vec2) > 1.5 * another_forest.displacement_score(&vec2));
+
+    // multiplied by log_2 ; the displacement score is in the same numeric
+    // range [0..log_2(sample size) as the regular score
+    assert!(displacement_score * f64::log2(capacity as f64) > 2.0);
+
+    // in contrast to displacement, density is calibrated at the dense points
+    assert!(abs(forest.density(&vec1) - another_forest.density(&vec1)) < 0.1 * forest.density(&vec1));
+    assert!(abs(forest.density(&vec2) - another_forest.density(&vec2)) < 0.1 * forest.density(&vec2));
+    // and much more than at anomalous points
+    assert!(forest.density(&vec1) > capacity as f64 * forest.density(&anomaly));
+    assert!(forest.density(&vec2) > capacity as f64 * forest.density(&anomaly));
+
+    // but now, unlike displacement the  calibration if awry at anomalies
+    // and moreiver in the other direction; larger samplesize gives larger densities because
+    // of spurious points coming closer
+    assert!(another_forest.density(&anomaly) > 1.5 *forest.density(&anomaly));
     }

--- a/Rust/tests/dynamicdensitytest.rs
+++ b/Rust/tests/dynamicdensitytest.rs
@@ -1,0 +1,148 @@
+
+extern crate rand;
+extern crate rand_chacha;
+extern crate rcflib;
+
+use std::f32::consts::PI;
+use num::abs;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
+use rcflib::visitor::visitor::VisitorInfo;
+use rcflib::rcf::{create_rcf, RCF};
+
+
+/// try cargo test --release
+/// these tests are designed to be longish
+
+
+#[test]
+fn dynamic_density() {
+    let dimensions = 2;
+    let shingle_size = 1;
+    let number_of_trees = 50;
+    let capacity = 256;
+    let initial_accept_fraction = 0.1;
+    let _point_store_capacity = capacity * number_of_trees + 1;
+    let time_decay = 0.1 / capacity as f64;
+    let bounding_box_cache_fraction = 1.0;
+    let random_seed = 17;
+    let parallel_enabled: bool = false;
+    let store_attributes: bool = false;
+    let internal_shingling: bool = false;
+    let internal_rotation = false;
+
+    let mut forest: Box<dyn RCF> = create_rcf(
+        dimensions,
+        shingle_size,
+        capacity,
+        number_of_trees,
+        random_seed,
+        store_attributes,
+        parallel_enabled,
+        internal_shingling,
+        internal_rotation,
+        time_decay,
+        initial_accept_fraction,
+        bounding_box_cache_fraction,
+    );
+
+    let data: Vec<Vec<f32>> = generate_fan(1000, 3);
+    let query_point = vec![0.7, 0.0f32];
+
+    for degree in 0..360 {
+        for j in 0..data.len() {
+            forest.update(&rotate_clockwise(&data[j], 2.0 * PI * degree as f32 / 360.0),0);
+        }
+
+        let density = forest.directional_density(&query_point);
+        let value = density.total();
+
+        if (degree <= 60) || ((degree >= 120) && (degree <= 180)) || ((degree >= 240) && (degree <= 300)) {
+            assert!(density.total() < 0.8 * capacity as f64); // the fan is above at 90,210,330
+        }
+
+        if ((degree >= 75) && (degree <= 105)) || ((degree >= 195) && (degree <= 225))
+            || ((degree >= 315) && (degree <= 345)) {
+            assert!(density.total()  > 0.5 * (capacity as f64));
+        }
+
+        // Testing for directionality
+        // There can be unclear directionality when the
+        // blades are right above
+
+        let blade_above_in_y = density.low[1];
+        let blade_below_in_y = density.high[1];
+        let blade_to_the_left = density.high[0];
+        let blade_to_the_right = density.low[0];
+
+        // the tests below have a freedom of 10% of the total value
+        if ((degree >= 75) && (degree <= 85)) || ((degree >= 195) && (degree <= 205))
+            || ((degree >= 315) && (degree <= 325)) {
+            assert!(blade_above_in_y + 0.1 * value > blade_below_in_y);
+            assert!(blade_above_in_y + 0.1 * value > blade_to_the_right);
+        }
+
+        if ((degree >= 95) && (degree <= 105)) || ((degree >= 215) && (degree <= 225))
+            || ((degree >= 335) && (degree <= 345)) {
+            assert!(blade_below_in_y + 0.1 * value > blade_above_in_y);
+            assert!(blade_below_in_y + 0.1 * value > blade_to_the_right);
+        }
+
+        if ((degree >= 60) && (degree <= 75)) || ((degree >= 180) && (degree <= 195))
+            || ((degree >= 300) && (degree <= 315)) {
+            assert!(blade_above_in_y+ 0.1 * value > blade_to_the_left);
+            assert!(blade_above_in_y + 0.1 * value > blade_to_the_right);
+        }
+
+        if ((degree >= 105) && (degree <= 120)) || ((degree >= 225) && (degree <= 240)) || (degree >= 345) {
+            assert!(blade_below_in_y + 0.1 * value > blade_to_the_left);
+            assert!(blade_below_in_y + 0.1 * value > blade_to_the_right);
+        }
+
+        // fans are farthest to the left at 30,150 and 270
+        if ((degree >= 15) && (degree <= 45)) || ((degree >= 135) && (degree <= 165))
+            || ((degree >= 255) && (degree <= 285)) {
+            assert!(blade_to_the_left + 0.1 * value > blade_above_in_y + blade_below_in_y + blade_to_the_right);
+            assert!(blade_above_in_y + blade_below_in_y + 0.1 * value > blade_to_the_right);
+        }
+
+    }
+}
+
+fn generate_fan(num_per_blade : usize, blades: usize) -> Vec<Vec<f32>> {
+    let mut data = Vec::new();
+
+    let data_with_key = MultiDimDataWithKey::mixture(
+        num_per_blade*blades,
+        &vec![vec![0f32,0f32]],
+        &vec![vec![0.05,0.2]],
+        &vec![1.0f32],
+        0
+    );
+    let mut rng = ChaCha20Rng::seed_from_u64(72345);
+    for point in data_with_key.data {
+        let toss : f64 = rng.gen();
+        let mut i = 0;
+        while (i < blades + 1) {
+            if (toss < i as f64 / blades as f64) {
+                let theta = 2.0 * PI * i as f32 / blades as f32;
+                let mut vec = rotate_clockwise(&point, theta);
+                vec[0] += 0.6 * theta.sin();
+                vec[1] += 0.6 * theta.cos();
+                data.push(vec);
+                break;
+            } else {
+                i += 1;
+            }
+        }
+    }
+    data
+}
+
+fn rotate_clockwise(point: &[f32], theta: f32) -> Vec<f32>{
+    let mut result = vec![0.0f32;2];
+    result[0] = theta.cos() * point[0] + theta.sin() * point[1];
+    result[1] = - theta.sin() * point[0] + theta.cos() * point[1];
+    return result;
+}


### PR DESCRIPTION


*Description of changes:* enables the dynamic density estimation (available in Java since V1.0) for Rust and brings the Rust version to (almost) feature parity with the Java RCF 2.0 (but using the layout and space saving of RCF3.0).

We note that the calibration/scaling is different from the Java version. This Rust version is calibrated such that for "high" density regions, the density would be less dependent on sample size. We note that density, in itself, can be less helpful than comparisons of densities (often their logarithms). The basic functions used are very similar to the displacement scoring used in the original paper and thus displacement_score() is enabled as well. Displacement score is calibrated to be in range [0,1] and less sensitive to the sample size (for potential anomalies). 

