### PR TITLE
Maven release and snapshot workflows

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,30 +1,35 @@
 # This workflow will build a package using Maven and then publish it to
 # Maven central each time a release is created on github.
 
-name: Publish Maven Package
+name: Publish Official Release to Maven Staging
 
 defaults:
   run:
     working-directory: Java/
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        required: true
+
 
 jobs:
   build:
-
+    name: Build project and publish release
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        server-id: ossrh
+        server-id: ossrh-release
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
@@ -34,4 +39,4 @@ jobs:
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,6 +1,11 @@
 # This workflow will build a package using Maven and then publish it to
-# Maven central each time a release is created on github.
+# to our staging repo for a final release to maven central
 
+# This workflow will also create a tag and github release for the current commit
+# The github release will be have '-java' added to name to distinguish rust vs java releases
+# Example:
+# current version in POM.XML and in maven central = 3.1.0
+# tag and github release = 3.1.0-java
 name: Publish Official Release to Maven Staging
 
 defaults:
@@ -9,11 +14,6 @@ defaults:
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
-        required: true
-
 
 jobs:
   build:
@@ -40,3 +40,16 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+    - name: Extract project version
+      id: project
+      run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.project.outputs.version }}-java
+        release_name: ${{ steps.project.outputs.version }}-java
+        draft: false
+        prerelease: false

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -30,19 +30,19 @@ jobs:
         server-password: MAVEN_PASSWORD
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
+    - name: Extract project version
+      id: project
+      run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-
     - name: Publish to Maven central
+      if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
       run: mvn deploy --file pom.xml
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-    - name: Extract project version
-      id: project
-      run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -1,0 +1,35 @@
+name: Build and publish snapshot on push to main
+on:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: Java/
+
+jobs:
+  build:
+    name: Build project and publish SNAPSHOT
+    runs-on: ubuntu-latest  
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Set up java for publishing snapshot
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          server-id: ossrh-snapshot
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Build with Maven
+          run: mvn -B package --file pom.xml
+      - name: Extract project version
+        id: project
+        run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+      - name: Publish to snapshot repo
+        if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
+        run: mvn clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -28,7 +28,7 @@ jobs:
         id: project
         run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
       - name: Publish to snapshot repo
-        if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
+        if: ${{ endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
         run: mvn clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -23,7 +23,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Build with Maven
-          run: mvn -B package --file pom.xml
+        run: mvn -B package --file pom.xml
       - name: Extract project version
         id: project
         run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/Java/README.md
+++ b/Java/README.md
@@ -135,7 +135,11 @@ vector data point, scores the data point, and then updates the model with this
 point. The program output appends a column of anomaly scores to the input:
 
 ```text
+<<<<<<< HEAD
 $ java -cp core/target/randomcutforest-core-3.0.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
+=======
+$ java -cp core/target/randomcutforest-core-3.0-rc4-SNAPSHOT.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
+>>>>>>> 9222dd1 (update read me with new snapshot version)
 $ tail example_output.csv
 -5.0029,0.0170,-0.0057,0.8129401629464965
 -4.9975,-0.0102,-0.0065,0.6591046054520615

--- a/Java/README.md
+++ b/Java/README.md
@@ -135,11 +135,7 @@ vector data point, scores the data point, and then updates the model with this
 point. The program output appends a column of anomaly scores to the input:
 
 ```text
-<<<<<<< HEAD
 $ java -cp core/target/randomcutforest-core-3.0.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
-=======
-$ java -cp core/target/randomcutforest-core-3.0-rc4-SNAPSHOT.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
->>>>>>> 9222dd1 (update read me with new snapshot version)
 $ tail example_output.csv
 -5.0029,0.0170,-0.0057,0.8129401629464965
 -4.9975,-0.0102,-0.0065,0.6591046054520615

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -224,11 +224,11 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>ossrh-snapshot</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
+            <id>ossrh-release</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
*Issue #, if available:*
#303
#301
*Description of changes:*

#### **maven-release workflow:**
This workflow is executed manually by a repo maintainer when releasing an official version to maven. It will publish the stable release to a staging repo where with one click we can publish it fully to maven central. It will also create a tag and a github release. If someone accidentally runs this when version still has `-SNAPSHOT`, there is extra safety to stop workflow.

#### **maven-snapshot:** 
releases a snapshot when commit is pushed to main and version is `-SNAPSHOT`.


Changed all version numbers to `3.0-rc4-SNAPSHOT`. We will be changing to a better practice in what version RCF is on when developing and releasing. The new process will involve incrementing to the next version right after a release as all new development is technically a part of the next release. We are also adding a `-SNAPSHOT` qualifier to the end of the version to indicate that this current version is during development.

_**side-note:**_ it is up to us to decide if we want to move the next development iteration to `3.0-rc4-SNAPSHOT` or `3.0-SNAPSHOT` and that is something I would like feedback on.

### General flow example:
1. 3.0.0 is released by manual click run on the new github `maven-release` workflow (more details in bottom)
2. We submit a PR to increment to 3.1.0-SNAPSHOT (we are actively developing features for 3.1 release)
    - This can be done easily with one command `mvn versions:set -DnewVersion=3.1.0-SNAPSHOT -DgenerateBackupPoms=false`
3. We are actively developing features that will be a part of 3.1 release, on every merge to main the latest snapshot can be fetched from the snapshot repository
4. We decide that we want to release 3.1 as on official release, we now submit a PR to bump the version from `3.1.0-SNAPSHOT` to `3.1.0`.
   - This can be done with one easy command: `mvn versions:set -DremoveSnapshot -DgenerateBackupPoms=false`
5. We manually run (1 click) the `maven-release` workflow, new tag is created, a new Github release created, and artifacts are uploaded to staging repository. To finalize this release we login to nexus and ensure it is closed and click release to officially push to maven central. 

The last step where we release to maven, we are actually only releasing to the staging repository where we have to login and click release one more time. This adds an extra layer of security and fault tolerance, however we can easily change this in the future to skip the staging part. For now I think we should first release just to the staging repository at least for the first official release with this new workflow. 

### Next steps:
- I spent some time trying to convert the repository over to gradle since gradle makes it a lot easier to create custom tasks, a more concise build script and overall better development experience. Gradle also is known to have much faster build times. However I was having multiple different errors with aligning dependencies and having everything work. I decided this should be a different task as we want to make sure we do it right and ensure the jar made from gradle is identical to maven.
- Create more workflows for auto incrementing versions and adding code coverage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
