### PR TITLE
Reformat files with `cargo fmt`

### DIFF
--- a/Rust/src/common/cluster.rs
+++ b/Rust/src/common/cluster.rs
@@ -1,24 +1,26 @@
 use std::cmp::{max, min};
+
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
+
 use crate::common::samplesummary::SampleSummary;
 
-const PHASE2_THRESHOLD : usize = 2;
+const PHASE2_THRESHOLD: usize = 2;
 const SEPARATION_RATIO_FOR_MERGE: f64 = 0.8;
 const WEIGHT_THRESHOLD: f64 = 1.25;
-const LENGTH_BOUND : usize = 1000;
+const LENGTH_BOUND: usize = 1000;
 
-pub trait Cluster<Q,T: ?Sized> {
+pub trait Cluster<Q, T: ?Sized> {
     // aclsuter should provide a measure of the point set convered by the cluster
     fn weight(&self) -> f64;
     // A cluster is an extended object of a type different from the base type of a
     // point indicated by T (and only the reference is used in the distance function
     // every clustering algorithm implicitly/explicitly defines this function
-    fn distance_to_point(&self, point : &T, distance: fn(&T, &T) -> f64) -> f64;
+    fn distance_to_point(&self, point: &T, distance: fn(&T, &T) -> f64) -> f64;
     // Likewise, the distance function needs to be extended (implicitly/explicitly)
     // to a distance function between clusters
-    fn distance_to_cluster(&self, other : &dyn Cluster<Q,T>, distance: fn(&T, &T) -> f64) -> f64;
+    fn distance_to_cluster(&self, other: &dyn Cluster<Q, T>, distance: fn(&T, &T) -> f64) -> f64;
     // a function that assigns a point indexed by usize from a list of samples to
     // the cluster; note the weight used in the function need not be the entire weight of the
     // sampled point (for example in case of soft assignments)
@@ -34,9 +36,9 @@ pub trait Cluster<Q,T: ?Sized> {
     fn average_radius(&self) -> f64;
     // a function that allows a cluster to absorb another cluster in an agglomerative \
     // clustering algorithm
-    fn absorb(&mut self, another: &dyn Cluster<Q,T>, distance: fn(&T, &T) -> f64);
+    fn absorb(&mut self, another: &dyn Cluster<Q, T>, distance: fn(&T, &T) -> f64);
     // a function to return a list of representatives corresponding to pairs (Q,weight)
-    fn representatives(&self) -> Vec<(Q,f32)>;
+    fn representatives(&self) -> Vec<(Q, f32)>;
     // a function to distill all representatives into a single representative under a given
     // distance function over the base type of the points
     fn primary_representative(&self, distance: fn(&T, &T) -> f64) -> Q;
@@ -46,18 +48,17 @@ pub trait Cluster<Q,T: ?Sized> {
 pub struct Center {
     representative: Vec<f32>,
     weight: f64,
-    points: Vec<(usize,f32)>,
-    sum_of_radii : f64
+    points: Vec<(usize, f32)>,
+    sum_of_radii: f64,
 }
 
-impl Center
-{
+impl Center {
     pub fn new(representative: &[f32], weight: f32) -> Self {
         Center {
             representative: Vec::from(representative),
             weight: weight as f64,
             points: Vec::new(),
-            sum_of_radii: 0.0
+            sum_of_radii: 0.0,
         }
     }
 
@@ -66,12 +67,13 @@ impl Center
     // clearly this is not optimal for means/L_infinity -- but median is more robust
     // and some interpretation in the context of upstream sampling
     //note that this is not a public function
-    fn optimize_small(&mut self, points:&[(&[f32],f32)]) {
+    fn optimize_small(&mut self, points: &[(&[f32], f32)]) {
         let dimensions = self.representative.len();
-        let total : f64 = self.points.iter().map(|a| a.1 as f64).sum();
+        let total: f64 = self.points.iter().map(|a| a.1 as f64).sum();
         for i in 0..dimensions {
-            self.points.sort_by(|a, b| points[a.0].0[i].partial_cmp(&points[b.0].0[i]).unwrap());
-            let position = pick(&self.points,(total/2.0) as f32);
+            self.points
+                .sort_by(|a, b| points[a.0].0[i].partial_cmp(&points[b.0].0[i]).unwrap());
+            let position = pick(&self.points, (total / 2.0) as f32);
             self.representative[i] = points[self.points[position].0].0[i];
         }
     }
@@ -80,29 +82,29 @@ impl Center
     // is now a sample. The same function as optimize_small does not suffice because
     // the borrow checker would not allow samples from self.points be moved and yet borrow self
     // note that this function is called via rayon par_iter() as well
-    fn optimize(&mut self, points:&[(&[f32],f32)], list: &mut[(usize,f32)]) {
+    fn optimize(&mut self, points: &[(&[f32], f32)], list: &mut [(usize, f32)]) {
         let dimensions = self.representative.len();
-        let total : f64 = list.iter().map(|a| a.1 as f64).sum();
+        let total: f64 = list.iter().map(|a| a.1 as f64).sum();
         for i in 0..dimensions {
             list.sort_by(|a, b| points[a.0].0[i].partial_cmp(&points[b.0].0[i]).unwrap());
-            let position = pick(list,(total/2.0) as f32);
+            let position = pick(list, (total / 2.0) as f32);
             self.representative[i] = points[list[position].0].0[i];
         }
     }
 }
 
-impl Cluster<Vec<f32>,[f32]> for Center {
+impl Cluster<Vec<f32>, [f32]> for Center {
     fn weight(&self) -> f64 {
         self.weight
     }
 
-    fn add_point (&mut self, index:usize, weight: f32, dist: f64){
-        self.points.push( (index,weight));
+    fn add_point(&mut self, index: usize, weight: f32, dist: f64) {
+        self.points.push((index, weight));
         self.weight += weight as f64;
         self.sum_of_radii += weight as f64 * dist;
     }
 
-    fn reset(&mut self){
+    fn reset(&mut self) {
         self.points.clear();
         self.weight = 0.0;
         self.sum_of_radii = 0.0;
@@ -112,13 +114,13 @@ impl Cluster<Vec<f32>,[f32]> for Center {
         if self.weight == 0.0 {
             0.0
         } else {
-            self.sum_of_radii/self.weight
+            self.sum_of_radii / self.weight
         }
     }
 
-    fn recompute(&mut self,points:&[(&[f32],f32)],distance : fn(&[f32],&[f32]) -> f64) -> f64{
+    fn recompute(&mut self, points: &[(&[f32], f32)], distance: fn(&[f32], &[f32]) -> f64) -> f64 {
         let old_value = self.sum_of_radii;
-        self.sum_of_radii  = 0.0;
+        self.sum_of_radii = 0.0;
         if self.weight == 0.0 {
             assert!(self.points.len() == 0, "adding points with weight 0.0 ?");
             return 0.0;
@@ -129,39 +131,48 @@ impl Cluster<Vec<f32>,[f32]> for Center {
             self.optimize_small(points);
         } else {
             let mut samples = Vec::new();
-            let mut rng =ChaCha20Rng::seed_from_u64(0);
+            let mut rng = ChaCha20Rng::seed_from_u64(0);
             for i in 0..self.points.len() {
-                if rng.gen::<f64>()  < (200.0 * self.points[i].1 as f64)/self.weight {
-                    samples.push((self.points[i].0,1.0));
+                if rng.gen::<f64>() < (200.0 * self.points[i].1 as f64) / self.weight {
+                    samples.push((self.points[i].0, 1.0));
                 }
-            };
-            self.optimize(points,&mut samples);
+            }
+            self.optimize(points, &mut samples);
         };
 
         for j in 0..self.points.len() {
-                self.sum_of_radii += self.points[j].1 as f64 * distance(&self.representative,points[self.points[j].0].0) as f64;
+            self.sum_of_radii += self.points[j].1 as f64
+                * distance(&self.representative, points[self.points[j].0].0) as f64;
         }
         (old_value - self.sum_of_radii)
     }
 
     fn distance_to_point(&self, point: &[f32], distance: fn(&[f32], &[f32]) -> f64) -> f64 {
-        (distance)(&self.representative,point)
+        (distance)(&self.representative, point)
     }
 
-    fn distance_to_cluster(&self, other: &dyn Cluster<Vec<f32>, [f32]>, distance: fn(&[f32], &[f32]) -> f64) -> f64{
-        other.distance_to_point(&self.representative,distance)
+    fn distance_to_cluster(
+        &self,
+        other: &dyn Cluster<Vec<f32>, [f32]>,
+        distance: fn(&[f32], &[f32]) -> f64,
+    ) -> f64 {
+        other.distance_to_point(&self.representative, distance)
     }
 
-    fn absorb(&mut self, another: &dyn Cluster<Vec<f32>, [f32]>, distance: fn(&[f32], &[f32]) -> f64) {
+    fn absorb(
+        &mut self,
+        another: &dyn Cluster<Vec<f32>, [f32]>,
+        distance: fn(&[f32], &[f32]) -> f64,
+    ) {
         let other_weight = another.weight();
-        let t = f64::exp(2.0*(self.weight - other_weight)/(self.weight + other_weight));
-        let factor = t/(1.0+t);
+        let t = f64::exp(2.0 * (self.weight - other_weight) / (self.weight + other_weight));
+        let factor = t / (1.0 + t);
         let list = another.representatives();
         let mut closest = &list[0].0;
-        let mut dist = distance(&self.representative,closest);
+        let mut dist = distance(&self.representative, closest);
         for i in 1..list.len() {
-            let t = distance(&self.representative,&list[i].0);
-            if t<dist {
+            let t = distance(&self.representative, &list[i].0);
+            if t < dist {
                 closest = &list[i].0;
                 dist = t;
             }
@@ -173,12 +184,11 @@ impl Cluster<Vec<f32>,[f32]> for Center {
                 + (1.0 - factor) * (closest[i] as f64)) as f32;
         }
 
-        self.sum_of_radii += (self.weight *(1.0 - factor)  + factor * other_weight)*dist;
+        self.sum_of_radii += (self.weight * (1.0 - factor) + factor * other_weight) * dist;
     }
 
-
-    fn representatives(&self) -> Vec<(Vec<f32>,f32)> {
-        vec![(self.representative.clone(),self.weight as f32);1]
+    fn representatives(&self) -> Vec<(Vec<f32>, f32)> {
+        vec![(self.representative.clone(), self.weight as f32); 1]
     }
 
     fn primary_representative(&self, distance: fn(&[f32], &[f32]) -> f64) -> Vec<f32> {
@@ -186,14 +196,12 @@ impl Cluster<Vec<f32>,[f32]> for Center {
     }
 }
 
-
-
-fn pick<T>(points: &[(T,f32)], wt : f32) -> usize{
+fn pick<T>(points: &[(T, f32)], wt: f32) -> usize {
     let mut position = 0;
     let mut running = wt;
     for i in 0..points.len() {
         position = i;
-        if running -points[i].1 <= 0.0 {
+        if running - points[i].1 <= 0.0 {
             break;
         } else {
             running -= points[i].1;
@@ -202,10 +210,16 @@ fn pick<T>(points: &[(T,f32)], wt : f32) -> usize{
     position
 }
 
-
-fn assign_and_recompute<Q,U,T: ?Sized>(points : &[(&T,f32)], centers: &mut[U], distance : fn(&T,&T) -> f64,parallel_enabled: bool) -> f64
-where U : Cluster <Q,T> + Send,  T: std::marker::Sync{
-
+fn assign_and_recompute<Q, U, T: ?Sized>(
+    points: &[(&T, f32)],
+    centers: &mut [U],
+    distance: fn(&T, &T) -> f64,
+    parallel_enabled: bool,
+) -> f64
+where
+    U: Cluster<Q, T> + Send,
+    T: std::marker::Sync,
+{
     for j in 0..centers.len() {
         centers[j].reset();
     }
@@ -215,7 +229,7 @@ where U : Cluster <Q,T> + Send,  T: std::marker::Sync{
         let mut dist = vec![0.0; centers.len()];
         let mut min_distance = f64::MAX;
         for j in 0..centers.len() {
-            dist[j] = centers[j].distance_to_point(points[i].0,distance);
+            dist[j] = centers[j].distance_to_point(points[i].0, distance);
             if min_distance > dist[j] {
                 min_distance = dist[j];
             }
@@ -235,25 +249,41 @@ where U : Cluster <Q,T> + Send,  T: std::marker::Sync{
             }
             for j in 0..centers.len() {
                 if dist[j] <= WEIGHT_THRESHOLD * min_distance {
-                    centers[j].add_point(i, (points[i].1 as f64 * min_distance / (sum * dist[j])) as f32, dist[j]);
+                    centers[j].add_point(
+                        i,
+                        (points[i].1 as f64 * min_distance / (sum * dist[j])) as f32,
+                        dist[j],
+                    );
                 }
             }
         }
     }
-    let gain : f64 = if parallel_enabled {
-        centers.par_iter_mut().map(|x| x.recompute(points,distance)).sum()
+    let gain: f64 = if parallel_enabled {
+        centers
+            .par_iter_mut()
+            .map(|x| x.recompute(points, distance))
+            .sum()
     } else {
-        centers.iter_mut().map(|x| x.recompute(points,distance)).sum()
+        centers
+            .iter_mut()
+            .map(|x| x.recompute(points, distance))
+            .sum()
     };
     gain
 }
 
-fn add_center<T : ?Sized,U,Q>(centers : &mut Vec<U>, points: &[(&T,f32)], distance: fn (&T,&T)-> f64, index: usize, create: fn(&T,f32) -> U)
-  where U: Cluster<Q,T> + Send
+fn add_center<T: ?Sized, U, Q>(
+    centers: &mut Vec<U>,
+    points: &[(&T, f32)],
+    distance: fn(&T, &T) -> f64,
+    index: usize,
+    create: fn(&T, f32) -> U,
+) where
+    U: Cluster<Q, T> + Send,
 {
     let mut min_dist = f64::MAX;
     for i in 0..centers.len() {
-        let t = centers[i].distance_to_point(points[index].0,distance);
+        let t = centers[i].distance_to_point(points[index].0, distance);
         if t < min_dist {
             min_dist = t;
         };
@@ -263,30 +293,63 @@ fn add_center<T : ?Sized,U,Q>(centers : &mut Vec<U>, points: &[(&T,f32)], distan
     }
 }
 
-pub fn iterative_clustering<U,Q,T :?Sized>(max_allowed:usize, sampled_points: &[(&T,f32)], create: fn(&T,f32) -> U, distance: fn(&T,&T) -> f64,parallel_enabled: bool)  ->
-Vec<U>
-    where U: Cluster<Q, T> + Send, T: std::marker::Sync
+pub fn iterative_clustering<U, Q, T: ?Sized>(
+    max_allowed: usize,
+    sampled_points: &[(&T, f32)],
+    create: fn(&T, f32) -> U,
+    distance: fn(&T, &T) -> f64,
+    parallel_enabled: bool,
+) -> Vec<U>
+where
+    U: Cluster<Q, T> + Send,
+    T: std::marker::Sync,
 {
-    general_iterative_clustering(max_allowed, sampled_points, max_allowed as u64, parallel_enabled, create, distance, false, true, SEPARATION_RATIO_FOR_MERGE)
+    general_iterative_clustering(
+        max_allowed,
+        sampled_points,
+        max_allowed as u64,
+        parallel_enabled,
+        create,
+        distance,
+        false,
+        true,
+        SEPARATION_RATIO_FOR_MERGE,
+    )
 }
 
-
-pub fn general_iterative_clustering<U,Q,T :?Sized>(max_allowed:usize, sampled_points: &[(&T,f32)], seed: u64, parallel_enabled: bool, create: fn(&T,f32) -> U, distance: fn(&T,&T) -> f64, phase_1_reassign: bool,enable_phase_3: bool, overlap_parameter : f64)  ->
-    Vec<U>
-    where U: Cluster<Q, T> + Send, T: std::marker::Sync
+pub fn general_iterative_clustering<U, Q, T: ?Sized>(
+    max_allowed: usize,
+    sampled_points: &[(&T, f32)],
+    seed: u64,
+    parallel_enabled: bool,
+    create: fn(&T, f32) -> U,
+    distance: fn(&T, &T) -> f64,
+    phase_1_reassign: bool,
+    enable_phase_3: bool,
+    overlap_parameter: f64,
+) -> Vec<U>
+where
+    U: Cluster<Q, T> + Send,
+    T: std::marker::Sync,
 {
     let mut rng = ChaCha20Rng::seed_from_u64(seed);
 
-    let mut centers : Vec<U> = Vec::new();
+    let mut centers: Vec<U> = Vec::new();
     //
     // we now peform an initialization; the sampling corresponds a denoising
     // note that if we are look at 2k random points, we are likely hitting every group of points
     // with weight 1/k whp
 
-    let sampled_sum : f32 = sampled_points.iter().map(|x| x.1).sum();
-    for _k in 0..10 * max_allowed{
+    let sampled_sum: f32 = sampled_points.iter().map(|x| x.1).sum();
+    for _k in 0..10 * max_allowed {
         let wt = (rng.gen::<f64>() * sampled_sum as f64) as f32;
-        add_center(&mut centers, &sampled_points,distance,pick(&sampled_points,wt), create);
+        add_center(
+            &mut centers,
+            &sampled_points,
+            distance,
+            pick(&sampled_points, wt),
+            create,
+        );
     }
 
     assign_and_recompute(&sampled_points, &mut centers, distance, parallel_enabled);
@@ -316,7 +379,9 @@ pub fn general_iterative_clustering<U,Q,T :?Sized>(max_allowed:usize, sampled_po
                     min_nbr = j;
                     min_dist = dist;
                 }
-                let numerator = centers[lower].average_radius() + centers[j].average_radius() + phase_3_distance;
+                let numerator = centers[lower].average_radius()
+                    + centers[j].average_radius()
+                    + phase_3_distance;
                 if numerator >= overlap_parameter * dist {
                     if measure * dist < numerator {
                         first = lower;
@@ -343,7 +408,7 @@ pub fn general_iterative_clustering<U,Q,T :?Sized>(max_allowed:usize, sampled_po
             large.first_mut().unwrap().absorb(&small[first], distance);
             centers.swap_remove(first);
             if phase_1_reassign || centers.len() <= PHASE2_THRESHOLD * max_allowed {
-                assign_and_recompute(&sampled_points, &mut centers, distance,parallel_enabled);
+                assign_and_recompute(&sampled_points, &mut centers, distance, parallel_enabled);
             }
 
             centers.sort_by(|o1, o2| o1.weight().partial_cmp(&o2.weight()).unwrap());
@@ -364,4 +429,3 @@ pub fn general_iterative_clustering<U,Q,T :?Sized>(max_allowed:usize, sampled_po
     centers.sort_by(|o1, o2| o2.weight().partial_cmp(&o1.weight()).unwrap()); // decreasing order
     return centers;
 }
-

--- a/Rust/src/common/directionaldensity.rs
+++ b/Rust/src/common/directionaldensity.rs
@@ -1,6 +1,4 @@
-
-use crate::common::divector::DiVector;
-use crate::samplerplustree::boundingbox::BoundingBox;
+use crate::{common::divector::DiVector, samplerplustree::boundingbox::BoundingBox};
 
 #[repr(C)]
 #[derive(Clone)]
@@ -8,11 +6,11 @@ pub struct InterpolationMeasure {
     pub measure: DiVector,
     pub distance: DiVector,
     pub probability_mass: DiVector,
-    pub sample_size: f32
+    pub sample_size: f32,
 }
 
 impl InterpolationMeasure {
-    pub fn empty(dimension: usize, sample_size: f32)  -> Self {
+    pub fn empty(dimension: usize, sample_size: f32) -> Self {
         InterpolationMeasure {
             measure: DiVector::empty(dimension),
             distance: DiVector::empty(dimension),
@@ -21,41 +19,51 @@ impl InterpolationMeasure {
         }
     }
 
-    pub fn new(measure : DiVector, distance: DiVector, prob_mass:DiVector,sample_size: f32) -> Self{
-        assert!(measure.dimensions() == distance.dimensions(), " incorrect lengths");
-        assert!(measure.dimensions() == prob_mass.dimensions(), " incorrect lengths");
-        InterpolationMeasure{
+    pub fn new(
+        measure: DiVector,
+        distance: DiVector,
+        prob_mass: DiVector,
+        sample_size: f32,
+    ) -> Self {
+        assert!(
+            measure.dimensions() == distance.dimensions(),
+            " incorrect lengths"
+        );
+        assert!(
+            measure.dimensions() == prob_mass.dimensions(),
+            " incorrect lengths"
+        );
+        InterpolationMeasure {
             measure: measure,
             distance: distance,
             probability_mass: prob_mass,
-            sample_size
+            sample_size,
         }
     }
 
     pub fn add_to(&self, other: &mut InterpolationMeasure) {
         self.probability_mass.add_to(&mut other.probability_mass);
-        self.distance.add_to(& mut other.distance);
+        self.distance.add_to(&mut other.distance);
         self.measure.add_to(&mut other.measure);
         other.sample_size += self.sample_size;
     }
 
-    pub fn divide(&mut self, num: usize){
-        self.scale(1.0/num as f64);
-        self.scale_samples(1.0/num as f64);
+    pub fn divide(&mut self, num: usize) {
+        self.scale(1.0 / num as f64);
+        self.scale_samples(1.0 / num as f64);
     }
 
-
-    pub fn scale(&mut self, factor : f64) {
+    pub fn scale(&mut self, factor: f64) {
         self.distance.scale(factor);
         self.probability_mass.scale(factor);
         self.measure.scale(factor);
     }
 
-    pub fn scale_samples(&mut self, factor : f64) {
-        self.sample_size =  (self.sample_size as f64 * factor) as f32;
+    pub fn scale_samples(&mut self, factor: f64) {
+        self.sample_size = (self.sample_size as f64 * factor) as f32;
     }
 
-    pub fn update(&mut self, point: &[f32], bounding_box: &BoundingBox, measure: f64) -> f64{
+    pub fn update(&mut self, point: &[f32], bounding_box: &BoundingBox, measure: f64) -> f64 {
         let min_values = bounding_box.get_min_values();
         let max_values = bounding_box.get_max_values();
         let minsum: f32 = min_values
@@ -70,17 +78,17 @@ impl InterpolationMeasure {
             .sum();
         let sum = maxsum + minsum;
         let new_range = sum as f64 + bounding_box.get_range_sum();
-        let prob = sum as f64/(new_range);
+        let prob = sum as f64 / (new_range);
         if prob > 0.0 {
-            self.scale( 1.0 - prob);
-            for i in 0.. point.len() {
+            self.scale(1.0 - prob);
+            for i in 0..point.len() {
                 if point[i] > max_values[i] {
-                    let t = (point[i] - max_values[i]) as f64/new_range;
+                    let t = (point[i] - max_values[i]) as f64 / new_range;
                     self.distance.high[i] += t * (point[i] - min_values[i]) as f64;
                     self.probability_mass.high[i] += t;
                     self.measure.high[i] += measure * t;
                 } else if point[i] < min_values[i] {
-                    let t = (min_values[i] - point[i]) as f64/new_range;
+                    let t = (min_values[i] - point[i]) as f64 / new_range;
                     self.distance.low[i] += t * (max_values[i] - point[i]) as f64;
                     self.probability_mass.low[i] += t;
                     self.measure.low[i] += measure * t;
@@ -90,9 +98,12 @@ impl InterpolationMeasure {
         prob
     }
 
-    pub fn directional_measure(&self, threshold: f64, manifold_dimension: f64) -> DiVector{
-        assert!(self.sample_size >= 0.0 && self.measure.total() >= 0.0, " cannot have negative samples or measure");
-        if self.sample_size == 0.0f32 || self.measure.total() == 0.0{
+    pub fn directional_measure(&self, threshold: f64, manifold_dimension: f64) -> DiVector {
+        assert!(
+            self.sample_size >= 0.0 && self.measure.total() >= 0.0,
+            " cannot have negative samples or measure"
+        );
+        if self.sample_size == 0.0f32 || self.measure.total() == 0.0 {
             return DiVector::empty(self.measure.dimensions());
         }
 
@@ -123,6 +134,6 @@ impl InterpolationMeasure {
     }
 
     pub fn density(&self) -> f64 {
-       self.directional_density().total()
+        self.directional_density().total()
     }
 }

--- a/Rust/src/common/divector.rs
+++ b/Rust/src/common/divector.rs
@@ -8,94 +8,105 @@ pub struct DiVector {
 }
 
 impl DiVector {
-    pub fn empty(dimension: usize)  -> Self {
-        DiVector{
-            high: vec![0.0;dimension],
-            low: vec![0.0;dimension]
+    pub fn empty(dimension: usize) -> Self {
+        DiVector {
+            high: vec![0.0; dimension],
+            low: vec![0.0; dimension],
         }
     }
 
-    pub fn new(high : &[f64], low :&[f64]) -> Self{
+    pub fn new(high: &[f64], low: &[f64]) -> Self {
         assert!(high.len() == low.len(), " incorrect lengths");
-        DiVector{
-            high : Vec::from(high),
-            low : Vec::from(low)
+        DiVector {
+            high: Vec::from(high),
+            low: Vec::from(low),
         }
     }
 
     pub fn assign_as_probability_of_cut(&mut self, bounding_box: &BoundingBox, point: &[f32]) {
-        let minsum: f64 = self.low
+        let minsum: f64 = self
+            .low
             .iter_mut()
             .zip(bounding_box.get_min_values())
             .zip(point)
-            .map(|((x, &y), &z)| if y - z > 0.0 {
-                *x = (y - z) as f64;
-                *x
-            } else {
-                *x = 0.0;
-                *x
+            .map(|((x, &y), &z)| {
+                if y - z > 0.0 {
+                    *x = (y - z) as f64;
+                    *x
+                } else {
+                    *x = 0.0;
+                    *x
+                }
             })
             .sum();
-        let maxsum: f64 = self.high
+        let maxsum: f64 = self
+            .high
             .iter_mut()
             .zip(point)
             .zip(bounding_box.get_max_values())
-            .map(|((x, &y), &z)| if y - z > 0.0 {
-                *x = (y - z) as f64;
-                *x
-            } else {
-                *x = 0.0;
-                *x
+            .map(|((x, &y), &z)| {
+                if y - z > 0.0 {
+                    *x = (y - z) as f64;
+                    *x
+                } else {
+                    *x = 0.0;
+                    *x
+                }
             })
             .sum();
 
         let sum = minsum + maxsum;
         if sum != 0.0 {
-            self.scale(1.0/(bounding_box.get_range_sum() + sum));
+            self.scale(1.0 / (bounding_box.get_range_sum() + sum));
         }
     }
 
     pub fn assign_as_probability_of_cut_with_missing_coordinates(
         &mut self,
-        bounding_box:&BoundingBox,
+        bounding_box: &BoundingBox,
         point: &[f32],
-        missing_coordinates: &[bool]
+        missing_coordinates: &[bool],
     ) {
-        let minsum: f64 = self.low
+        let minsum: f64 = self
+            .low
             .iter_mut()
             .zip(bounding_box.get_min_values())
             .zip(point)
             .zip(missing_coordinates)
-            .map(|(((x, &y), &z), &b)| if !b && y - z > 0.0 {
-                *x = (y - z) as f64;
-                *x
-            } else {
-                *x = 0.0;
-                *x
+            .map(|(((x, &y), &z), &b)| {
+                if !b && y - z > 0.0 {
+                    *x = (y - z) as f64;
+                    *x
+                } else {
+                    *x = 0.0;
+                    *x
+                }
             })
             .sum();
-        let maxsum: f64 = self.high
+        let maxsum: f64 = self
+            .high
             .iter_mut()
             .zip(point)
             .zip(bounding_box.get_max_values())
             .zip(missing_coordinates)
-            .map(|(((x, &y), &z), &b)| if !b && y - z > 0.0 {
-                *x = (y - z) as f64;
-                *x
-            } else {
-                *x = 0.0;
-                *x
+            .map(|(((x, &y), &z), &b)| {
+                if !b && y - z > 0.0 {
+                    *x = (y - z) as f64;
+                    *x
+                } else {
+                    *x = 0.0;
+                    *x
+                }
             })
             .sum();
 
         let sum = minsum + maxsum;
         if sum != 0.0 {
-            self.scale(1.0/(bounding_box.get_range_sum() + sum));
+            self.scale(1.0 / (bounding_box.get_range_sum() + sum));
         }
     }
 
-
-    pub fn assign(&mut self, other :&DiVector){
+    pub fn assign(&mut self, other: &DiVector) {
         for (x, &y) in self.high.iter_mut().zip(&other.high) {
             *x = y;
         }
@@ -104,38 +115,33 @@ impl DiVector {
         }
     }
 
-    pub fn add_from(&mut self, other: &DiVector, factor : f64) {
-        other.add_to_scaled(self,factor);
+    pub fn add_from(&mut self, other: &DiVector, factor: f64) {
+        other.add_to_scaled(self, factor);
     }
 
     pub fn add_to(&self, other: &mut DiVector) {
-
         for (x, &y) in other.high.iter_mut().zip(&self.high) {
             *x += y;
         }
         for (x, &y) in other.low.iter_mut().zip(&self.low) {
             *x += y;
         }
-
     }
 
-    pub fn add_to_scaled(&self, other: &mut DiVector, factor : f64) {
-
+    pub fn add_to_scaled(&self, other: &mut DiVector, factor: f64) {
         for (x, &y) in other.high.iter_mut().zip(&self.high) {
             *x += y * factor;
         }
         for (x, &y) in other.low.iter_mut().zip(&self.low) {
             *x += y * factor;
         }
-
     }
 
-    pub fn divide(&mut self, num: usize){
-        self.scale(1.0/num as f64)
+    pub fn divide(&mut self, num: usize) {
+        self.scale(1.0 / num as f64)
     }
 
-
-    pub fn scale(&mut self, factor : f64) {
+    pub fn scale(&mut self, factor: f64) {
         for x in self.high.iter_mut() {
             *x *= factor;
         }
@@ -148,10 +154,10 @@ impl DiVector {
         self.high.iter().sum::<f64>() + self.low.iter().sum::<f64>()
     }
 
-    pub fn normalize(&mut self, value : f64) {
+    pub fn normalize(&mut self, value: f64) {
         let current = self.total();
         if current <= 0.0 {
-            let v = value/(2.0 * self.high.len() as f64);
+            let v = value / (2.0 * self.high.len() as f64);
             for x in self.high.iter_mut() {
                 *x = v;
             }
@@ -159,7 +165,7 @@ impl DiVector {
                 *x = v;
             }
         } else {
-            self.scale(value/current);
+            self.scale(value / current);
         }
     }
 
@@ -170,5 +176,4 @@ impl DiVector {
     pub fn high_low_sum(&self, index: usize) -> f64 {
         self.high[index] + self.low[index]
     }
-
 }

--- a/Rust/src/common/mod.rs
+++ b/Rust/src/common/mod.rs
@@ -1,7 +1,7 @@
-pub mod divector;
-pub mod samplesummary;
+pub mod cluster;
 pub mod conditionalfieldsummarizer;
+pub(crate) mod directionaldensity;
+pub mod divector;
 pub mod intervalstoremanager;
 pub mod multidimdatawithkey;
-pub mod cluster;
-pub(crate) mod directionaldensity;
+pub mod samplesummary;

--- a/Rust/src/common/multidimdatawithkey.rs
+++ b/Rust/src/common/multidimdatawithkey.rs
@@ -3,10 +3,11 @@ extern crate rand;
 extern crate rand_chacha;
 use std::f32::consts::PI;
 
-use crate::rand::Rng;
+use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
-use rand::SeedableRng;
+
+use crate::rand::Rng;
 
 pub struct MultiDimDataWithKey {
     pub data: Vec<Vec<f32>>,
@@ -24,8 +25,14 @@ impl MultiDimDataWithKey {
         seed: u64,
         base_dimension: usize,
     ) -> Self {
-        assert!(period.len() == base_dimension, " need a period for each dimension ");
-        assert!(amplitude.len() == base_dimension, " need an amplitude for each dimension");
+        assert!(
+            period.len() == base_dimension,
+            " need a period for each dimension "
+        );
+        assert!(
+            amplitude.len() == base_dimension,
+            " need an amplitude for each dimension"
+        );
         let mut rng = ChaCha20Rng::seed_from_u64(seed);
         let mut noiserng = ChaCha20Rng::seed_from_u64(seed + 1);
         let mut phase: Vec<usize> = Vec::new();
@@ -44,7 +51,8 @@ impl MultiDimDataWithKey {
             let mut new_change = vec![0.0; base_dimension];
             let mut used: bool = false;
             for j in 0..base_dimension {
-                elem[j] = amplitude[j] * (2.0 * PI * (i + phase[j]) as f32 / period[j] as f32).cos()
+                elem[j] = amplitude[j]
+                    * (2.0 * PI * (i + phase[j]) as f32 / period[j] as f32).cos()
                     + noise * noiserng.gen::<f32>();
                 if flag && noiserng.gen::<f64>() < 0.3 {
                     let factor: f32 = 5.0 * (1.0 + noiserng.gen::<f32>());
@@ -66,7 +74,7 @@ impl MultiDimDataWithKey {
         MultiDimDataWithKey {
             data,
             change_indices,
-            labels : Vec::new(),
+            labels: Vec::new(),
             changes,
         }
     }
@@ -76,17 +84,29 @@ impl MultiDimDataWithKey {
         mean: &[Vec<f32>],
         scale: &[Vec<f32>],
         weight: &[f32],
-        seed: u64
+        seed: u64,
     ) -> Self {
         let mut rng = ChaCha20Rng::seed_from_u64(seed);
         assert!(num > 0, " number of elements cannot be 0");
         assert!(mean.len() > 0, " cannot be null");
         let base_dimension = mean[0].len();
-        assert!(mean.len() == scale.len(), " need scales and means to be 1-1");
-        assert!(weight.len() == mean.len(), " need weights and means to be 1-1");
+        assert!(
+            mean.len() == scale.len(),
+            " need scales and means to be 1-1"
+        );
+        assert!(
+            weight.len() == mean.len(),
+            " need weights and means to be 1-1"
+        );
         for i in 0..mean.len() {
-            assert!(mean[i].len() == base_dimension, " must have the same dimensions");
-            assert!(scale[i].len() == base_dimension, "sclaes must have the same dimension as the mean");
+            assert!(
+                mean[i].len() == base_dimension,
+                " must have the same dimensions"
+            );
+            assert!(
+                scale[i].len() == base_dimension,
+                "sclaes must have the same dimension as the mean"
+            );
             assert!(weight[i] >= 0.0, " weights cannot be negative");
         }
         let sum: f32 = weight.iter().sum();
@@ -95,12 +115,12 @@ impl MultiDimDataWithKey {
         let mut labels = Vec::new();
         for _j in 0..num {
             let mut i = 0;
-            let mut wt : f32 = sum * rng.gen::<f32>();
-            while wt > weight[i]  {
+            let mut wt: f32 = sum * rng.gen::<f32>();
+            while wt > weight[i] {
                 wt -= weight[i];
                 i += 1;
             }
-            data.push(new_vec(&mean[i],&scale[i],&mut rng));
+            data.push(new_vec(&mean[i], &scale[i], &mut rng));
             labels.push(i);
         }
 
@@ -108,34 +128,31 @@ impl MultiDimDataWithKey {
             data,
             labels,
             change_indices: vec![],
-            changes: vec![]
+            changes: vec![],
         }
-
     }
-
 }
 
 fn next_element(mean: f32, scale: f32, rng: &mut ChaCha20Rng) -> f32 {
-    let mut r:f32 = f64::sqrt(-2.0f64 * f64::ln(rng.gen::<f64>())) as f32;
+    let mut r: f32 = f64::sqrt(-2.0f64 * f64::ln(rng.gen::<f64>())) as f32;
     // the following is to discard inf being returned from ln()
     while r.is_infinite() {
         r = f64::sqrt(-2.0f64 * f64::ln(rng.gen::<f64>())) as f32;
     }
 
-    let switch : f32 = rng.gen();
+    let switch: f32 = rng.gen();
     if 0.5 < switch {
-        mean + scale * r * f32::cos(2.0*PI*rng.gen::<f32>())
+        mean + scale * r * f32::cos(2.0 * PI * rng.gen::<f32>())
     } else {
-        mean + scale * r * f32::sin(2.0*PI*rng.gen::<f32>())
+        mean + scale * r * f32::sin(2.0 * PI * rng.gen::<f32>())
     }
 }
 
-
-fn new_vec(mean : &[f32], scale: &[f32], rng: &mut ChaCha20Rng) -> Vec<f32>{
+fn new_vec(mean: &[f32], scale: &[f32], rng: &mut ChaCha20Rng) -> Vec<f32> {
     let dimensions = mean.len();
     let mut answer = Vec::new();
     for i in 0..dimensions {
-        answer.push(next_element(mean[i],scale[i],rng));
+        answer.push(next_element(mean[i], scale[i], rng));
     }
     answer
 }

--- a/Rust/src/example.rs
+++ b/Rust/src/example.rs
@@ -1,12 +1,12 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
-use rand_chacha::ChaCha20Rng;
 use rand::{Rng, SeedableRng};
-use rcflib::common::multidimdatawithkey;
-
-use rcflib::rcf::{create_rcf, RCF};
+use rand_chacha::ChaCha20Rng;
+use rcflib::{
+    common::multidimdatawithkey,
+    rcf::{create_rcf, RCF},
+};
 
 fn main() {
     let shingle_size = 8;
@@ -42,14 +42,14 @@ fn main() {
     );
 
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*60.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 60.0);
     }
 
     let data_with_key = multidimdatawithkey::MultiDimDataWithKey::multi_cosine(
         data_size,
-        &vec![60;base_dimension],
+        &vec![60; base_dimension],
         &amplitude,
         noise,
         0,
@@ -62,11 +62,14 @@ fn main() {
     let mut count = 0;
 
     for i in 0..data_with_key.data.len() {
-
         if i > 200 {
             let next_values = forest.extrapolate(1);
             assert!(next_values.len() == base_dimension);
-            error += next_values.iter().zip(&data_with_key.data[i]).map(|(x,y)| ((x-y) as f64 *(x-y) as f64)).sum::<f64>();
+            error += next_values
+                .iter()
+                .zip(&data_with_key.data[i])
+                .map(|(x, y)| ((x - y) as f64 * (x - y) as f64))
+                .sum::<f64>();
             count += base_dimension;
         }
 
@@ -90,5 +93,9 @@ fn main() {
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());
-    println!(" RMSE {},  noise {} ", f64::sqrt(error/count as f64), noise);
+    println!(
+        " RMSE {},  noise {} ",
+        f64::sqrt(error / count as f64),
+        noise
+    );
 }

--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -3,23 +3,25 @@ mod pointstore;
 pub mod rcf;
 mod samplerplustree;
 mod types;
-pub mod visitor;
 mod util;
+pub mod visitor;
 
 extern crate rand;
 extern crate rand_chacha;
 
 use num::abs;
 
-
-pub fn l1distance(a: &[f32], b : &[f32]) -> f64{
-    a.iter().zip(b).map(|(&x,&y)| abs(x as f64 - y as f64)).sum()
+pub fn l1distance(a: &[f32], b: &[f32]) -> f64 {
+    a.iter()
+        .zip(b)
+        .map(|(&x, &y)| abs(x as f64 - y as f64))
+        .sum()
 }
 
-pub fn linfinitydistance(a: &[f32], b : &[f32]) -> f64{
+pub fn linfinitydistance(a: &[f32], b: &[f32]) -> f64 {
     let mut dist = 0.0;
-    for i in 0..a.len(){
-        let t= abs(a[i] as f64 - b[i] as f64);
+    for i in 0..a.len() {
+        let t = abs(a[i] as f64 - b[i] as f64);
         if dist < t {
             dist = t;
         };
@@ -27,7 +29,11 @@ pub fn linfinitydistance(a: &[f32], b : &[f32]) -> f64{
     dist
 }
 
-pub fn l2distance(a: &[f32], b : &[f32]) -> f64{
-    f64::sqrt(a.iter().zip(b).map(|(&x,&y)| (abs(x as f64 -y as f64) * abs ( x as f64 - y as f64))).sum())
+pub fn l2distance(a: &[f32], b: &[f32]) -> f64 {
+    f64::sqrt(
+        a.iter()
+            .zip(b)
+            .map(|(&x, &y)| (abs(x as f64 - y as f64) * abs(x as f64 - y as f64)))
+            .sum(),
+    )
 }
-

--- a/Rust/src/pointstore.rs
+++ b/Rust/src/pointstore.rs
@@ -1,14 +1,13 @@
 extern crate num;
 use std::{collections::HashMap, convert::TryFrom, fmt::Debug};
-use crate::types::Location;
-use crate::common::intervalstoremanager::IntervalStoreManager;
 
+use crate::{common::intervalstoremanager::IntervalStoreManager, types::Location};
 
 pub trait PointStore {
     fn get_shingled_point(&self, point: &[f32]) -> Vec<f32>;
     fn get_size(&self) -> usize;
     fn get_missing_indices(&self, look_ahead: usize, values: &[usize]) -> Vec<usize>;
-    fn get_next_indices(&self,look_ahead : usize) -> Vec<usize>;
+    fn get_next_indices(&self, look_ahead: usize) -> Vec<usize>;
     fn get_copy(&self, index: usize) -> Vec<f32>;
     fn is_equal(&self, point: &[f32], index: usize) -> bool;
     fn get_reference_and_offset(&self, index: usize) -> (&[f32], usize);
@@ -101,7 +100,11 @@ where
         let base = self.dimensions / self.shingle_size;
         if point.len() == base && self.shingle_size > 1 {
             if !self.internal_shingling {
-                println!("The point must be '{}' floats long, got {} ", self.dimensions, point.len());
+                println!(
+                    "The point must be '{}' floats long, got {} ",
+                    self.dimensions,
+                    point.len()
+                );
                 panic!();
             }
             if !self.internal_rotation {
@@ -122,7 +125,11 @@ where
             }
             return new_point;
         } else if point.len() != self.dimensions {
-            println!("The point must be '{}' floats long, got {}", self.dimensions, point.len());
+            println!(
+                "The point must be '{}' floats long, got {}",
+                self.dimensions,
+                point.len()
+            );
             panic!();
         }
         for i in 0..self.dimensions {
@@ -141,7 +148,10 @@ where
 
     fn get_missing_indices(&self, look_ahead: usize, values: &[usize]) -> Vec<usize> {
         if !self.internal_shingling {
-            assert!(look_ahead == 0, "look ahead is meaningless for external shingling");
+            assert!(
+                look_ahead == 0,
+                "look ahead is meaningless for external shingling"
+            );
             return Vec::from(values);
         }
         let mut answer = Vec::new();
@@ -149,7 +159,9 @@ where
         for i in 0..values.len() {
             assert!(values[i] < base);
             if self.internal_rotation {
-                answer.push(((self.next_sequence_index + look_ahead) * base + values[i]) %self.dimensions);
+                answer.push(
+                    ((self.next_sequence_index + look_ahead) * base + values[i]) % self.dimensions,
+                );
             } else {
                 answer.push(self.dimensions - base + values[i]);
             }
@@ -157,10 +169,10 @@ where
         answer
     }
 
-    fn get_next_indices(&self,look_ahead : usize) -> Vec<usize> {
+    fn get_next_indices(&self, look_ahead: usize) -> Vec<usize> {
         let base = self.dimensions / self.shingle_size;
-        let vec : Vec<usize> = (0..base).collect();
-         self.get_missing_indices(look_ahead, &vec)
+        let vec: Vec<usize> = (0..base).collect();
+        self.get_missing_indices(look_ahead, &vec)
     }
 
     fn get_copy(&self, index: usize) -> Vec<f32> {

--- a/Rust/src/samplerplustree/boundingbox.rs
+++ b/Rust/src/samplerplustree/boundingbox.rs
@@ -34,7 +34,7 @@ impl BoundingBox {
     }
 
     pub fn add_box(&mut self, x: &BoundingBox) {
-        self.add_two_arrays(x.get_min_values(),x.get_max_values());
+        self.add_two_arrays(x.get_min_values(), x.get_max_values());
     }
 
     fn add_two_arrays(&mut self, minvalues: &[f32], maxvalues: &[f32]) -> bool {
@@ -97,7 +97,11 @@ impl BoundingBox {
         (sum as f64) / (self.range_sum + sum as f64)
     }
 
-    pub fn probability_of_cut_with_missing_coordinates(&self, point: &[f32], missing_coordinates: &[bool]) -> f64 {
+    pub fn probability_of_cut_with_missing_coordinates(
+        &self,
+        point: &[f32],
+        missing_coordinates: &[bool],
+    ) -> f64 {
         let minsum: f32 = self
             .min_values
             .iter()
@@ -109,7 +113,7 @@ impl BoundingBox {
             .iter()
             .zip(self.get_max_values())
             .zip(missing_coordinates)
-            .map(|((&x, &y),&z)| if !z && x - y > 0.0 { x - y } else { 0.0 })
+            .map(|((&x, &y), &z)| if !z && x - y > 0.0 { x - y } else { 0.0 })
             .sum();
         let sum = maxsum + minsum;
 
@@ -120,5 +124,4 @@ impl BoundingBox {
         }
         (sum as f64) / (self.range_sum + sum as f64)
     }
-
 }

--- a/Rust/src/samplerplustree/mod.rs
+++ b/Rust/src/samplerplustree/mod.rs
@@ -1,7 +1,7 @@
-pub mod samplerplustree;
-pub mod sampler;
-mod randomcuttree;
-pub mod nodeview;
-pub mod nodestore;
-mod cut;
 pub mod boundingbox;
+mod cut;
+pub mod nodestore;
+pub mod nodeview;
+mod randomcuttree;
+pub mod sampler;
+pub mod samplerplustree;

--- a/Rust/src/samplerplustree/nodeview.rs
+++ b/Rust/src/samplerplustree/nodeview.rs
@@ -1,92 +1,146 @@
-use crate::common::divector::DiVector;
-use crate::pointstore::PointStore;
-use crate::samplerplustree::boundingbox::BoundingBox;
-use crate::samplerplustree::nodestore::NodeStore;
-use crate::visitor::visitor::VisitorInfo;
+use crate::{
+    common::divector::DiVector,
+    pointstore::PointStore,
+    samplerplustree::{boundingbox::BoundingBox, nodestore::NodeStore},
+    visitor::visitor::VisitorInfo,
+};
 
 pub trait UpdatableNodeView<NS, PS>
-    where
-        NS: NodeStore,
-        PS: PointStore,
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
-    fn create(root:usize, node_store:&NS) -> Self;
-    fn update_at_leaf(&mut self, point: &[f32], index: usize, node_store:&NS, point_store: &PS, visitor_info: &VisitorInfo);
-    fn update_from_node_traversing_down(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS, visitor_info: &VisitorInfo);
-    fn update_from_node_traversing_up(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS, visitor_info: &VisitorInfo);
-    fn get_current_node(&self) -> usize;
-    fn set_use_shadow_box(&mut self, node_store:&NS, point_store: &PS);
-}
-
-pub trait UpdatableMultiNodeView<NS, PS> : UpdatableNodeView<NS, PS>
-    where
-        NS: NodeStore,
-        PS: PointStore,
-{
-    fn create(root:usize, node_store:&NS) -> Self;
-    fn set_trigger_traversing_down(&mut self,point :&[f32],parent : usize, node_store : &NS, point_store : &PS,visitor_info : &VisitorInfo);
-    fn update_view_to_parent_with_missing_coordinates(&mut self,
-    parent : usize,
-    point : &[f32],
-    missing_coordinates : &[bool],
-    node_store :&NS,
-    point_store : &PS,
-    visitor_info : &VisitorInfo
+    fn create(root: usize, node_store: &NS) -> Self;
+    fn update_at_leaf(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
     );
-    fn set_current_node(&mut self, index:usize);
-    fn get_bounding_box(&self) -> Option<BoundingBox>;
-    fn merge_paths(&mut self, parent : usize,saved_box: Option<BoundingBox>,point:&[f32],missing_coordinates:&[bool],node_store:&NS,point_store :&PS);
+    fn update_from_node_traversing_down(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    );
+    fn update_from_node_traversing_up(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    );
+    fn get_current_node(&self) -> usize;
+    fn set_use_shadow_box(&mut self, node_store: &NS, point_store: &PS);
 }
 
-
+pub trait UpdatableMultiNodeView<NS, PS>: UpdatableNodeView<NS, PS>
+where
+    NS: NodeStore,
+    PS: PointStore,
+{
+    fn create(root: usize, node_store: &NS) -> Self;
+    fn set_trigger_traversing_down(
+        &mut self,
+        point: &[f32],
+        parent: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    );
+    fn update_view_to_parent_with_missing_coordinates(
+        &mut self,
+        parent: usize,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    );
+    fn set_current_node(&mut self, index: usize);
+    fn get_bounding_box(&self) -> Option<BoundingBox>;
+    fn merge_paths(
+        &mut self,
+        parent: usize,
+        saved_box: Option<BoundingBox>,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+    );
+}
 
 #[repr(C)]
 pub struct SmallNodeView {
-    current_node : usize,
+    current_node: usize,
     probability_of_cut: f64,
-    shadow_box_probablity_of_cut : f64,
+    shadow_box_probablity_of_cut: f64,
     mass: usize,
-    depth : usize,
+    depth: usize,
     leaf_index: usize,
     leaf_duplicate: bool,
     use_shadow_box: bool,
-    current_box : Option<BoundingBox>,
-    shadow_box : Option<BoundingBox>
+    current_box: Option<BoundingBox>,
+    shadow_box: Option<BoundingBox>,
 }
 
 impl SmallNodeView {
-    pub fn get_probability_of_cut(&self) -> f64 {self.probability_of_cut}
-    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {self.shadow_box_probablity_of_cut}
-    pub fn get_mass(&self) -> usize {self.mass}
-    pub fn get_depth(&self) -> usize {self.depth}
-    pub fn get_leaf_index(&self) -> usize {self.leaf_index}
-    pub fn is_duplicate(&self) -> bool {self.leaf_duplicate}
-    pub fn new<NS:NodeStore>(root : usize, node_store : &NS) -> Self {
+    pub fn get_probability_of_cut(&self) -> f64 {
+        self.probability_of_cut
+    }
+    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {
+        self.shadow_box_probablity_of_cut
+    }
+    pub fn get_mass(&self) -> usize {
+        self.mass
+    }
+    pub fn get_depth(&self) -> usize {
+        self.depth
+    }
+    pub fn get_leaf_index(&self) -> usize {
+        self.leaf_index
+    }
+    pub fn is_duplicate(&self) -> bool {
+        self.leaf_duplicate
+    }
+    pub fn new<NS: NodeStore>(root: usize, node_store: &NS) -> Self {
         SmallNodeView {
-            current_node : root,
+            current_node: root,
             probability_of_cut: f64::MAX, // not feasible; but that is the point!
             shadow_box_probablity_of_cut: f64::MAX,
             mass: 0,
             depth: 0,
             leaf_index: usize::MAX,
             leaf_duplicate: false,
-            use_shadow_box : false,
-            current_box : None,
-            shadow_box   : None
+            use_shadow_box: false,
+            current_box: None,
+            shadow_box: None,
         }
     }
 }
 
-
 impl<NS, PS> UpdatableNodeView<NS, PS> for SmallNodeView
-    where
-        NS: NodeStore,
-        PS: PointStore,
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
     fn create(root: usize, _node_store: &NS) -> Self {
-        SmallNodeView::new(root,_node_store)
+        SmallNodeView::new(root, _node_store)
     }
 
-    fn update_at_leaf(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS, visito_info:&VisitorInfo) {
+    fn update_at_leaf(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visito_info: &VisitorInfo,
+    ) {
         self.leaf_index = node_store.get_leaf_point_index(index);
         self.mass = node_store.get_mass(index);
         self.probability_of_cut = if point_store.is_equal(point, self.leaf_index) {
@@ -97,37 +151,52 @@ impl<NS, PS> UpdatableNodeView<NS, PS> for SmallNodeView
             1.0f64
         };
         if node_store.use_path_for_box() {
-            self.current_box = Some(node_store.get_box(self.current_node,point_store));
+            self.current_box = Some(node_store.get_box(self.current_node, point_store));
         }
     }
 
-    fn update_from_node_traversing_down(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
-        if node_store.is_left_of(self.current_node,point) {
+    fn update_from_node_traversing_down(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        if node_store.is_left_of(self.current_node, point) {
             self.current_node = node_store.get_left_index(self.current_node);
-        }  else {
+        } else {
             self.current_node = node_store.get_right_index(self.current_node);
         }
         self.depth += 1;
     }
 
-    fn update_from_node_traversing_up(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
-        self.probability_of_cut = match &mut self.current_box{
-            Some( x) => {
-                let sibling = node_store.get_sibling(self.current_node,index);
+    fn update_from_node_traversing_up(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        self.probability_of_cut = match &mut self.current_box {
+            Some(x) => {
+                let sibling = node_store.get_sibling(self.current_node, index);
                 if self.use_shadow_box {
                     let z = node_store.get_box(sibling, point_store);
                     x.add_box(&z);
                     match &mut self.shadow_box {
-                        Some(y) => { y.add_box(&z)},
-                        None => { self.shadow_box = Some(z)},
+                        Some(y) => y.add_box(&z),
+                        None => self.shadow_box = Some(z),
                     }
-                    self.shadow_box_probablity_of_cut = self.shadow_box.as_ref().unwrap().probability_of_cut(point);
+                    self.shadow_box_probablity_of_cut =
+                        self.shadow_box.as_ref().unwrap().probability_of_cut(point);
                 } else {
                     node_store.grow_node_box(x, point_store, index, sibling);
                 };
                 x.probability_of_cut(point)
             }
-            None => node_store.get_probability_of_cut(index, point, point_store)
+            None => node_store.get_probability_of_cut(index, point, point_store),
         };
         self.current_node = index;
         self.mass = node_store.get_mass(index);
@@ -138,47 +207,65 @@ impl<NS, PS> UpdatableNodeView<NS, PS> for SmallNodeView
         self.current_node
     }
 
-    fn set_use_shadow_box(&mut self, node_store: &NS, point_store:&PS) {
+    fn set_use_shadow_box(&mut self, node_store: &NS, point_store: &PS) {
         self.use_shadow_box = true;
         // we will maintain a current box since we haver to maintain a shadow box in any case
         // the shadow box is not set; it can only be set at the next level
         // when update_from_node_up() is invoked
         // we will maintain the invariant that *if the shadow is present then the current box also is present*
-        self.current_box=Some(node_store.get_box(self.current_node,point_store));
+        self.current_box = Some(node_store.get_box(self.current_node, point_store));
     }
 }
 
 #[repr(C)]
 pub struct MediumNodeView {
-    current_node : usize,
+    current_node: usize,
     sibling: usize,
     probability_of_cut: f64,
-    shadow_box_probablity_of_cut : f64,
+    shadow_box_probablity_of_cut: f64,
     mass: usize,
-    depth : usize,
+    depth: usize,
     leaf_index: usize,
     leaf_duplicate: bool,
     use_shadow_box: bool,
-    current_box : Option<BoundingBox>,
-    shadow_box : Option<BoundingBox>,
+    current_box: Option<BoundingBox>,
+    shadow_box: Option<BoundingBox>,
     cut_dimension: usize,
-    cut_value : f32,
-    point_at_leaf : Vec<f32>
+    cut_value: f32,
+    point_at_leaf: Vec<f32>,
 }
 
 impl MediumNodeView {
-    pub fn get_probability_of_cut(&self) -> f64 {self.probability_of_cut}
-    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {self.shadow_box_probablity_of_cut}
-    pub fn get_mass(&self) -> usize {self.mass}
-    pub fn get_depth(&self) -> usize {self.depth}
-    pub fn get_leaf_index(&self) -> usize {self.leaf_index}
-    pub fn is_duplicate(&self) -> bool {self.leaf_duplicate}
-    pub fn get_cut_dimension(&self) -> usize {self.cut_dimension}
-    pub fn get_cut_value(&self) -> f32 {self.cut_value}
-    pub fn get_leaf_point(&self) -> Vec<f32> {self.point_at_leaf.clone()}
-    pub fn new<NS:NodeStore>(root : usize, node_store : &NS) -> Self {
-        let (cut_dimension,cut_value,left_child,right_child)
-            = node_store.get_cut_and_children(root);
+    pub fn get_probability_of_cut(&self) -> f64 {
+        self.probability_of_cut
+    }
+    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {
+        self.shadow_box_probablity_of_cut
+    }
+    pub fn get_mass(&self) -> usize {
+        self.mass
+    }
+    pub fn get_depth(&self) -> usize {
+        self.depth
+    }
+    pub fn get_leaf_index(&self) -> usize {
+        self.leaf_index
+    }
+    pub fn is_duplicate(&self) -> bool {
+        self.leaf_duplicate
+    }
+    pub fn get_cut_dimension(&self) -> usize {
+        self.cut_dimension
+    }
+    pub fn get_cut_value(&self) -> f32 {
+        self.cut_value
+    }
+    pub fn get_leaf_point(&self) -> Vec<f32> {
+        self.point_at_leaf.clone()
+    }
+    pub fn new<NS: NodeStore>(root: usize, node_store: &NS) -> Self {
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(root);
         let mass = node_store.get_mass(root);
         Self {
             current_node: root,
@@ -194,21 +281,28 @@ impl MediumNodeView {
             shadow_box: None,
             cut_dimension,
             cut_value,
-            point_at_leaf: Vec::new()
+            point_at_leaf: Vec::new(),
         }
     }
 }
 
 impl<NS, PS> UpdatableNodeView<NS, PS> for MediumNodeView
-    where
-        NS: NodeStore,
-        PS: PointStore,
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
-    fn create(root: usize, node_store : &NS) -> Self {
-        MediumNodeView::new(root,node_store)
+    fn create(root: usize, node_store: &NS) -> Self {
+        MediumNodeView::new(root, node_store)
     }
 
-    fn update_at_leaf(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS, visitor_info:&VisitorInfo) {
+    fn update_at_leaf(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
         self.leaf_index = node_store.get_leaf_point_index(index);
         self.point_at_leaf = point_store.get_copy(self.leaf_index);
         self.mass = node_store.get_mass(index);
@@ -220,83 +314,128 @@ impl<NS, PS> UpdatableNodeView<NS, PS> for MediumNodeView
             1.0f64
         };
         if node_store.use_path_for_box() {
-            self.current_box = Some(BoundingBox::new(&self.point_at_leaf,&self.point_at_leaf));
+            self.current_box = Some(BoundingBox::new(&self.point_at_leaf, &self.point_at_leaf));
         }
     }
 
-    fn update_from_node_traversing_down(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
-        if node_store.is_left_of(self.current_node,point) {
+    fn update_from_node_traversing_down(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        if node_store.is_left_of(self.current_node, point) {
             self.current_node = node_store.get_left_index(self.current_node);
-        }  else {
+        } else {
             self.current_node = node_store.get_right_index(self.current_node);
         }
         self.depth += 1;
     }
 
-    fn update_from_node_traversing_up(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
-        self.probability_of_cut = match &mut self.current_box{
-            Some( x) => {
-                self.sibling = node_store.get_sibling(self.current_node,index);
+    fn update_from_node_traversing_up(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        self.probability_of_cut = match &mut self.current_box {
+            Some(x) => {
+                self.sibling = node_store.get_sibling(self.current_node, index);
                 if self.use_shadow_box {
                     let z = node_store.get_box(self.sibling, point_store);
                     x.add_box(&z);
                     match &mut self.shadow_box {
-                        Some(y) => { y.add_box(&z)},
-                        None => { self.shadow_box = Some(z)},
+                        Some(y) => y.add_box(&z),
+                        None => self.shadow_box = Some(z),
                     }
-                    self.shadow_box_probablity_of_cut = self.shadow_box.as_ref().unwrap().probability_of_cut(point);
+                    self.shadow_box_probablity_of_cut =
+                        self.shadow_box.as_ref().unwrap().probability_of_cut(point);
                 } else {
                     node_store.grow_node_box(x, point_store, index, self.sibling);
                 };
                 x.probability_of_cut(point)
             }
-            None => node_store.get_probability_of_cut(index, point, point_store)
+            None => node_store.get_probability_of_cut(index, point, point_store),
         };
         self.current_node = index;
-        let (cut_dimension,cut_value,left_child,right_child) = node_store.get_cut_and_children(self.current_node);
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = cut_dimension;
         self.cut_value = cut_value;
         self.mass = node_store.get_mass(index);
         self.depth -= 1;
     }
 
-
     fn get_current_node(&self) -> usize {
         self.current_node
     }
 
-    fn set_use_shadow_box(&mut self, node_store: &NS, point_store:&PS) {
+    fn set_use_shadow_box(&mut self, node_store: &NS, point_store: &PS) {
         self.use_shadow_box = true;
         // we will maintain a current box since we haver to maintain a shadow box in any case
         // the shadow box is not set; it can only be set at the next level
         // when update_from_node_up() is invoked
         // we will maintain the invariant that *if the shadow is present then the current box also is present*
-        self.current_box=Some(node_store.get_box(self.current_node,point_store));
+        self.current_box = Some(node_store.get_box(self.current_node, point_store));
     }
 }
 
-impl<NS,PS> UpdatableMultiNodeView<NS, PS> for MediumNodeView
-    where
-        NS: NodeStore,
-        PS: PointStore,
+impl<NS, PS> UpdatableMultiNodeView<NS, PS> for MediumNodeView
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
-    fn create(root: usize, node_store : &NS) -> Self {
-        MediumNodeView::new(root,node_store)
+    fn create(root: usize, node_store: &NS) -> Self {
+        MediumNodeView::new(root, node_store)
     }
 
-    fn set_trigger_traversing_down(&mut self, point: &[f32], parent: usize, node_store: &NS, point_store: &PS, visitor_info : &VisitorInfo) {
-        let (cut_dimension,cut_value,left_child,right_child) = node_store.get_cut_and_children(self.current_node);
+    fn set_trigger_traversing_down(
+        &mut self,
+        point: &[f32],
+        parent: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = cut_dimension;
         self.cut_value = cut_value;
     }
 
-    fn update_view_to_parent_with_missing_coordinates(&mut self, parent: usize, point: &[f32], missing_coordinates: &[bool], node_store: &NS, point_store: &PS, visitor_info: &VisitorInfo) {
-        if node_store.use_path_for_box(){
-            let sibling = node_store.get_sibling(self.current_node,parent);
-            node_store.grow_node_box(self.current_box.as_mut().unwrap(), point_store,parent,sibling);
-            self.probability_of_cut = self.current_box.as_ref().unwrap().probability_of_cut_with_missing_coordinates(point,missing_coordinates);
+    fn update_view_to_parent_with_missing_coordinates(
+        &mut self,
+        parent: usize,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        if node_store.use_path_for_box() {
+            let sibling = node_store.get_sibling(self.current_node, parent);
+            node_store.grow_node_box(
+                self.current_box.as_mut().unwrap(),
+                point_store,
+                parent,
+                sibling,
+            );
+            self.probability_of_cut = self
+                .current_box
+                .as_ref()
+                .unwrap()
+                .probability_of_cut_with_missing_coordinates(point, missing_coordinates);
         } else {
-            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(parent,point,missing_coordinates,point_store);
+            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(
+                parent,
+                point,
+                missing_coordinates,
+                point_store,
+            );
         }
         self.current_node = parent;
     }
@@ -312,13 +451,33 @@ impl<NS,PS> UpdatableMultiNodeView<NS, PS> for MediumNodeView
         }
     }
 
-    fn merge_paths(&mut self, parent: usize, saved_box: Option<BoundingBox>, point: &[f32], missing_coordinates: &[bool], node_store: &NS, point_store: &PS) {
-        if node_store.use_path_for_box(){
+    fn merge_paths(
+        &mut self,
+        parent: usize,
+        saved_box: Option<BoundingBox>,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+    ) {
+        if node_store.use_path_for_box() {
             // both boxes, current and saved, should be present as invariant
-            self.current_box.as_mut().unwrap().add_box(saved_box.as_ref().unwrap());
-            self.probability_of_cut = self.current_box.as_ref().unwrap().probability_of_cut_with_missing_coordinates(point,missing_coordinates);
+            self.current_box
+                .as_mut()
+                .unwrap()
+                .add_box(saved_box.as_ref().unwrap());
+            self.probability_of_cut = self
+                .current_box
+                .as_ref()
+                .unwrap()
+                .probability_of_cut_with_missing_coordinates(point, missing_coordinates);
         } else {
-            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(parent,point,missing_coordinates,point_store);
+            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(
+                parent,
+                point,
+                missing_coordinates,
+                point_store,
+            );
         }
         self.current_node = parent;
     }
@@ -326,46 +485,68 @@ impl<NS,PS> UpdatableMultiNodeView<NS, PS> for MediumNodeView
 
 #[repr(C)]
 pub struct LargeNodeView {
-    current_node : usize,
+    current_node: usize,
     sibling: usize,
     probability_of_cut: f64,
-    shadow_box_probablity_of_cut : f64,
+    shadow_box_probablity_of_cut: f64,
     mass: usize,
-    depth : usize,
+    depth: usize,
     leaf_index: usize,
     leaf_duplicate: bool,
     use_shadow_box: bool,
-    current_box : Option<BoundingBox>,
-    shadow_box : Option<BoundingBox>,
+    current_box: Option<BoundingBox>,
+    shadow_box: Option<BoundingBox>,
     cut_dimension: usize,
-    cut_value : f32,
+    cut_value: f32,
     left_child: usize,
     right_child: usize,
-    point_at_leaf : Vec<f32>
+    point_at_leaf: Vec<f32>,
 }
 
 impl LargeNodeView {
-    pub fn get_probability_of_cut(&self) -> f64 {self.probability_of_cut}
-    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {self.shadow_box_probablity_of_cut}
-    pub fn get_mass(&self) -> usize {self.mass}
-    pub fn get_depth(&self) -> usize {self.depth}
-    pub fn get_leaf_index(&self) -> usize {self.leaf_index}
-    pub fn is_duplicate(&self) -> bool {self.leaf_duplicate}
-    pub fn get_cut_dimension(&self) -> usize {self.cut_dimension}
-    pub fn get_cut_value(&self) -> f32 {self.cut_value}
-    pub fn get_leaf_point(&self) -> Vec<f32> {self.point_at_leaf.clone()}
-    pub fn bounding_box(&self) -> BoundingBox {self.current_box.as_ref().unwrap().copy()}
-    pub fn shadow_box(&self) -> BoundingBox {self.shadow_box.as_ref().unwrap().copy()}
-    pub fn assign_probability_of_cut(&self,di_vector:&mut DiVector, point : &[f32]) {
-        di_vector.assign_as_probability_of_cut(self.current_box.as_ref().unwrap(),point)
+    pub fn get_probability_of_cut(&self) -> f64 {
+        self.probability_of_cut
     }
-    pub fn assign_probability_of_cut_shadow_box(&self,di_vector:&mut DiVector, point : &[f32]) {
+    pub fn get_shadow_box_probability_of_cut(&self) -> f64 {
+        self.shadow_box_probablity_of_cut
+    }
+    pub fn get_mass(&self) -> usize {
+        self.mass
+    }
+    pub fn get_depth(&self) -> usize {
+        self.depth
+    }
+    pub fn get_leaf_index(&self) -> usize {
+        self.leaf_index
+    }
+    pub fn is_duplicate(&self) -> bool {
+        self.leaf_duplicate
+    }
+    pub fn get_cut_dimension(&self) -> usize {
+        self.cut_dimension
+    }
+    pub fn get_cut_value(&self) -> f32 {
+        self.cut_value
+    }
+    pub fn get_leaf_point(&self) -> Vec<f32> {
+        self.point_at_leaf.clone()
+    }
+    pub fn bounding_box(&self) -> BoundingBox {
+        self.current_box.as_ref().unwrap().copy()
+    }
+    pub fn shadow_box(&self) -> BoundingBox {
+        self.shadow_box.as_ref().unwrap().copy()
+    }
+    pub fn assign_probability_of_cut(&self, di_vector: &mut DiVector, point: &[f32]) {
+        di_vector.assign_as_probability_of_cut(self.current_box.as_ref().unwrap(), point)
+    }
+    pub fn assign_probability_of_cut_shadow_box(&self, di_vector: &mut DiVector, point: &[f32]) {
         assert!(self.use_shadow_box, "shadow box not in use");
-        di_vector.assign_as_probability_of_cut(self.shadow_box.as_ref().unwrap(),point)
+        di_vector.assign_as_probability_of_cut(self.shadow_box.as_ref().unwrap(), point)
     }
-    pub fn new<NS: NodeStore>(root:usize,node_store:&NS) -> Self {
-        let (cut_dimension, cut_value, left_child, right_child)
-            = node_store.get_cut_and_children(root);
+    pub fn new<NS: NodeStore>(root: usize, node_store: &NS) -> Self {
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(root);
         let mass = node_store.get_mass(root);
         Self {
             current_node: root,
@@ -383,21 +564,28 @@ impl LargeNodeView {
             cut_value,
             left_child,
             right_child,
-            point_at_leaf: Vec::new()
+            point_at_leaf: Vec::new(),
         }
     }
 }
 
 impl<NS, PS> UpdatableNodeView<NS, PS> for LargeNodeView
-    where
-        NS: NodeStore,
-        PS: PointStore,
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
-    fn create(root: usize, node_store : &NS) -> Self {
-        LargeNodeView::new(root,node_store)
+    fn create(root: usize, node_store: &NS) -> Self {
+        LargeNodeView::new(root, node_store)
     }
 
-    fn update_at_leaf(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS, visitor_info:&VisitorInfo) {
+    fn update_at_leaf(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
         self.leaf_index = node_store.get_leaf_point_index(index);
         self.point_at_leaf = point_store.get_copy(self.leaf_index);
         self.mass = node_store.get_mass(index);
@@ -408,41 +596,63 @@ impl<NS, PS> UpdatableNodeView<NS, PS> for LargeNodeView
             self.leaf_duplicate = false;
             1.0f64
         };
-        self.current_box = Some(BoundingBox::new(&self.point_at_leaf,&self.point_at_leaf));
+        self.current_box = Some(BoundingBox::new(&self.point_at_leaf, &self.point_at_leaf));
     }
 
-    fn update_from_node_traversing_down(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
+    fn update_from_node_traversing_down(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
         if point[self.cut_dimension] <= self.cut_value {
             self.current_node = self.left_child;
-        }  else {
+        } else {
             self.current_node = self.right_child;
         }
-        let (cut_dimension,cut_value,left_child,right_child) = node_store.get_cut_and_children(self.current_node);
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = cut_dimension;
         self.cut_value = cut_value;
         self.left_child = left_child;
         self.right_child = right_child;
         self.depth += 1;
-        self.mass =node_store.get_mass(self.current_node);
+        self.mass = node_store.get_mass(self.current_node);
     }
 
-    fn update_from_node_traversing_up(&mut self, point: &[f32], index: usize, node_store: &NS, point_store: &PS,visitor_info:&VisitorInfo) {
+    fn update_from_node_traversing_up(
+        &mut self,
+        point: &[f32],
+        index: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
         self.sibling = node_store.get_sibling(self.current_node, index);
         if self.use_shadow_box {
             let z = node_store.get_box(self.sibling, point_store);
             self.current_box.as_mut().unwrap().add_box(&z);
             match &mut self.shadow_box {
-                Some(y) => { y.add_box(&z) },
-                None => { self.shadow_box = Some(z) },
+                Some(y) => y.add_box(&z),
+                None => self.shadow_box = Some(z),
             }
-            self.shadow_box_probablity_of_cut = self.shadow_box.as_ref().unwrap().probability_of_cut(point);
+            self.shadow_box_probablity_of_cut =
+                self.shadow_box.as_ref().unwrap().probability_of_cut(point);
         } else {
-            node_store.grow_node_box(self.current_box.as_mut().unwrap(), point_store, index, self.sibling);
+            node_store.grow_node_box(
+                self.current_box.as_mut().unwrap(),
+                point_store,
+                index,
+                self.sibling,
+            );
         };
         self.probability_of_cut = self.current_box.as_ref().unwrap().probability_of_cut(point);
 
         self.current_node = index;
-        let (cut_dimension, cut_value, left_child, right_child) = node_store.get_cut_and_children(self.current_node);
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = cut_dimension;
         self.cut_value = cut_value;
         self.left_child = left_child;
@@ -455,34 +665,64 @@ impl<NS, PS> UpdatableNodeView<NS, PS> for LargeNodeView
         self.current_node
     }
 
-    fn set_use_shadow_box(&mut self, node_store: &NS, point_store:&PS) {
+    fn set_use_shadow_box(&mut self, node_store: &NS, point_store: &PS) {
         self.use_shadow_box = true;
         // note that the current box is always maintained
     }
 }
 
-impl<NS,PS> UpdatableMultiNodeView<NS, PS> for LargeNodeView
-    where
-        NS: NodeStore,
-        PS: PointStore,
+impl<NS, PS> UpdatableMultiNodeView<NS, PS> for LargeNodeView
+where
+    NS: NodeStore,
+    PS: PointStore,
 {
-    fn create(root: usize, node_store : &NS) -> Self {
-        LargeNodeView::new(root,node_store)
+    fn create(root: usize, node_store: &NS) -> Self {
+        LargeNodeView::new(root, node_store)
     }
 
-    fn set_trigger_traversing_down(&mut self, point: &[f32], parent: usize, node_store: &NS, point_store: &PS, visitor_info : &VisitorInfo) {
-        let (cut_dimension,cut_value,left_child,right_child) = node_store.get_cut_and_children(self.current_node);
+    fn set_trigger_traversing_down(
+        &mut self,
+        point: &[f32],
+        parent: usize,
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        let (cut_dimension, cut_value, left_child, right_child) =
+            node_store.get_cut_and_children(self.current_node);
         self.cut_dimension = cut_dimension;
         self.cut_value = cut_value;
     }
 
-    fn update_view_to_parent_with_missing_coordinates(&mut self, parent: usize, point: &[f32], missing_coordinates: &[bool], node_store: &NS, point_store: &PS, visitor_info: &VisitorInfo) {
-        if node_store.use_path_for_box(){
-            let sibling = node_store.get_sibling(self.current_node,parent);
-            node_store.grow_node_box(self.current_box.as_mut().unwrap(), point_store,parent,sibling);
-            self.probability_of_cut = self.current_box.as_ref().unwrap().probability_of_cut_with_missing_coordinates(point,missing_coordinates);
+    fn update_view_to_parent_with_missing_coordinates(
+        &mut self,
+        parent: usize,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+        visitor_info: &VisitorInfo,
+    ) {
+        if node_store.use_path_for_box() {
+            let sibling = node_store.get_sibling(self.current_node, parent);
+            node_store.grow_node_box(
+                self.current_box.as_mut().unwrap(),
+                point_store,
+                parent,
+                sibling,
+            );
+            self.probability_of_cut = self
+                .current_box
+                .as_ref()
+                .unwrap()
+                .probability_of_cut_with_missing_coordinates(point, missing_coordinates);
         } else {
-            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(parent,point,missing_coordinates,point_store);
+            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(
+                parent,
+                point,
+                missing_coordinates,
+                point_store,
+            );
         }
         self.current_node = parent;
     }
@@ -498,13 +738,33 @@ impl<NS,PS> UpdatableMultiNodeView<NS, PS> for LargeNodeView
         }
     }
 
-    fn merge_paths(&mut self, parent: usize, saved_box: Option<BoundingBox>, point: &[f32], missing_coordinates: &[bool], node_store: &NS, point_store: &PS) {
-        if node_store.use_path_for_box(){
+    fn merge_paths(
+        &mut self,
+        parent: usize,
+        saved_box: Option<BoundingBox>,
+        point: &[f32],
+        missing_coordinates: &[bool],
+        node_store: &NS,
+        point_store: &PS,
+    ) {
+        if node_store.use_path_for_box() {
             // both boxes, current and saved, should be present as invariant
-            self.current_box.as_mut().unwrap().add_box(saved_box.as_ref().unwrap());
-            self.probability_of_cut = self.current_box.as_ref().unwrap().probability_of_cut_with_missing_coordinates(point,missing_coordinates);
+            self.current_box
+                .as_mut()
+                .unwrap()
+                .add_box(saved_box.as_ref().unwrap());
+            self.probability_of_cut = self
+                .current_box
+                .as_ref()
+                .unwrap()
+                .probability_of_cut_with_missing_coordinates(point, missing_coordinates);
         } else {
-            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(parent,point,missing_coordinates,point_store);
+            self.probability_of_cut = node_store.get_probability_of_cut_with_missing_coordinates(
+                parent,
+                point,
+                missing_coordinates,
+                point_store,
+            );
         }
         self.current_node = parent;
     }

--- a/Rust/src/samplerplustree/randomcuttree.rs
+++ b/Rust/src/samplerplustree/randomcuttree.rs
@@ -1,20 +1,26 @@
 use std::fmt::Debug;
+
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
-use crate::pointstore::PointStore;
-use crate::samplerplustree::boundingbox::BoundingBox;
-use crate::samplerplustree::cut::Cut;
-use crate::samplerplustree::nodestore::{NodeStore, VectorNodeStore};
-use crate::samplerplustree::nodeview::{MediumNodeView, UpdatableMultiNodeView, UpdatableNodeView};
-use crate::types::Location;
-use crate::visitor::imputevisitor::ImputeVisitor;
-use crate::visitor::visitor::{SimpleMultiVisitor, Visitor, VisitorInfo};
+
+use crate::{
+    pointstore::PointStore,
+    samplerplustree::{
+        boundingbox::BoundingBox,
+        cut::Cut,
+        nodestore::{NodeStore, VectorNodeStore},
+        nodeview::{MediumNodeView, UpdatableMultiNodeView, UpdatableNodeView},
+    },
+    types::Location,
+    visitor::{
+        imputevisitor::ImputeVisitor,
+        visitor::{SimpleMultiVisitor, Visitor, VisitorInfo},
+    },
+};
 
 extern crate rand;
 extern crate rand_chacha;
-
-
 
 #[repr(C)]
 pub struct RCFTree<C, P, N>
@@ -87,7 +93,8 @@ where
         } else {
             let point = &point_store.get_copy(point_index);
             let mut path_to_root = Vec::new();
-            self.node_store.set_path(&mut path_to_root, self.root, point);
+            self.node_store
+                .set_path(&mut path_to_root, self.root, point);
             let (mut node, mut sibling) = path_to_root.pop().unwrap();
 
             let leaf_point_index = self.node_store.get_point_index(node);
@@ -248,7 +255,6 @@ where
         leaf_point_index
     }
 
-
     pub fn conditional_field<PS: PointStore>(
         &self,
         missing: &[usize],
@@ -256,28 +262,29 @@ where
         point_store: &PS,
         centrality: f64,
         seed: u64,
-        visitor_info: &VisitorInfo
+        visitor_info: &VisitorInfo,
     ) -> (f64, usize, f64) {
         if self.root == self.node_store.null_node() {
             return (0.0, usize::MAX, 0.0);
         }
-        let mut visitor = ImputeVisitor::new(
-            missing,
-            centrality,
-            self.tree_mass,
-            seed,
-        );
-        let mut node_view = MediumNodeView::new(self.root,&self.node_store);
+        let mut visitor = ImputeVisitor::new(missing, centrality, self.tree_mass, seed);
+        let mut node_view = MediumNodeView::new(self.root, &self.node_store);
         let mut missing_coordinates = vec![false; self.dimensions];
         for i in missing.iter() {
             missing_coordinates[*i] = true;
         }
-        self.traverse_multi_with_missing_coordinates(&mut node_view, &mut visitor, visitor_info, point, &missing_coordinates, point_store);
+        self.traverse_multi_with_missing_coordinates(
+            &mut node_view,
+            &mut visitor,
+            visitor_info,
+            point,
+            &missing_coordinates,
+            point_store,
+        );
         visitor.result(&visitor_info)
     }
 
-
-    pub fn traverse_multi_with_missing_coordinates<V,NodeView,PS,R>(
+    pub fn traverse_multi_with_missing_coordinates<V, NodeView, PS, R>(
         &self,
         node_view: &mut NodeView,
         visitor: &mut V,
@@ -285,33 +292,73 @@ where
         point: &[f32],
         missing_coordinates: &[bool],
         point_store: &PS,
-    )
-    where V: SimpleMultiVisitor<NodeView,R>,
-          NodeView: UpdatableMultiNodeView<VectorNodeStore<C, P, N>, PS>,
-          PS: PointStore
+    ) where
+        V: SimpleMultiVisitor<NodeView, R>,
+        NodeView: UpdatableMultiNodeView<VectorNodeStore<C, P, N>, PS>,
+        PS: PointStore,
     {
         let node = node_view.get_current_node();
         if self.node_store.is_leaf(node) {
-            node_view.update_at_leaf(point,node,&self.node_store, &point_store, &visitor_info);
-            visitor.accept_leaf(point, visitor_info,node_view);
+            node_view.update_at_leaf(point, node, &self.node_store, &point_store, &visitor_info);
+            visitor.accept_leaf(point, visitor_info, node_view);
         } else {
             let parent = node;
-            node_view.set_trigger_traversing_down(point,parent, &self.node_store, point_store,visitor_info);
+            node_view.set_trigger_traversing_down(
+                point,
+                parent,
+                &self.node_store,
+                point_store,
+                visitor_info,
+            );
             if missing_coordinates[self.node_store.get_cut_dimension(parent)] {
                 let right = self.node_store.get_left_index(parent);
                 let left = self.node_store.get_right_index(parent);
                 node_view.set_current_node(left);
-                self.traverse_multi_with_missing_coordinates(node_view, visitor, visitor_info,point, missing_coordinates, point_store);
+                self.traverse_multi_with_missing_coordinates(
+                    node_view,
+                    visitor,
+                    visitor_info,
+                    point,
+                    missing_coordinates,
+                    point_store,
+                );
                 let saved_box = node_view.get_bounding_box();
                 node_view.set_current_node(right);
-                self.traverse_multi_with_missing_coordinates(node_view, visitor, visitor_info,point, missing_coordinates, point_store);
-                visitor.combine_branches(point, &node_view,visitor_info);
+                self.traverse_multi_with_missing_coordinates(
+                    node_view,
+                    visitor,
+                    visitor_info,
+                    point,
+                    missing_coordinates,
+                    point_store,
+                );
+                visitor.combine_branches(point, &node_view, visitor_info);
                 if !visitor.is_converged() {
-                    node_view.merge_paths(parent,saved_box,point,missing_coordinates,&self.node_store,point_store);
+                    node_view.merge_paths(
+                        parent,
+                        saved_box,
+                        point,
+                        missing_coordinates,
+                        &self.node_store,
+                        point_store,
+                    );
                 }
             } else {
-                node_view.update_from_node_traversing_down(point,parent,&self.node_store,point_store,&visitor_info);
-                self.traverse_multi_with_missing_coordinates(node_view, visitor, visitor_info,point, missing_coordinates, point_store);
+                node_view.update_from_node_traversing_down(
+                    point,
+                    parent,
+                    &self.node_store,
+                    point_store,
+                    &visitor_info,
+                );
+                self.traverse_multi_with_missing_coordinates(
+                    node_view,
+                    visitor,
+                    visitor_info,
+                    point,
+                    missing_coordinates,
+                    point_store,
+                );
                 if !visitor.is_converged() {
                     node_view.update_view_to_parent_with_missing_coordinates(
                         parent,
@@ -319,22 +366,21 @@ where
                         missing_coordinates,
                         &self.node_store,
                         point_store,
-                        &visitor_info
+                        &visitor_info,
                     );
                 }
             }
             if !visitor.is_converged() {
-                visitor.accept(point, visitor_info,node_view);
+                visitor.accept(point, visitor_info, node_view);
             }
         }
     }
-
 
     pub fn get_size(&self) -> usize {
         self.node_store.get_size(self.dimensions.into()) + std::mem::size_of::<RCFTree<C, P, N>>()
     }
 
-    fn traverse_recursive<R,PS,NodeView,V>(
+    fn traverse_recursive<R, PS, NodeView, V>(
         &self,
         point: &[f32],
         node_view: &mut NodeView,
@@ -343,79 +389,102 @@ where
         point_store: &PS,
     ) where
         PS: PointStore,
-        V:  Visitor<NodeView, R>,
-        R : Clone,
-        NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>
+        V: Visitor<NodeView, R>,
+        R: Clone,
+        NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>,
     {
         let current_node = node_view.get_current_node();
         if self.node_store.is_leaf(current_node) {
-            node_view.update_at_leaf(point,current_node,&self.node_store, &point_store, &visitor_info);
-            visitor.accept_leaf(point,visitor_info,&node_view);
+            node_view.update_at_leaf(
+                point,
+                current_node,
+                &self.node_store,
+                &point_store,
+                &visitor_info,
+            );
+            visitor.accept_leaf(point, visitor_info, &node_view);
             if visitor.use_shadow_box() {
-                node_view.set_use_shadow_box(&self.node_store,point_store);
+                node_view.set_use_shadow_box(&self.node_store, point_store);
             }
         } else {
-            node_view.update_from_node_traversing_down(point,current_node, &self.node_store, point_store,visitor_info);
-            self.traverse_recursive(point,node_view,visitor,visitor_info,point_store);
+            node_view.update_from_node_traversing_down(
+                point,
+                current_node,
+                &self.node_store,
+                point_store,
+                visitor_info,
+            );
+            self.traverse_recursive(point, node_view, visitor, visitor_info, point_store);
             if !visitor.is_converged() {
-                node_view.update_from_node_traversing_up(point, current_node, &self.node_store, &point_store, &visitor_info);
+                node_view.update_from_node_traversing_up(
+                    point,
+                    current_node,
+                    &self.node_store,
+                    &point_store,
+                    &visitor_info,
+                );
                 visitor.accept(point, visitor_info, &node_view);
             }
         }
     }
 }
 
-pub trait Traversable<NodeView, N, PS,V,R>
-        where
-            N: Location,
-            <N as TryFrom<usize>>::Error: Debug,
-            usize: From<N>,
-            PS: PointStore,
-            V : Visitor<NodeView,R>
-    {
-        fn traverse(
-            &self,
-            point: &[f32],
-            parameters: &[usize],
-            visitor_factory : fn(usize,&[usize],&VisitorInfo) -> V,
-            visitor_info: &VisitorInfo,
-            point_store: &PS,
-            default : &R,
-        ) -> R;
-    }
-
-
-impl<C, P, N, PS, NodeView,V,R> Traversable<NodeView, N, PS,V,R> for RCFTree<C, P, N>
-    where
-        C: Location,
-        <C as TryFrom<usize>>::Error: Debug,
-        usize: From<C>,
-        P: Location,
-        <P as TryFrom<usize>>::Error: Debug,
-        usize: From<P>,
-        N: Location,
-        <N as TryFrom<usize>>::Error: Debug,
-        usize: From<N>,
-        PS: PointStore,
-        NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>,
-        V : Visitor<NodeView,R>,
-        R : Clone
+pub trait Traversable<NodeView, N, PS, V, R>
+where
+    N: Location,
+    <N as TryFrom<usize>>::Error: Debug,
+    usize: From<N>,
+    PS: PointStore,
+    V: Visitor<NodeView, R>,
 {
     fn traverse(
         &self,
         point: &[f32],
         parameters: &[usize],
-        visitor_factory : fn(usize,&[usize],&VisitorInfo) -> V,
+        visitor_factory: fn(usize, &[usize], &VisitorInfo) -> V,
         visitor_info: &VisitorInfo,
         point_store: &PS,
-        default: &R
+        default: &R,
+    ) -> R;
+}
+
+impl<C, P, N, PS, NodeView, V, R> Traversable<NodeView, N, PS, V, R> for RCFTree<C, P, N>
+where
+    C: Location,
+    <C as TryFrom<usize>>::Error: Debug,
+    usize: From<C>,
+    P: Location,
+    <P as TryFrom<usize>>::Error: Debug,
+    usize: From<P>,
+    N: Location,
+    <N as TryFrom<usize>>::Error: Debug,
+    usize: From<N>,
+    PS: PointStore,
+    NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>,
+    V: Visitor<NodeView, R>,
+    R: Clone,
+{
+    fn traverse(
+        &self,
+        point: &[f32],
+        parameters: &[usize],
+        visitor_factory: fn(usize, &[usize], &VisitorInfo) -> V,
+        visitor_info: &VisitorInfo,
+        point_store: &PS,
+        default: &R,
     ) -> R {
         if self.root == self.node_store.null_node() {
             return default.clone();
         }
-        let mut visitor = visitor_factory(self.tree_mass,parameters,&visitor_info);
-        let mut node_view = NodeView::create(self.root,&self.node_store);
-        self.traverse_recursive(point,&mut node_view,&mut visitor,&visitor_info,&point_store);
+        let mut visitor = visitor_factory(self.tree_mass, parameters, &visitor_info);
+        let mut node_view = NodeView::create(self.root, &self.node_store);
+        self.traverse_recursive(
+            point,
+            &mut node_view,
+            &mut visitor,
+            &visitor_info,
+            &point_store,
+        );
         visitor.result(visitor_info)
     }
 }

--- a/Rust/src/samplerplustree/samplerplustree.rs
+++ b/Rust/src/samplerplustree/samplerplustree.rs
@@ -2,17 +2,22 @@ extern crate rand;
 extern crate rand_chacha;
 
 use std::fmt::Debug;
+
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
-use crate::pointstore::PointStore;
-use crate::samplerplustree::nodestore::VectorNodeStore;
-use crate::samplerplustree::nodeview::UpdatableNodeView;
-use crate::samplerplustree::randomcuttree::{RCFTree, Traversable};
-use crate::samplerplustree::sampler::Sampler;
-use crate::types::Location;
-use crate::visitor::visitor::{Visitor, VisitorInfo};
 
+use crate::{
+    pointstore::PointStore,
+    samplerplustree::{
+        nodestore::VectorNodeStore,
+        nodeview::UpdatableNodeView,
+        randomcuttree::{RCFTree, Traversable},
+        sampler::Sampler,
+    },
+    types::Location,
+    visitor::visitor::{Visitor, VisitorInfo},
+};
 
 #[repr(C)]
 pub struct SamplerPlusTree<C, P, N>
@@ -126,26 +131,34 @@ where
         } else if self.initial_accept_fraction >= 1.0 {
             0.0
         } else {
-            1.0
-                - (fill_fraction - self.initial_accept_fraction)
+            1.0 - (fill_fraction - self.initial_accept_fraction)
                 / (1.0 - self.initial_accept_fraction)
-        }
+        };
     }
 
-    pub fn simple_traversal<NodeView,V,R,PS>(&self,
-                                       point: &[f32],
-                                       point_store: &PS,
-                                       parameters : &[usize],
-                                       visitor_info : &VisitorInfo,
-                                       visitor_factory : fn(usize,&[usize],&VisitorInfo) -> V,
-                                       default : &R
+    pub fn simple_traversal<NodeView, V, R, PS>(
+        &self,
+        point: &[f32],
+        point_store: &PS,
+        parameters: &[usize],
+        visitor_info: &VisitorInfo,
+        visitor_factory: fn(usize, &[usize], &VisitorInfo) -> V,
+        default: &R,
     ) -> R
-    where        NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>,
-                 V : Visitor<NodeView,R>,
-                 PS: PointStore,
-                 R: Clone
+    where
+        NodeView: UpdatableNodeView<VectorNodeStore<C, P, N>, PS>,
+        V: Visitor<NodeView, R>,
+        PS: PointStore,
+        R: Clone,
     {
-         self.tree.traverse(point, parameters, visitor_factory, visitor_info, point_store, default)
+        self.tree.traverse(
+            point,
+            parameters,
+            visitor_factory,
+            visitor_info,
+            point_store,
+            default,
+        )
     }
 
     pub fn conditional_field<PS>(
@@ -154,9 +167,10 @@ where
         centrality: f64,
         point: &[f32],
         point_store: &PS,
-        visitor_info : &VisitorInfo,
-    ) -> (f64,usize,f64)
-    where PS : PointStore
+        visitor_info: &VisitorInfo,
+    ) -> (f64, usize, f64)
+    where
+        PS: PointStore,
     {
         self.tree.conditional_field(
             positions,
@@ -164,7 +178,7 @@ where
             point_store,
             centrality,
             self.random_seed,
-            visitor_info
+            visitor_info,
         )
     }
 

--- a/Rust/src/util.rs
+++ b/Rust/src/util.rs
@@ -1,16 +1,12 @@
-
-
-pub(crate) fn add_to(a: &f64, b : &mut f64){
+pub(crate) fn add_to(a: &f64, b: &mut f64) {
     *b += *a;
 }
-pub(crate) fn divide(a : &mut f64, b: usize) {
+pub(crate) fn divide(a: &mut f64, b: usize) {
     *a /= b as f64;
 }
 
-pub(crate) fn add_nbr(a:&(f64,usize,f64), b: &mut Vec<(f64,usize,f64)>){
+pub(crate) fn add_nbr(a: &(f64, usize, f64), b: &mut Vec<(f64, usize, f64)>) {
     b.push(*a)
 }
 
-
-pub(crate) fn nbr_finish( _a: &mut Vec<(f64,usize,f64)>, _b:usize){}
-
+pub(crate) fn nbr_finish(_a: &mut Vec<(f64, usize, f64)>, _b: usize) {}

--- a/Rust/src/visitor/attributionvisitor.rs
+++ b/Rust/src/visitor/attributionvisitor.rs
@@ -1,8 +1,10 @@
 use num::abs;
-use crate::common::divector::DiVector;
-use crate::samplerplustree::nodeview::LargeNodeView;
-use crate::visitor::visitor::{Visitor, VisitorInfo};
 
+use crate::{
+    common::divector::DiVector,
+    samplerplustree::nodeview::LargeNodeView,
+    visitor::visitor::{Visitor, VisitorInfo},
+};
 
 #[repr(C)]
 pub struct AttributionVisitor {
@@ -12,53 +14,54 @@ pub struct AttributionVisitor {
     tree_mass: usize,
     hit_duplicate: bool,
     use_shadow_box: bool,
-    attribution : DiVector,
-    probability : DiVector
+    attribution: DiVector,
+    probability: DiVector,
 }
 
 impl AttributionVisitor {
-    pub fn new(
-        tree_mass: usize,
-        dimension : usize,
-        visitor_info : &VisitorInfo
-    ) -> Self {
+    pub fn new(tree_mass: usize, dimension: usize, visitor_info: &VisitorInfo) -> Self {
         AttributionVisitor {
             tree_mass,
             leaf_index: usize::MAX,
             converged: false,
             score: 0.0,
-            hit_duplicate : false,
-            use_shadow_box : false,
-            attribution : DiVector::empty(dimension),
-            probability : DiVector::empty(dimension)
+            hit_duplicate: false,
+            use_shadow_box: false,
+            attribution: DiVector::empty(dimension),
+            probability: DiVector::empty(dimension),
         }
     }
 
     pub fn create_visitor(
         tree_mass: usize,
         parameters: &[usize],
-        visitor_info : &VisitorInfo
+        visitor_info: &VisitorInfo,
     ) -> AttributionVisitor {
         let dimension = parameters[0];
-        AttributionVisitor::new(tree_mass,dimension,visitor_info)
+        AttributionVisitor::new(tree_mass, dimension, visitor_info)
     }
 }
 
-impl Visitor<LargeNodeView,DiVector> for AttributionVisitor {
-    fn accept_leaf(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
+impl Visitor<LargeNodeView, DiVector> for AttributionVisitor {
+    fn accept_leaf(
+        &mut self,
+        point: &[f32],
+        visitor_info: &VisitorInfo,
+        node_view: &LargeNodeView,
+    ) {
         let mass = node_view.get_mass();
         self.leaf_index = node_view.get_leaf_index();
         if mass > visitor_info.ignore_mass {
             if node_view.is_duplicate() {
-                self.score =
-                    (visitor_info.damp)(mass, self.tree_mass) * (visitor_info.score_seen)(node_view.get_depth(), mass);
+                self.score = (visitor_info.damp)(mass, self.tree_mass)
+                    * (visitor_info.score_seen)(node_view.get_depth(), mass);
                 self.hit_duplicate = true;
                 self.use_shadow_box = true;
             } else {
                 self.score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
-                node_view.assign_probability_of_cut(&mut self.probability,point);
+                node_view.assign_probability_of_cut(&mut self.probability, point);
                 assert!(abs(self.probability.total() - 1.0) < 1e-6);
-                self.attribution.add_from(&self.probability,self.score);
+                self.attribution.add_from(&self.probability, self.score);
             }
         } else {
             self.score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
@@ -69,15 +72,16 @@ impl Visitor<LargeNodeView,DiVector> for AttributionVisitor {
     fn accept(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
         if !self.converged {
             if !self.use_shadow_box {
-                node_view.assign_probability_of_cut(&mut self.probability,point);
+                node_view.assign_probability_of_cut(&mut self.probability, point);
             } else {
-                node_view.assign_probability_of_cut_shadow_box(&mut self.probability,point);
+                node_view.assign_probability_of_cut_shadow_box(&mut self.probability, point);
             };
             let prob = self.probability.total();
             if prob == 0.0 {
                 self.converged = true;
             } else {
-                let new_value = (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
+                let new_value =
+                    (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
                 if !self.hit_duplicate {
                     self.score = (1.0 - prob) * self.score + prob * new_value;
                 }
@@ -87,8 +91,8 @@ impl Visitor<LargeNodeView,DiVector> for AttributionVisitor {
         }
     }
 
-    fn result(&self, visitor_info:&VisitorInfo) -> DiVector {
-        let t = (visitor_info.normalizer)(self.score,self.tree_mass);
+    fn result(&self, visitor_info: &VisitorInfo) -> DiVector {
+        let t = (visitor_info.normalizer)(self.score, self.tree_mass);
         let mut answer = self.attribution.clone();
         answer.normalize(t);
         answer
@@ -101,5 +105,4 @@ impl Visitor<LargeNodeView,DiVector> for AttributionVisitor {
     fn use_shadow_box(&self) -> bool {
         self.use_shadow_box
     }
-
 }

--- a/Rust/src/visitor/imputevisitor.rs
+++ b/Rust/src/visitor/imputevisitor.rs
@@ -1,43 +1,40 @@
 use num::abs;
 use rand::{random, Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use crate::samplerplustree::nodeview::MediumNodeView;
-use crate::visitor::visitor::{SimpleMultiVisitor, Visitor, VisitorInfo};
 
+use crate::{
+    samplerplustree::nodeview::MediumNodeView,
+    visitor::visitor::{SimpleMultiVisitor, Visitor, VisitorInfo},
+};
 
 #[repr(C)]
 pub struct ImputeVisitor {
     centrality: f64,
     tree_mass: usize,
-    rng : ChaCha20Rng,
+    rng: ChaCha20Rng,
     missing: Vec<usize>,
     stack: Vec<ImputeVisitorStackElement>,
-    use_shadow_box: bool
+    use_shadow_box: bool,
 }
 
 #[repr(C)]
-struct ImputeVisitorStackElement{
+struct ImputeVisitorStackElement {
     converged: bool,
-    score : f64,
-    random : f32,
-    index : usize,
-    distance : f64
+    score: f64,
+    random: f32,
+    index: usize,
+    distance: f64,
 }
 
 impl ImputeVisitor {
-    pub fn new(
-        missing: &[usize],
-        centrality: f64,
-        tree_mass: usize,
-        seed : u64
-    ) -> Self {
+    pub fn new(missing: &[usize], centrality: f64, tree_mass: usize, seed: u64) -> Self {
         ImputeVisitor {
             tree_mass,
             centrality,
-            rng : ChaCha20Rng::seed_from_u64(seed),
+            rng: ChaCha20Rng::seed_from_u64(seed),
             missing: Vec::from(missing),
-            stack : Vec::new(),
-            use_shadow_box : false
+            stack: Vec::new(),
+            use_shadow_box: false,
         }
     }
 
@@ -46,25 +43,41 @@ impl ImputeVisitor {
         parameters: &[usize],
         _visitor_info: &VisitorInfo,
     ) -> Self {
-        let percentile = if parameters.len()>0 {parameters[0]} else {50};
-        let seed = if parameters.len()>1 {parameters[1]} else {0};
-        let centrality = if percentile<5 || percentile > 95 {0.0} else {1.0 - abs(1.0 - percentile as f64/50.0)};
-         ImputeVisitor::new(&Vec::new(), centrality, tree_mass, seed as u64)
+        let percentile = if parameters.len() > 0 {
+            parameters[0]
+        } else {
+            50
+        };
+        let seed = if parameters.len() > 1 {
+            parameters[1]
+        } else {
+            0
+        };
+        let centrality = if percentile < 5 || percentile > 95 {
+            0.0
+        } else {
+            1.0 - abs(1.0 - percentile as f64 / 50.0)
+        };
+        ImputeVisitor::new(&Vec::new(), centrality, tree_mass, seed as u64)
     }
 
     /// the following function allows the score to vary between the score used in
     /// anomaly detection and fully random sample based on the parameter centrality
     /// these two cases correspond to centrality = 1 and centrality = 0 respectively
 
-    fn adjusted_score(&self, e : &ImputeVisitorStackElement, visitor_info: &VisitorInfo)->f64{
-           self.centrality * (visitor_info.normalizer) (e.score,self.tree_mass) +
-               (1.0 - self.centrality) * e.random as f64
+    fn adjusted_score(&self, e: &ImputeVisitorStackElement, visitor_info: &VisitorInfo) -> f64 {
+        self.centrality * (visitor_info.normalizer)(e.score, self.tree_mass)
+            + (1.0 - self.centrality) * e.random as f64
     }
 }
 
-
-impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
-    fn accept_leaf(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &MediumNodeView) {
+impl Visitor<MediumNodeView, (f64, usize, f64)> for ImputeVisitor {
+    fn accept_leaf(
+        &mut self,
+        point: &[f32],
+        visitor_info: &VisitorInfo,
+        node_view: &MediumNodeView,
+    ) {
         let mass = node_view.get_mass();
         let leaf_point = node_view.get_leaf_point();
         let mut new_point = Vec::from(point);
@@ -76,9 +89,9 @@ impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
         let score: f64;
         if mass > visitor_info.ignore_mass || self.missing.len() != 0 {
             if node_view.is_duplicate() {
-                score =
-                    (visitor_info.damp)(mass, self.tree_mass) * (visitor_info.score_seen)(node_view.get_depth(), mass);
-               converged = true;
+                score = (visitor_info.damp)(mass, self.tree_mass)
+                    * (visitor_info.score_seen)(node_view.get_depth(), mass);
+                converged = true;
             } else {
                 score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
             }
@@ -91,18 +104,20 @@ impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
             self.use_shadow_box = true;
         }
         let dist = (visitor_info.distance)(&new_point, &leaf_point);
-        self.stack
-            .push(ImputeVisitorStackElement {
-                converged,
-                score,
-                index: node_view.get_leaf_index(),
-                random: self.rng.gen::<f32>(),
-                distance: dist
-            });
+        self.stack.push(ImputeVisitorStackElement {
+            converged,
+            score,
+            index: node_view.get_leaf_index(),
+            random: self.rng.gen::<f32>(),
+            distance: dist,
+        });
     }
 
     fn accept(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &MediumNodeView) {
-        assert!(self.stack.len() > 0, " there should have been an accept_leaf call which would have created a non-null stack");
+        assert!(
+            self.stack.len() > 0,
+            " there should have been an accept_leaf call which would have created a non-null stack"
+        );
         let mut top_of_stack = self.stack.pop().unwrap();
         if !top_of_stack.converged {
             let prob = if !self.use_shadow_box {
@@ -116,7 +131,8 @@ impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
                 top_of_stack.converged = true;
             } else {
                 let new_score = (1.0 - prob) * top_of_stack.score
-                    + prob * (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
+                    + prob
+                        * (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
                 top_of_stack.converged = false;
                 top_of_stack.score = new_score;
             }
@@ -124,8 +140,12 @@ impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
         }
     }
 
-    fn result(&self, visitor_info: &VisitorInfo) -> (f64,usize,f64) {
-        assert_eq!(self.stack.len(), 1, "incorrect state, stack length should be 1");
+    fn result(&self, visitor_info: &VisitorInfo) -> (f64, usize, f64) {
+        assert_eq!(
+            self.stack.len(),
+            1,
+            "incorrect state, stack length should be 1"
+        );
         let top_of_stack = self.stack.last().unwrap();
         let t = (visitor_info.normalizer)(top_of_stack.score, self.tree_mass);
         (t, top_of_stack.index, top_of_stack.distance)
@@ -138,18 +158,22 @@ impl Visitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
     fn use_shadow_box(&self) -> bool {
         self.use_shadow_box
     }
-
 }
 
-
-impl SimpleMultiVisitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
-
-    fn combine_branches(&mut self, _point: &[f32], _node_view: &MediumNodeView, visitor_info:&VisitorInfo) {
+impl SimpleMultiVisitor<MediumNodeView, (f64, usize, f64)> for ImputeVisitor {
+    fn combine_branches(
+        &mut self,
+        _point: &[f32],
+        _node_view: &MediumNodeView,
+        visitor_info: &VisitorInfo,
+    ) {
         assert!(self.stack.len() >= 2, "incorrect state");
         let mut top_of_stack = self.stack.pop().unwrap();
         let mut next_of_stack = self.stack.pop().unwrap();
 
-        if self.adjusted_score(&top_of_stack, &visitor_info) < self.adjusted_score(&next_of_stack, &visitor_info) {
+        if self.adjusted_score(&top_of_stack, &visitor_info)
+            < self.adjusted_score(&next_of_stack, &visitor_info)
+        {
             top_of_stack.converged = top_of_stack.converged || next_of_stack.converged;
             self.stack.push(top_of_stack);
         } else {
@@ -157,8 +181,4 @@ impl SimpleMultiVisitor<MediumNodeView,(f64,usize,f64)> for ImputeVisitor {
             self.stack.push(next_of_stack);
         }
     }
-
 }
-
-
-

--- a/Rust/src/visitor/interpolationvisitor.rs
+++ b/Rust/src/visitor/interpolationvisitor.rs
@@ -1,9 +1,10 @@
 use num::abs;
-use crate::common::divector::DiVector;
-use crate::common::directionaldensity::InterpolationMeasure;
-use crate::samplerplustree::nodeview::LargeNodeView;
-use crate::visitor::visitor::{Visitor, VisitorInfo};
 
+use crate::{
+    common::{directionaldensity::InterpolationMeasure, divector::DiVector},
+    samplerplustree::nodeview::LargeNodeView,
+    visitor::visitor::{Visitor, VisitorInfo},
+};
 
 #[repr(C)]
 pub struct InterpolationVisitor {
@@ -13,52 +14,53 @@ pub struct InterpolationVisitor {
     tree_mass: usize,
     hit_duplicate: bool,
     use_shadow_box: bool,
-    interpolation_measure: InterpolationMeasure
+    interpolation_measure: InterpolationMeasure,
 }
 
 impl InterpolationVisitor {
-    pub fn new(
-        tree_mass: usize,
-        dimension : usize,
-        visitor_info : &VisitorInfo
-    ) -> Self {
+    pub fn new(tree_mass: usize, dimension: usize, visitor_info: &VisitorInfo) -> Self {
         InterpolationVisitor {
             tree_mass,
             leaf_index: usize::MAX,
             converged: false,
             score: 0.0,
-            hit_duplicate : false,
-            use_shadow_box : false,
-            interpolation_measure : InterpolationMeasure::empty(dimension,tree_mass as f32)
+            hit_duplicate: false,
+            use_shadow_box: false,
+            interpolation_measure: InterpolationMeasure::empty(dimension, tree_mass as f32),
         }
     }
 
     pub fn create_visitor(
         tree_mass: usize,
         parameters: &[usize],
-        visitor_info : &VisitorInfo
+        visitor_info: &VisitorInfo,
     ) -> InterpolationVisitor {
         let dimension = parameters[0];
-        InterpolationVisitor::new(tree_mass,dimension,visitor_info)
+        InterpolationVisitor::new(tree_mass, dimension, visitor_info)
     }
 }
 
-impl Visitor<LargeNodeView,InterpolationMeasure> for InterpolationVisitor {
-    fn accept_leaf(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
+impl Visitor<LargeNodeView, InterpolationMeasure> for InterpolationVisitor {
+    fn accept_leaf(
+        &mut self,
+        point: &[f32],
+        visitor_info: &VisitorInfo,
+        node_view: &LargeNodeView,
+    ) {
         let mass = node_view.get_mass();
         let leaf_point = node_view.get_leaf_point();
         self.leaf_index = node_view.get_leaf_index();
         if mass > visitor_info.ignore_mass {
             if node_view.is_duplicate() {
-                self.score =
-                    (visitor_info.damp)(mass, self.tree_mass) * (visitor_info.score_seen)(node_view.get_depth(), mass);
+                self.score = (visitor_info.damp)(mass, self.tree_mass)
+                    * (visitor_info.score_seen)(node_view.get_depth(), mass);
                 self.hit_duplicate = true;
                 self.use_shadow_box = true;
             } else {
                 let t = (visitor_info.score_unseen)(node_view.get_depth(), mass);
                 self.score = t;
                 let bounding_box = node_view.bounding_box();
-                self.interpolation_measure.update(point,&bounding_box,t);
+                self.interpolation_measure.update(point, &bounding_box, t);
             }
         } else {
             self.score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
@@ -68,14 +70,16 @@ impl Visitor<LargeNodeView,InterpolationMeasure> for InterpolationVisitor {
 
     fn accept(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &LargeNodeView) {
         if !self.converged {
-            let bounding_box =
-            if !self.use_shadow_box {
+            let bounding_box = if !self.use_shadow_box {
                 node_view.bounding_box()
             } else {
                 node_view.shadow_box()
             };
-            let new_value = (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
-            let prob = self.interpolation_measure.update(point,&bounding_box,new_value);
+            let new_value =
+                (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
+            let prob = self
+                .interpolation_measure
+                .update(point, &bounding_box, new_value);
             if prob == 0.0 {
                 self.converged = true;
             } else {
@@ -86,8 +90,8 @@ impl Visitor<LargeNodeView,InterpolationMeasure> for InterpolationVisitor {
         }
     }
 
-    fn result(&self, visitor_info:&VisitorInfo) -> InterpolationMeasure {
-        let t = (visitor_info.normalizer)(self.score,self.tree_mass);
+    fn result(&self, visitor_info: &VisitorInfo) -> InterpolationMeasure {
+        let t = (visitor_info.normalizer)(self.score, self.tree_mass);
         let mut answer = self.interpolation_measure.clone();
         answer.measure.normalize(t);
         answer
@@ -100,5 +104,4 @@ impl Visitor<LargeNodeView,InterpolationMeasure> for InterpolationVisitor {
     fn use_shadow_box(&self) -> bool {
         self.use_shadow_box
     }
-
 }

--- a/Rust/src/visitor/mod.rs
+++ b/Rust/src/visitor/mod.rs
@@ -1,5 +1,5 @@
-pub mod visitor;
-pub mod scalarscorevisitor;
-pub mod imputevisitor;
 pub mod attributionvisitor;
+pub mod imputevisitor;
 pub mod interpolationvisitor;
+pub mod scalarscorevisitor;
+pub mod visitor;

--- a/Rust/src/visitor/scalarscorevisitor.rs
+++ b/Rust/src/visitor/scalarscorevisitor.rs
@@ -1,5 +1,7 @@
-use crate::samplerplustree::nodeview::SmallNodeView;
-use crate::visitor::visitor::{Visitor, VisitorInfo};
+use crate::{
+    samplerplustree::nodeview::SmallNodeView,
+    visitor::visitor::{Visitor, VisitorInfo},
+};
 
 #[repr(C)]
 pub struct ScalarScoreVisitor {
@@ -7,33 +9,34 @@ pub struct ScalarScoreVisitor {
     leaf_index: usize,
     score: f64,
     tree_mass: usize,
-    use_shadow_box: bool
+    use_shadow_box: bool,
 }
 
 impl ScalarScoreVisitor {
-    pub fn Default(
-        tree_mass: usize,
-        _parameters : &[usize],
-        _visitor_info : &VisitorInfo
-    ) -> Self {
+    pub fn Default(tree_mass: usize, _parameters: &[usize], _visitor_info: &VisitorInfo) -> Self {
         ScalarScoreVisitor {
             tree_mass,
             leaf_index: usize::MAX,
             converged: false,
             score: 0.0,
-            use_shadow_box : false
+            use_shadow_box: false,
         }
     }
 }
 
-impl Visitor<SmallNodeView,f64> for ScalarScoreVisitor {
-    fn accept_leaf(&mut self, _point: &[f32], visitor_info: &VisitorInfo, node_view: &SmallNodeView) {
+impl Visitor<SmallNodeView, f64> for ScalarScoreVisitor {
+    fn accept_leaf(
+        &mut self,
+        _point: &[f32],
+        visitor_info: &VisitorInfo,
+        node_view: &SmallNodeView,
+    ) {
         let mass = node_view.get_mass();
         self.leaf_index = node_view.get_leaf_index();
         if mass > visitor_info.ignore_mass {
             if node_view.is_duplicate() {
-                self.score =
-                    (visitor_info.damp)(mass, self.tree_mass) * (visitor_info.score_seen)(node_view.get_depth(), mass);
+                self.score = (visitor_info.damp)(mass, self.tree_mass)
+                    * (visitor_info.score_seen)(node_view.get_depth(), mass);
                 self.converged = true;
             } else {
                 self.score = (visitor_info.score_unseen)(node_view.get_depth(), mass);
@@ -55,13 +58,14 @@ impl Visitor<SmallNodeView,f64> for ScalarScoreVisitor {
                 self.converged = true;
             } else {
                 self.score = (1.0 - prob) * self.score
-                    + prob * (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
+                    + prob
+                        * (visitor_info.score_unseen)(node_view.get_depth(), node_view.get_mass());
             }
         }
     }
 
     fn result(&self, visitor_info: &VisitorInfo) -> f64 {
-        (visitor_info.normalizer)(self.score,self.tree_mass)
+        (visitor_info.normalizer)(self.score, self.tree_mass)
     }
 
     fn is_converged(&self) -> bool {
@@ -71,5 +75,4 @@ impl Visitor<SmallNodeView,f64> for ScalarScoreVisitor {
     fn use_shadow_box(&self) -> bool {
         self.use_shadow_box
     }
-
 }

--- a/Rust/src/visitor/visitor.rs
+++ b/Rust/src/visitor/visitor.rs
@@ -1,5 +1,10 @@
-use crate::l1distance;
-use crate::rcf::{damp, displacement_normalizer, identity, normalizer, score_seen, score_seen_displacement, score_unseen, score_unseen_displacement};
+use crate::{
+    l1distance,
+    rcf::{
+        damp, displacement_normalizer, identity, normalizer, score_seen, score_seen_displacement,
+        score_unseen, score_unseen_displacement,
+    },
+};
 
 #[repr(C)]
 pub struct VisitorInfo {
@@ -8,30 +13,39 @@ pub struct VisitorInfo {
     pub score_unseen: fn(usize, usize) -> f64,
     pub damp: fn(usize, usize) -> f64,
     pub normalizer: fn(f64, usize) -> f64,
-    pub distance: fn(&[f32],&[f32]) -> f64
+    pub distance: fn(&[f32], &[f32]) -> f64,
 }
 
-
 pub trait Visitor<NodeView, Result> {
-    fn accept(&mut self, point : &[f32], visitor_info: &VisitorInfo, node_view: &NodeView);
-    fn accept_leaf(&mut self, point : &[f32], visitor_info: &VisitorInfo, node_view: &NodeView);
+    fn accept(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &NodeView);
+    fn accept_leaf(&mut self, point: &[f32], visitor_info: &VisitorInfo, node_view: &NodeView);
     fn is_converged(&self) -> bool;
-    fn result(&self,visitor_info:&VisitorInfo) -> Result;
+    fn result(&self, visitor_info: &VisitorInfo) -> Result;
     fn use_shadow_box(&self) -> bool;
 }
 
-pub trait SimpleMultiVisitor<NodeView, Result> : Visitor<NodeView, Result>{
-    fn combine_branches(&mut self, point: &[f32], _node_view: &NodeView, visitor_info:&VisitorInfo);
+pub trait SimpleMultiVisitor<NodeView, Result>: Visitor<NodeView, Result> {
+    fn combine_branches(
+        &mut self,
+        point: &[f32],
+        _node_view: &NodeView,
+        visitor_info: &VisitorInfo,
+    );
 }
 
-pub trait UniqueMultiVisitor<NodeView,Result>: SimpleMultiVisitor<NodeView, Result> {
-    fn trigger(&self, point: &[f32], node_view: &NodeView,visitor_info:&VisitorInfo) -> bool;
-    fn unique_answer(&self,visitor_info:&VisitorInfo) -> Vec<f32>;
+pub trait UniqueMultiVisitor<NodeView, Result>: SimpleMultiVisitor<NodeView, Result> {
+    fn trigger(&self, point: &[f32], node_view: &NodeView, visitor_info: &VisitorInfo) -> bool;
+    fn unique_answer(&self, visitor_info: &VisitorInfo) -> Vec<f32>;
 }
 
-pub trait StreamingMultiVisitor<NodeView,Result>: UniqueMultiVisitor<NodeView,Result> {
-    fn initialize_branch_split(&mut self, point: &[f32], node_view: &NodeView,visitor_info:&VisitorInfo);
-    fn second_branch(&mut self, point: &[f32], node_view: &NodeView, visitor_info:&VisitorInfo);
+pub trait StreamingMultiVisitor<NodeView, Result>: UniqueMultiVisitor<NodeView, Result> {
+    fn initialize_branch_split(
+        &mut self,
+        point: &[f32],
+        node_view: &NodeView,
+        visitor_info: &VisitorInfo,
+    );
+    fn second_branch(&mut self, point: &[f32], node_view: &NodeView, visitor_info: &VisitorInfo);
 }
 
 impl VisitorInfo {
@@ -42,41 +56,43 @@ impl VisitorInfo {
             score_unseen,
             damp,
             normalizer,
-            distance : l1distance
+            distance: l1distance,
         }
     }
     pub fn displacement() -> Self {
         VisitorInfo {
             ignore_mass: 0,
-            score_seen : score_seen_displacement,
-            score_unseen : score_unseen_displacement,
+            score_seen: score_seen_displacement,
+            score_unseen: score_unseen_displacement,
             damp,
-            normalizer : displacement_normalizer,
-            distance : l1distance
+            normalizer: displacement_normalizer,
+            distance: l1distance,
         }
     }
     pub fn density() -> Self {
         VisitorInfo {
             ignore_mass: 0,
-            score_seen : score_unseen_displacement,
-            score_unseen : score_unseen_displacement,
+            score_seen: score_unseen_displacement,
+            score_unseen: score_unseen_displacement,
             damp,
-            normalizer : identity,
-            distance : l1distance
+            normalizer: identity,
+            distance: l1distance,
         }
     }
-    pub fn use_score(ignore_mass:usize,
-               score_seen: fn(usize, usize) -> f64,
-               score_unseen: fn(usize, usize) -> f64,
-               damp: fn(usize, usize) -> f64,
-               normalizer: fn(f64, usize) -> f64) -> Self {
+    pub fn use_score(
+        ignore_mass: usize,
+        score_seen: fn(usize, usize) -> f64,
+        score_unseen: fn(usize, usize) -> f64,
+        damp: fn(usize, usize) -> f64,
+        normalizer: fn(f64, usize) -> f64,
+    ) -> Self {
         VisitorInfo {
             ignore_mass,
             score_seen,
             score_unseen,
             damp,
             normalizer,
-            distance : l1distance
+            distance: l1distance,
         }
     }
     pub fn use_distance(distance: fn(&[f32], &[f32]) -> f64) -> Self {

--- a/Rust/tests/anomalydetectionattributionupdate.rs
+++ b/Rust/tests/anomalydetectionattributionupdate.rs
@@ -1,4 +1,3 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
@@ -6,8 +5,10 @@ extern crate rcflib;
 use num::abs;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::rcf::{create_rcf, RCF};
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
@@ -46,13 +47,13 @@ fn anomalydetection_attribution_and_update() {
         bounding_box_cache_fraction,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*100.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 100.0);
     }
     let data_with_key = MultiDimDataWithKey::multi_cosine(
         data_size,
-        &vec![60;base_dimension],
+        &vec![60; base_dimension],
         &amplitude,
         noise,
         0,
@@ -63,7 +64,6 @@ fn anomalydetection_attribution_and_update() {
     let _next_index = 0;
 
     for i in 0..data_with_key.data.len() {
-
         let attribution = forest.attribution(&data_with_key.data[i]);
         let new_score = forest.score(&data_with_key.data[i]);
         assert!(abs(new_score - attribution.total()) < 1e-6);
@@ -83,7 +83,10 @@ fn anomalydetection_attribution_and_update() {
         "Average score {} ",
         (score / data_with_key.data.len() as f64)
     );
-    assert!(score < data_with_key.data.len() as f64, " average score is above 1");
+    assert!(
+        score < data_with_key.data.len() as f64,
+        " average score is above 1"
+    );
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());

--- a/Rust/tests/anomalydetectionimputescoreupdate.rs
+++ b/Rust/tests/anomalydetectionimputescoreupdate.rs
@@ -1,17 +1,16 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::rcf::{create_rcf, RCF};
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
-
-
 
 #[test]
 fn anomalydetection_impute_score_and_update() {
@@ -47,13 +46,13 @@ fn anomalydetection_impute_score_and_update() {
         bounding_box_cache_fraction,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*100.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 100.0);
     }
     let data_with_key = MultiDimDataWithKey::multi_cosine(
         data_size,
-        &vec![60;base_dimension],
+        &vec![60; base_dimension],
         &amplitude,
         noise,
         0,
@@ -66,11 +65,14 @@ fn anomalydetection_impute_score_and_update() {
     let mut count = 0;
 
     for i in 0..data_with_key.data.len() {
-
         if i > 200 {
             let next_values = forest.extrapolate(1);
             assert!(next_values.len() == base_dimension);
-            error += next_values.iter().zip(&data_with_key.data[i]).map(|(x,y)| ((x-y) as f64 *(x-y) as f64)).sum::<f64>();
+            error += next_values
+                .iter()
+                .zip(&data_with_key.data[i])
+                .map(|(x, y)| ((x - y) as f64 * (x - y) as f64))
+                .sum::<f64>();
             count += base_dimension;
         }
 
@@ -94,5 +96,9 @@ fn anomalydetection_impute_score_and_update() {
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());
-    println!(" RMSE {},  noise {} ", f64::sqrt(error/count as f64), noise);
+    println!(
+        " RMSE {},  noise {} ",
+        f64::sqrt(error / count as f64),
+        noise
+    );
 }

--- a/Rust/tests/anomalydetectionscoreupdate.rs
+++ b/Rust/tests/anomalydetectionscoreupdate.rs
@@ -1,12 +1,13 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::rcf::{create_rcf, RCF};
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
@@ -45,13 +46,13 @@ fn anomalydetection_score_and_update() {
         bounding_box_cache_fraction,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*100.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 100.0);
     }
     let data_with_key = MultiDimDataWithKey::multi_cosine(
         data_size,
-        &vec![60;base_dimension],
+        &vec![60; base_dimension],
         &amplitude,
         noise,
         0,
@@ -79,7 +80,10 @@ fn anomalydetection_score_and_update() {
         "Average score {} ",
         (score / data_with_key.data.len() as f64)
     );
-    assert!(score < data_with_key.data.len() as f64, " average score is above 1");
+    assert!(
+        score < data_with_key.data.len() as f64,
+        " average score is above 1"
+    );
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());

--- a/Rust/tests/dynamicdensitytest.rs
+++ b/Rust/tests/dynamicdensitytest.rs
@@ -1,20 +1,20 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use std::f32::consts::PI;
+
 use num::abs;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::visitor::visitor::VisitorInfo;
-use rcflib::rcf::{create_rcf, RCF};
-
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+    visitor::visitor::VisitorInfo,
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
-
 
 #[test]
 fn dynamic_density() {
@@ -52,19 +52,27 @@ fn dynamic_density() {
 
     for degree in 0..360 {
         for j in 0..data.len() {
-            forest.update(&rotate_clockwise(&data[j], 2.0 * PI * degree as f32 / 360.0),0);
+            forest.update(
+                &rotate_clockwise(&data[j], 2.0 * PI * degree as f32 / 360.0),
+                0,
+            );
         }
 
         let density = forest.directional_density(&query_point);
         let value = density.total();
 
-        if (degree <= 60) || ((degree >= 120) && (degree <= 180)) || ((degree >= 240) && (degree <= 300)) {
+        if (degree <= 60)
+            || ((degree >= 120) && (degree <= 180))
+            || ((degree >= 240) && (degree <= 300))
+        {
             assert!(density.total() < 0.8 * capacity as f64); // the fan is above at 90,210,330
         }
 
-        if ((degree >= 75) && (degree <= 105)) || ((degree >= 195) && (degree <= 225))
-            || ((degree >= 315) && (degree <= 345)) {
-            assert!(density.total()  > 0.5 * (capacity as f64));
+        if ((degree >= 75) && (degree <= 105))
+            || ((degree >= 195) && (degree <= 225))
+            || ((degree >= 315) && (degree <= 345))
+        {
+            assert!(density.total() > 0.5 * (capacity as f64));
         }
 
         // Testing for directionality
@@ -77,52 +85,65 @@ fn dynamic_density() {
         let blade_to_the_right = density.low[0];
 
         // the tests below have a freedom of 10% of the total value
-        if ((degree >= 75) && (degree <= 85)) || ((degree >= 195) && (degree <= 205))
-            || ((degree >= 315) && (degree <= 325)) {
+        if ((degree >= 75) && (degree <= 85))
+            || ((degree >= 195) && (degree <= 205))
+            || ((degree >= 315) && (degree <= 325))
+        {
             assert!(blade_above_in_y + 0.1 * value > blade_below_in_y);
             assert!(blade_above_in_y + 0.1 * value > blade_to_the_right);
         }
 
-        if ((degree >= 95) && (degree <= 105)) || ((degree >= 215) && (degree <= 225))
-            || ((degree >= 335) && (degree <= 345)) {
+        if ((degree >= 95) && (degree <= 105))
+            || ((degree >= 215) && (degree <= 225))
+            || ((degree >= 335) && (degree <= 345))
+        {
             assert!(blade_below_in_y + 0.1 * value > blade_above_in_y);
             assert!(blade_below_in_y + 0.1 * value > blade_to_the_right);
         }
 
-        if ((degree >= 60) && (degree <= 75)) || ((degree >= 180) && (degree <= 195))
-            || ((degree >= 300) && (degree <= 315)) {
-            assert!(blade_above_in_y+ 0.1 * value > blade_to_the_left);
+        if ((degree >= 60) && (degree <= 75))
+            || ((degree >= 180) && (degree <= 195))
+            || ((degree >= 300) && (degree <= 315))
+        {
+            assert!(blade_above_in_y + 0.1 * value > blade_to_the_left);
             assert!(blade_above_in_y + 0.1 * value > blade_to_the_right);
         }
 
-        if ((degree >= 105) && (degree <= 120)) || ((degree >= 225) && (degree <= 240)) || (degree >= 345) {
+        if ((degree >= 105) && (degree <= 120))
+            || ((degree >= 225) && (degree <= 240))
+            || (degree >= 345)
+        {
             assert!(blade_below_in_y + 0.1 * value > blade_to_the_left);
             assert!(blade_below_in_y + 0.1 * value > blade_to_the_right);
         }
 
         // fans are farthest to the left at 30,150 and 270
-        if ((degree >= 15) && (degree <= 45)) || ((degree >= 135) && (degree <= 165))
-            || ((degree >= 255) && (degree <= 285)) {
-            assert!(blade_to_the_left + 0.1 * value > blade_above_in_y + blade_below_in_y + blade_to_the_right);
+        if ((degree >= 15) && (degree <= 45))
+            || ((degree >= 135) && (degree <= 165))
+            || ((degree >= 255) && (degree <= 285))
+        {
+            assert!(
+                blade_to_the_left + 0.1 * value
+                    > blade_above_in_y + blade_below_in_y + blade_to_the_right
+            );
             assert!(blade_above_in_y + blade_below_in_y + 0.1 * value > blade_to_the_right);
         }
-
     }
 }
 
-fn generate_fan(num_per_blade : usize, blades: usize) -> Vec<Vec<f32>> {
+fn generate_fan(num_per_blade: usize, blades: usize) -> Vec<Vec<f32>> {
     let mut data = Vec::new();
 
     let data_with_key = MultiDimDataWithKey::mixture(
-        num_per_blade*blades,
-        &vec![vec![0f32,0f32]],
-        &vec![vec![0.05,0.2]],
+        num_per_blade * blades,
+        &vec![vec![0f32, 0f32]],
+        &vec![vec![0.05, 0.2]],
         &vec![1.0f32],
-        0
+        0,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(72345);
     for point in data_with_key.data {
-        let toss : f64 = rng.gen();
+        let toss: f64 = rng.gen();
         let mut i = 0;
         while (i < blades + 1) {
             if (toss < i as f64 / blades as f64) {
@@ -140,9 +161,9 @@ fn generate_fan(num_per_blade : usize, blades: usize) -> Vec<Vec<f32>> {
     data
 }
 
-fn rotate_clockwise(point: &[f32], theta: f32) -> Vec<f32>{
-    let mut result = vec![0.0f32;2];
+fn rotate_clockwise(point: &[f32], theta: f32) -> Vec<f32> {
+    let mut result = vec![0.0f32; 2];
     result[0] = theta.cos() * point[0] + theta.sin() * point[1];
-    result[1] = - theta.sin() * point[0] + theta.cos() * point[1];
+    result[1] = -theta.sin() * point[0] + theta.cos() * point[1];
     return result;
 }

--- a/Rust/tests/imputedifferentperiod.rs
+++ b/Rust/tests/imputedifferentperiod.rs
@@ -1,16 +1,16 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::rcf::{create_rcf, RCF};
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
-
 
 #[test]
 fn impute_different_period() {
@@ -46,14 +46,14 @@ fn impute_different_period() {
         bounding_box_cache_fraction,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*100.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 100.0);
     }
     let mut period_rng = ChaCha20Rng::seed_from_u64(7);
-    let mut period =  Vec::new();
+    let mut period = Vec::new();
     for _i in 0..base_dimension {
-        period.push( ((1.0 + 0.2 * period_rng.gen::<f32>())*60.0) as usize);
+        period.push(((1.0 + 0.2 * period_rng.gen::<f32>()) * 60.0) as usize);
     }
     let data_with_key = MultiDimDataWithKey::multi_cosine(
         data_size,
@@ -69,11 +69,14 @@ fn impute_different_period() {
     let mut count = 0;
 
     for i in 0..data_with_key.data.len() {
-
         if i > 200 {
             let next_values = forest.extrapolate(1);
             assert!(next_values.len() == base_dimension);
-            error += next_values.iter().zip(&data_with_key.data[i]).map(|(x,y)| ((x-y) as f64 *(x-y) as f64)).sum::<f64>();
+            error += next_values
+                .iter()
+                .zip(&data_with_key.data[i])
+                .map(|(x, y)| ((x - y) as f64 * (x - y) as f64))
+                .sum::<f64>();
             count += base_dimension;
         }
         forest.update(&data_with_key.data[i], 0);
@@ -82,5 +85,9 @@ fn impute_different_period() {
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());
-    println!(" RMSE {},  noise {} ", f64::sqrt(error/count as f64), noise);
+    println!(
+        " RMSE {},  noise {} ",
+        f64::sqrt(error / count as f64),
+        noise
+    );
 }

--- a/Rust/tests/imputesameperiod.rs
+++ b/Rust/tests/imputesameperiod.rs
@@ -1,17 +1,16 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::rcf::{create_rcf, RCF};
-
+use rcflib::{
+    common::multidimdatawithkey::MultiDimDataWithKey,
+    rcf::{create_rcf, RCF},
+};
 
 /// try cargo test --release
 /// these tests are designed to be longish
-
 
 #[test]
 fn impute_same_period() {
@@ -47,30 +46,32 @@ fn impute_same_period() {
         bounding_box_cache_fraction,
     );
     let mut rng = ChaCha20Rng::seed_from_u64(42);
-    let mut amplitude =  Vec::new();
+    let mut amplitude = Vec::new();
     for _i in 0..base_dimension {
-        amplitude.push( (1.0 + 0.2 * rng.gen::<f32>())*100.0);
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 100.0);
     }
     let data_with_key = MultiDimDataWithKey::multi_cosine(
         data_size,
-        &vec![60;base_dimension],
+        &vec![60; base_dimension],
         &amplitude,
         noise,
         0,
         base_dimension.into(),
     );
 
-
     let _next_index = 0;
     let mut error = 0.0;
     let mut count = 0;
 
     for i in 0..data_with_key.data.len() {
-
         if i > 200 {
             let next_values = forest.extrapolate(1);
             assert!(next_values.len() == base_dimension);
-            error += next_values.iter().zip(&data_with_key.data[i]).map(|(x,y)| ((x-y) as f64 *(x-y) as f64)).sum::<f64>();
+            error += next_values
+                .iter()
+                .zip(&data_with_key.data[i])
+                .map(|(x, y)| ((x - y) as f64 * (x - y) as f64))
+                .sum::<f64>();
             count += base_dimension;
         }
         forest.update(&data_with_key.data[i], 0);
@@ -79,5 +80,9 @@ fn impute_same_period() {
     println!("Success! {}", forest.get_entries_seen());
     println!("PointStore Size {} ", forest.get_point_store_size());
     println!("Total size {} bytes (approx)", forest.get_size());
-    println!(" RMSE {},  noise {} ", f64::sqrt(error/count as f64), noise);
+    println!(
+        " RMSE {},  noise {} ",
+        f64::sqrt(error / count as f64),
+        noise
+    );
 }

--- a/Rust/tests/samplesummarytest.rs
+++ b/Rust/tests/samplesummarytest.rs
@@ -1,66 +1,70 @@
-
 extern crate rand;
 extern crate rand_chacha;
 extern crate rcflib;
 
 use num::abs;
-use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha20Rng;
-
-
 /// try cargo test --release
 /// these tests are designed to be longish
-
 use parameterized_test::create;
-use rand::prelude::ThreadRng;
+use rand::{prelude::ThreadRng, Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
-use rcflib::common::multidimdatawithkey::MultiDimDataWithKey;
-use rcflib::common::samplesummary::summarize;
-use rcflib::{l1distance, l2distance,linfinitydistance};
+use rcflib::{
+    common::{multidimdatawithkey::MultiDimDataWithKey, samplesummary::summarize},
+    l1distance, l2distance, linfinitydistance,
+};
 
 #[cfg(test)]
 parameterized_test::create! { sample_summary_distance_test, (test_dimension,distance), {
-    assert!(core(1000000,test_dimension,0,distance));
-    }}
+assert!(core(1000000,test_dimension,0,distance));
+}}
 
-fn core(data_size: usize, test_dimension: usize, seed: u64,distance : fn(&[f32],&[f32]) -> f64) -> bool{
+fn core(
+    data_size: usize,
+    test_dimension: usize,
+    seed: u64,
+    distance: fn(&[f32], &[f32]) -> f64,
+) -> bool {
     let mut rng = ChaCha20Rng::seed_from_u64(seed);
     let data_size = 200000;
     let mut mean = Vec::new();
     let mut scale = Vec::new();
-    let yard_stick = distance(&vec![0.0;test_dimension],&vec![1.0;test_dimension]) as f32;
+    let yard_stick = distance(&vec![0.0; test_dimension], &vec![1.0; test_dimension]) as f32;
     for i in 0..test_dimension {
-        let mut vec1 = vec![0.0f32;test_dimension];
-        let mut vec2 = vec![0.0f32;test_dimension];
+        let mut vec1 = vec![0.0f32; test_dimension];
+        let mut vec2 = vec![0.0f32; test_dimension];
         vec1[i] = 2.0 * yard_stick;
-        vec2[i] = - 2.0 * yard_stick;
+        vec2[i] = -2.0 * yard_stick;
         mean.push(vec1);
         mean.push(vec2);
-        scale.push(vec![0.1f32;test_dimension]);
-        scale.push(vec![0.1f32;test_dimension]);
-    };
+        scale.push(vec![0.1f32; test_dimension]);
+        scale.push(vec![0.1f32; test_dimension]);
+    }
 
     let data_with_key = MultiDimDataWithKey::mixture(
         data_size,
         &mean,
         &scale,
-        &vec![(0.5 / test_dimension as f32);2*test_dimension],
-        seed
+        &vec![(0.5 / test_dimension as f32); 2 * test_dimension],
+        seed,
     );
 
     let mut input = Vec::new();
     for i in 0..data_with_key.data.len() {
-        input.push((data_with_key.data[i].clone(),1.0f32));
+        input.push((data_with_key.data[i].clone(), 1.0f32));
     }
-    let mut result = summarize(&input,distance,2*test_dimension+3,false);
+    let mut result = summarize(&input, distance, 2 * test_dimension + 3, false);
     let mut answer = result.summary_points.len() == 2 * test_dimension;
     // should be two centers per dimension
     // the top two should correspond to +/- 5.0 in first dimension
     for i in 0..test_dimension {
-        result.summary_points.sort_by(|a,b| a[i].partial_cmp(&b[i]).unwrap());
+        result
+            .summary_points
+            .sort_by(|a, b| a[i].partial_cmp(&b[i]).unwrap());
         answer = answer && abs(result.summary_points[0][i] + 2.0 * yard_stick) < 0.2;
-        answer = answer && abs(result.summary_points[2*test_dimension-1][i] - 2.0 * yard_stick) < 0.2;
-        for j in 1..(2*test_dimension-1) {
+        answer = answer
+            && abs(result.summary_points[2 * test_dimension - 1][i] - 2.0 * yard_stick) < 0.2;
+        for j in 1..(2 * test_dimension - 1) {
             answer = answer && abs(result.summary_points[j][i]) < 0.2;
         }
     }
@@ -81,7 +85,7 @@ sample_summary_distance_test! {
 }
 
 #[test]
-fn benchmark(){
+fn benchmark() {
     let mut generator = ThreadRng::default();
     let one_seed: u64 = generator.gen();
     println!(" single seed is {}", one_seed);
@@ -89,10 +93,9 @@ fn benchmark(){
 
     let mut error = 0;
     for i in 0..10 {
-        let seed =rng.next_u64();
+        let seed = rng.next_u64();
         let d = rng.gen_range(3..23);
-        error += (core(200000,d,seed,l1distance) == false) as i32;
+        error += (core(200000, d, seed, l1distance) == false) as i32;
     }
-    assert!(error<5);
+    assert!(error < 5);
 }
-


### PR DESCRIPTION
*Description of changes:*

Normalize formatting in rust files by running the `cargo fmt` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
