### PR TITLE
Rust : introduces BasicTRCF

### DIFF
--- a/Rust/src/common/anomalydescriptor.rs
+++ b/Rust/src/common/anomalydescriptor.rs
@@ -31,12 +31,14 @@ pub struct AnomalyDescriptor {
 
     pub data_confidence: f32,
 
+    pub forecast_reasonable: bool,
+
     // present only if grade > 0
     pub attribution: Option<DiVector>,
 
     pub expected_rcf_point: Option<Vec<f32>>,
 
-    pub relative_index: Option<usize>,
+    pub relative_index: Option<i32>,
 
     // useful for time augmented forests
     pub expected_timestamp: Option<usize>,
@@ -61,9 +63,9 @@ pub struct AnomalyDescriptor {
 }
 
 impl AnomalyDescriptor {
-    pub fn new(point: Vec<f32>, timestamp: usize) -> Self {
+    pub fn new(point: &[f32], timestamp: usize) -> Self {
         AnomalyDescriptor {
-            current_input: point.clone(),
+            current_input: Vec::from(point),
             current_timestamp: timestamp,
             missing_values: None,
             rcf_point: None,
@@ -72,6 +74,7 @@ impl AnomalyDescriptor {
             threshold: 0.0,
             anomaly_grade: 0.0,
             data_confidence: 0.0,
+            forecast_reasonable: false,
             attribution: None,
             expected_rcf_point: None,
             relative_index: None,
@@ -102,6 +105,7 @@ impl AnomalyDescriptor {
             threshold: 0.0,
             anomaly_grade: 0.0,
             data_confidence: 0.0,
+            forecast_reasonable: false,
             attribution: None,
             expected_rcf_point: None,
             relative_index: None,

--- a/Rust/src/common/conditionalfieldsummarizer.rs
+++ b/Rust/src/common/conditionalfieldsummarizer.rs
@@ -9,6 +9,10 @@ fn project_missing(point: &Vec<f32>, position: &[usize]) -> Vec<f32> {
     position.iter().map(|i| point[*i]).collect()
 }
 
+const CONDITIONAL_UPPER_FRACTION : f64 = 0.9;
+
+const CONDITIONAL_LOWER_FRACTION : f64 = 0.1;
+
 /// the following function is a conduit that summarizes the conditional samples derived from the trees
 /// The samples are denoted by (PointIndex, f32) where the PointIndex(usize) corresponds to the point identifier
 /// in the point store and the f32 associated with a scalar value (corresponding to weight)
@@ -54,7 +58,7 @@ impl FieldSummarizer {
         &self,
         pointstore: &dyn PointStore,
         point_list_with_distance: &[(f64, usize, f64)],
-        missing: &[usize],
+        missing: &[usize]
     ) -> SampleSummary {
         let mut distance_list: Vec<f64> = point_list_with_distance.iter().map(|a| a.2).collect();
         distance_list.sort_by(|a, b| a.partial_cmp(&b).unwrap());
@@ -114,11 +118,23 @@ impl FieldSummarizer {
                 - sum_values[j] * sum_values[j] / (total_weight as f64 * total_weight as f64);
             deviation[j] = f64::sqrt(if t > 0.0 { t } else { 0.0 }) as f32;
         }
+        let vec_weight : f64 = vec.iter().map(|x| x.1 as f64).sum();
+        let num = vec_weight/2.0;
+        let lower_fraction = vec_weight *CONDITIONAL_LOWER_FRACTION;
+        let upper_fraction = vec_weight*CONDITIONAL_UPPER_FRACTION;
         let mut median = vec![0.0f32; dimensions];
+        let mut upper = vec![0.0f32; dimensions];
+        let mut lower = vec![0.0f32; dimensions];
+
         for j in 0..dimensions {
-            let mut v: Vec<f32> = vec.iter().map(|x| x.0[j]).collect();
-            v.sort_by(|a, b| a.partial_cmp(b).unwrap());
-            median[j] = v[vec.len() / 2];
+            let mut y: Vec<(f32,f32)> = vec.iter().map(|x| (x.0[j],x.1)).collect();
+            y.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            let first = SampleSummary::pick(&y,lower_fraction,0,0.0);
+            lower[j] = y[first.0].0;
+            let second = SampleSummary::pick(&y,num,first.0,first.1);
+            median[j] = y[second.0].0;
+            let third = SampleSummary::pick(&y,upper_fraction,second.0,second.1);
+            upper[j] = y[third.0].0;
         }
 
         let summary = summarize(&vec, self.distance, self.max_number, false);
@@ -128,6 +144,8 @@ impl FieldSummarizer {
             total_weight: summary.total_weight,
             mean,
             median,
+            upper,
+            lower,
             deviation,
         }
     }

--- a/Rust/src/common/divector.rs
+++ b/Rust/src/common/divector.rs
@@ -176,4 +176,23 @@ impl DiVector {
     pub fn high_low_sum(&self, index: usize) -> f64 {
         self.high[index] + self.low[index]
     }
+
+    pub fn max_contribution(&self, base_dimension: usize) -> usize {
+        let mut val = 0.0;
+        let mut index = 0;
+        for i in 0..base_dimension {
+            val += self.high_low_sum(i);
+        }
+        for j in 1..(self.dimensions() / base_dimension) {
+            let mut sum = 0.0;
+            for i in 0..base_dimension {
+                sum += self.high_low_sum(j * base_dimension + i);
+            }
+            if sum > val {
+                val = sum;
+                index = j;
+            }
+        }
+        index
+    }
 }

--- a/Rust/src/common/mod.rs
+++ b/Rust/src/common/mod.rs
@@ -6,4 +6,5 @@ pub mod intervalstoremanager;
 pub mod multidimdatawithkey;
 pub mod samplesummary;
 pub mod deviation;
-mod anomalydescriptor;
+pub mod anomalydescriptor;
+pub mod rangevector;

--- a/Rust/src/common/rangevector.rs
+++ b/Rust/src/common/rangevector.rs
@@ -1,0 +1,74 @@
+
+
+/**
+ * A RangeVector is used when we want to track a quantity and its upper and
+ * lower bounds
+ */
+#[repr(C)]
+#[derive(Clone)]
+pub struct RangeVector {
+    pub values: Vec<f32>,
+    pub upper: Vec<f32>,
+    pub lower: Vec<f32>
+}
+
+impl RangeVector {
+    pub fn new(dimensions: usize) -> Self {
+        RangeVector {
+            values: vec![0.0; dimensions],
+            upper: vec![0.0; dimensions],
+            lower: vec![0.0; dimensions]
+        }
+    }
+
+    pub fn from(values : Vec<f32>) -> Self {
+        RangeVector{
+            values : values.clone(),
+            upper : values.clone(),
+            lower : values.clone()
+        }
+    }
+
+    pub fn create(values: &[f32], upper: &[f32], lower:&[f32]) -> Self {
+        assert!(values.len() == upper.len() && upper.len() == lower.len(), " incorrect lengths");
+        for i in 0..values.len() {
+            assert!(values[i] <= upper[i], " incorrect upper bound at {}", i);
+            assert!(lower[i] <= values [i], "incorrect lower bounds at {}",i);
+        }
+        RangeVector{
+            values :Vec::from(values),
+            upper : Vec::from(upper),
+            lower : Vec::from(lower)
+        }
+    }
+
+    pub fn shift(&mut self, i:usize, shift: f32) {
+        for j in 0..self.values.len() {
+            self.values[i] += shift;
+            self.upper[i] += shift;
+            self.lower[i] += shift;
+            // managing precision explicitly
+            if self.upper[i] < self.values[i] {
+                self.upper[i] = self.values[i];
+            }
+            if self.lower[i] > self.values[i] {
+                self.lower[i] = self.values[i];
+            }
+        }
+    }
+
+    pub fn scale(&mut self, i:usize, scale: f32) {
+        for j in 0..self.values.len() {
+            self.values[i] *= scale;
+            self.upper[i] *= scale;
+            self.lower[i] *= scale;
+            // managing precision explicitly
+            if self.upper[i] < self.values[i] {
+                self.upper[i] = self.values[i];
+            }
+            if self.lower[i] > self.values[i] {
+                self.lower[i] = self.values[i];
+            }
+        }
+    }
+}

--- a/Rust/src/example.rs
+++ b/Rust/src/example.rs
@@ -63,7 +63,7 @@ fn main() {
 
     for i in 0..data_with_key.data.len() {
         if i > 200 {
-            let next_values = forest.extrapolate(1).unwrap();
+            let next_values = forest.extrapolate(1).unwrap().values;
             assert!(next_values.len() == base_dimension);
             error += next_values
                 .iter()

--- a/Rust/src/lib.rs
+++ b/Rust/src/lib.rs
@@ -6,6 +6,7 @@ mod samplerplustree;
 mod types;
 mod util;
 pub mod visitor;
+pub mod trcf;
 
 extern crate rand;
 extern crate rand_chacha;

--- a/Rust/src/trcf/basicthresholder.rs
+++ b/Rust/src/trcf/basicthresholder.rs
@@ -1,0 +1,264 @@
+use crate::common::deviation::Deviation;
+
+const DEFAULT_ELASTICITY : f32= 0.01;
+const DEFAULT_HORIZON : f32 = 0.5;
+const DEFAULT_HORIZON_ONED : f32 = 0.75;
+const DEFAULT_MINIMUM_SCORES : i32 = 10;
+const DEFAULT_ABSOLUTE_THRESHOLD : f32= 0.8;
+const DEFAULT_ABSOLUTE_SCORE_FRACTION :f32 = 0.5;
+const DEFAULT_UPPER_THRESHOLD :f32= 2.0;
+const DEFAULT_LOWER_THRESHOLD :f32 = 1.0;
+const DEFAULT_LOWER_THRESHOLD_ONED :f32 = 1.1;
+const DEFAULT_LOWER_THRESHOLD_NORMALIZED : f32 = 0.9;
+const DEFAULT_INITIAL_THRESHOLD :f32= 1.5;
+const DEFAULT_Z_FACTOR :f32 = 2.0;
+const DEFAULT_UPPER_FACTOR :f32 = 5.0;
+const DEFAULT_AUTO_ADJUST_LOWER_THRESHOLD :bool = false;
+const DEFAULT_THRESHOLD_STEP :f32 = 0.1;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct BasicThresholder {
+    elasticity: f32,
+    count: i32,
+    horizon: f32,
+    last_score: f32,
+    primary_deviation: Deviation,
+    secondary_deviation: Deviation,
+    threshold_deviation: Deviation,
+    auto_threshold: bool,
+    absolute_threshold:f32,
+    absolute_score_fraction: f32,
+    upper_threshold: f32,
+    lower_threshold: f32,
+    initial_threshold: f32,
+    z_factor: f32,
+    upper_z_factor: f32,
+    in_potential_anomaly: bool,
+    minimum_scores: i32,
+}
+
+impl BasicThresholder {
+    pub fn new_adjustible(discount : f32, adjust:bool) -> Self {
+        BasicThresholder{
+            elasticity: DEFAULT_ELASTICITY,
+            count: 0,
+            horizon: DEFAULT_HORIZON,
+            last_score: 0.0,
+            primary_deviation: Deviation::new(discount as f64),
+            secondary_deviation: Deviation::new(discount as f64),
+            threshold_deviation: Deviation::new(discount as f64/2.0),
+            auto_threshold: adjust,
+            absolute_threshold: DEFAULT_ABSOLUTE_THRESHOLD,
+            absolute_score_fraction: DEFAULT_ABSOLUTE_SCORE_FRACTION,
+            upper_threshold: DEFAULT_UPPER_THRESHOLD,
+            lower_threshold: DEFAULT_LOWER_THRESHOLD,
+            initial_threshold: DEFAULT_INITIAL_THRESHOLD,
+            z_factor: DEFAULT_Z_FACTOR,
+            upper_z_factor: DEFAULT_UPPER_FACTOR,
+            in_potential_anomaly: false,
+            minimum_scores: DEFAULT_MINIMUM_SCORES
+        }
+    }
+
+    pub fn new(discount : f32) -> Self{
+        BasicThresholder::new_adjustible(discount,false)
+    }
+
+    pub fn is_deviation_ready(&self) -> bool {
+        if self.count < self.minimum_scores {
+            return false;
+        }
+
+        if self.horizon == 0.0 {
+            return self.secondary_deviation.count() >= self.minimum_scores;
+        } else if self.horizon == 1.0 {
+            return self.primary_deviation.count() >= self.minimum_scores;
+        } else {
+            return self.secondary_deviation.count() >= self.minimum_scores
+                && self.primary_deviation.count() >= self.minimum_scores;
+        }
+    }
+
+    fn intermediate_fraction(&self) -> f32 {
+        if self.count < self.minimum_scores {
+            return 0.0;
+        } else if self.count > 2 * self.minimum_scores {
+            return 1.0;
+        } else {
+            return (self.count - self.minimum_scores) as f32 * 1.0 / self.minimum_scores as f32;
+        }
+    }
+
+    fn short_term_threshold(&self, factor : f32, intermediate_fraction : f32) -> f32{
+        if !self.is_deviation_ready() { // count < minimumScore is this branch
+            if self.initial_threshold>self.lower_threshold{
+                self.initial_threshold
+            } else {
+                self.lower_threshold
+            }
+        } else {
+            let t = intermediate_fraction *self.longterm_threshold(factor) +
+                (1.0 -intermediate_fraction)*self.initial_threshold;
+            if t>self.lower_threshold{
+                t
+            } else {
+                self.lower_threshold
+            }
+        }
+    }
+
+    pub fn threshold(&self) -> f32{
+        return self.longterm_threshold(self.z_factor);
+    }
+
+    pub fn longterm_threshold(&self, factor:f32) -> f32 {
+        let t= (self.primary_deviation.mean() as f32) + factor * self.longterm_deviation();
+        if t >self.lower_threshold {
+            t
+        } else {
+            self.lower_threshold
+        }
+    }
+
+    fn longterm_deviation(&self) -> f32{
+        self.horizon * (self.primary_deviation.deviation() as f32) + (1.0 - self.horizon) * (self.secondary_deviation.deviation() as f32)
+    }
+
+    pub fn anomaly_grade_with_factor(&self, score : f32, previous : bool, factor: f32) -> f32{
+        assert!(factor >= self.z_factor, "incorrect call");
+
+        let elastic_addition = if previous {self.elasticity} else {0.0};
+        let intermediate_fraction = self.intermediate_fraction();
+        if intermediate_fraction == 1.0 {
+            if score < self.longterm_threshold(factor) - elastic_addition {
+                return 0.0;
+            }
+            let mut t_Factor = self.upper_z_factor;
+            let longterm_deviation = self.longterm_deviation();
+            if longterm_deviation > 0.0 {
+                let t =  (score - self.primary_deviation.mean() as f32) / longterm_deviation;
+                if (t as f32) < t_Factor {
+                    t_Factor = t as f32;
+                }
+            }
+            return (t_Factor - self.z_factor) / (self.upper_z_factor - self.z_factor);
+        } else {
+            let t = self.short_term_threshold(factor, intermediate_fraction);
+            if score < t - elastic_addition {
+                return 0.0;
+            }
+            let upper = if self.upper_threshold > 2.0 * t {self.upper_threshold} else {2.0*t};
+            let quasi_score = if score <upper {score} else {upper};
+            return (quasi_score - t) / (upper - t);
+        }
+    }
+
+    pub fn anomaly_grade(&self, score : f32, previous : bool) -> f32{
+        return self.anomaly_grade_with_factor(score, previous, self.z_factor);
+    }
+
+    pub fn update_threshold(&mut self, score:f32) {
+        let gap : f32 = if score > self.lower_threshold {1.0} else {0.0};
+        self.threshold_deviation.update(gap as f64);
+        if self.auto_threshold && self.threshold_deviation.count() > self.minimum_scores {
+            // note the rate is set at half the anomaly rate
+            if self.threshold_deviation.mean() > self.threshold_deviation.discount() {
+                let t = self.lower_threshold + DEFAULT_THRESHOLD_STEP;
+                self.set_lower_threshold(t, self.auto_threshold);
+                self.threshold_deviation.set_count(0);
+            } else if self.threshold_deviation.mean() < self.threshold_deviation.discount() / 4.0 {
+                let t = self.lower_threshold - DEFAULT_THRESHOLD_STEP;
+                if t > self.absolute_threshold {
+                    self.set_lower_threshold(t, self.auto_threshold);
+                    self.threshold_deviation.set_count(0);
+                }
+            }
+        }
+    }
+
+    pub fn update_primary(&mut self, score : f64) {
+        self.last_score = score as f32;
+        self.primary_deviation.update(score);
+        self.update_threshold(score as f32);
+        self.count += 1;
+    }
+
+    pub fn update_both(&mut self, primary : f32, secondary : f32) {
+        self.last_score = primary;
+        self.primary_deviation.update(primary as f64);
+        self.secondary_deviation.update(secondary as f64);
+        self.update_threshold(primary as f32);
+        self.count += 1;
+    }
+
+    pub fn update(&mut self, primary: f32, secondary: f32, last_score: f32, previous : bool){
+        self.update_both(primary,secondary - last_score);
+        self.in_potential_anomaly = previous;
+    }
+    // the next set of functions maintain the invariant that
+    // DEFAULT_Z_FACTOR <= z_FACTOR < 2.0 * z_factor <= upper_z_factor
+
+    pub fn set_z_factor(&mut self, factor : f32) {
+        let z_factor = if factor > DEFAULT_Z_FACTOR {factor} else {DEFAULT_Z_FACTOR};
+        if self.upper_z_factor < 2.0 * z_factor {
+            self.upper_z_factor = 2.0 * z_factor;
+        }
+    }
+
+    pub fn set_upper_z_factor(&mut self, factor : f32) {
+        let t = if factor> 2.0*self.z_factor {factor} else {2.0*self.z_factor};
+        self.upper_z_factor = t
+    }
+
+    // the next set of functions maintain the invariant that
+    // absolute_threshold <= lower_threshold < initial_threshold <= upper_threshold
+    // absolute_threshold <= lower_threshold < 2.0 *lower_threshold <= upper_threshold
+    // to increase proceed as upper_threshold, initial_threshold, lower_threshold, absolute_threshold
+    // to decrease proceed in reverse of the above order
+
+    pub fn set_lower_threshold(&mut self, lower : f32, adjust: bool) {
+        let lower_t = if lower>self.absolute_threshold {lower} else {self.absolute_threshold};
+        self.lower_threshold = lower_t;
+        self.auto_threshold = adjust;
+        if self.initial_threshold < lower_t {
+            self.initial_threshold = lower_t;
+        };
+        if self.upper_threshold < 2.0 * lower_t {
+            self.upper_threshold = 2.0 * lower_t;
+        }
+    }
+
+    pub fn set_absolute_threshold(&mut self, value:f32) {
+        self.absolute_threshold = value;
+        self.set_lower_threshold(self.absolute_threshold, self.auto_threshold);
+    }
+
+    pub fn set_initial_threshold(&mut self, initial : f32) {
+        self.initial_threshold = if initial< self.lower_threshold {self.lower_threshold} else {initial};
+        if self.upper_threshold < initial {
+            self.upper_threshold = initial;
+        }
+    }
+
+    pub fn set_upper_threshold(&mut self, upper : f32) {
+        self.upper_threshold = if upper < self.initial_threshold {self.initial_threshold} else {upper};
+        if self.upper_threshold < 2.0 * self.lower_threshold {
+            self.upper_threshold = 2.0 * self.lower_threshold;
+        }
+    }
+
+    pub fn in_potential_anomaly(&self) -> bool {
+        self.in_potential_anomaly
+    }
+
+    pub fn set_horizon(&mut self, horizon:f32) {
+        assert!(horizon >= 0.0 && horizon <= 1.0, "incorrect horizon parameter");
+        self.horizon = horizon;
+    }
+
+    pub fn last_score(&self) -> f32{
+        self.last_score
+    }
+
+}

--- a/Rust/src/trcf/basictrcf.rs
+++ b/Rust/src/trcf/basictrcf.rs
@@ -1,0 +1,79 @@
+
+use crate::common::anomalydescriptor::AnomalyDescriptor;
+use crate::common::rangevector::RangeVector;
+use crate::common::samplesummary::SampleSummary;
+use crate::rcf::{create_rcf, RCF};
+use crate::types::{Location, Result};
+use crate::errors::RCFError;
+use crate::trcf::predictorcorrector::PredictorCorrector;
+
+pub struct BasicTRCF {
+    dimensions: usize,
+    capacity: usize,
+    number_of_trees: usize,
+    rcf : Box<dyn RCF>,
+    predictor_corrector: PredictorCorrector,
+    shingle_size: usize,
+    internal_timestamp : usize,
+    bounding_box_cache_fraction: f64,
+    last_anomaly_descriptor : AnomalyDescriptor,
+}
+
+
+impl BasicTRCF {
+    pub fn new(
+        dimensions: usize,
+        shingle_size: usize,
+        capacity: usize,
+        number_of_trees: usize,
+        random_seed: u64,
+        parallel_enabled: bool,
+        time_decay: f64,
+        anomaly_rate: f32,
+        initial_accept_fraction: f64,
+        bounding_box_cache_fraction: f64,
+    ) -> Self {
+        BasicTRCF{
+            dimensions,
+            capacity,
+            number_of_trees,
+            rcf: create_rcf(dimensions,shingle_size,capacity,number_of_trees,random_seed,false,parallel_enabled,true,false,time_decay,initial_accept_fraction,bounding_box_cache_fraction),
+            predictor_corrector : PredictorCorrector::new(anomaly_rate),
+            shingle_size,
+            bounding_box_cache_fraction,
+            internal_timestamp : 0,
+            last_anomaly_descriptor: AnomalyDescriptor::new(&Vec::new(),0),
+        }
+    }
+
+    pub fn process(&mut self, point: &[f32], timestamp: usize) -> Result<AnomalyDescriptor>{
+        let mut result = AnomalyDescriptor::new(point,timestamp);
+        result.internal_timestamp = self.internal_timestamp;
+        self.internal_timestamp += 1;
+        result.rcf_point = Some(self.rcf.shingled_point(point));
+        result.forecast_reasonable = self.rcf.entries_seen() > 200;
+        self.predictor_corrector.detect_and_modify(&mut result,&self.last_anomaly_descriptor,self.shingle_size, &self.rcf,false,false);
+        if result.anomaly_grade > 0.0 {
+            if let Some(x) = &result.expected_rcf_point {
+                let base_dimension = self.dimensions / self.shingle_size;
+                let start: usize = (self.shingle_size as i32 + result.relative_index.unwrap() - 1) as usize * base_dimension;
+                result.expected_values_list = Some(vec![Vec::from(&x[start..start+base_dimension])]);
+                result.past_values = Some(Vec::from(&result.rcf_point.as_ref().unwrap()[start..start+base_dimension]));
+                result.likelihood_of_values=Some(vec![1.0f32]);
+            }
+            self.last_anomaly_descriptor = result.clone();
+        }
+
+        self.rcf.update(point,timestamp as u64);
+        Ok(result)
+    }
+
+    pub fn extrapolate(&self, look_ahead: usize) -> Result<RangeVector> {
+        self.rcf.extrapolate(look_ahead)
+    }
+
+
+}
+
+
+

--- a/Rust/src/trcf/mod.rs
+++ b/Rust/src/trcf/mod.rs
@@ -1,0 +1,3 @@
+mod predictorcorrector;
+mod basicthresholder;
+pub mod basictrcf;

--- a/Rust/src/trcf/predictorcorrector.rs
+++ b/Rust/src/trcf/predictorcorrector.rs
@@ -1,0 +1,253 @@
+use crate::common::divector::DiVector;
+use crate::rcf::RCF;
+use crate::trcf::basicthresholder::BasicThresholder;
+use crate::common::anomalydescriptor::AnomalyDescriptor;
+
+const DEFAULT_NUMBER_OF_MAX_ATTRIBUTORS: usize = 5;
+const DEFAULT_REPEAT_ANOMALY_Z_FACTOR : f32 = 3.5;
+const DEFAULT_IGNORE_SIMILAR_FACTOR :f32 = 0.3;
+const DEFAULT_IGNORE_SIMILAR : bool = false;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct PredictorCorrector {
+    basic_thresholder: BasicThresholder,
+    ignore_similar : f32,
+    trigger_factor : f32,
+    max_attributors: usize
+}
+
+impl PredictorCorrector {
+    // for mappers
+    pub fn new(discount: f32) -> Self {
+        PredictorCorrector {
+            basic_thresholder: BasicThresholder::new_adjustible(discount, false),
+            ignore_similar: DEFAULT_IGNORE_SIMILAR_FACTOR,
+            trigger_factor: DEFAULT_REPEAT_ANOMALY_Z_FACTOR,
+            max_attributors: DEFAULT_NUMBER_OF_MAX_ATTRIBUTORS
+        }
+    }
+
+    pub fn expected_point(di_vector: &DiVector, max_attributors: usize, position: usize, base_dimension: usize, point: &[f32],
+                          forest: &Box<dyn RCF>) -> Vec<f32> {
+        let mut likely_missing_indices: Vec<usize>;
+
+        if base_dimension == 1 {
+            likely_missing_indices = vec![position; 1];
+        } else {
+            let mut sum = 0.0;
+            let mut values = vec![0.0; base_dimension];
+            for i in 0..base_dimension {
+                values[i] = di_vector.high_low_sum(i + position);
+                sum += values[i];
+            }
+            // sort decreasing
+            values.sort_by(|a, b| b.partial_cmp(a).unwrap());
+
+            let mut pick = 0;
+            while pick < base_dimension && values[pick] >= (sum * 0.5 / max_attributors as f64) {
+                pick += 1;
+            }
+            likely_missing_indices = Vec::new();
+
+            if pick != 0 && pick <= max_attributors {
+                let cutoff = values[pick - 1];
+                for i in 0..base_dimension {
+                    if di_vector.high_low_sum(i + position) >= cutoff && likely_missing_indices.len() < max_attributors {
+                        likely_missing_indices.push(position + i);
+                    }
+                }
+            }
+        }
+
+        let mut answer = Vec::from(point);
+        if likely_missing_indices.len() != 0 && (2 * likely_missing_indices.len()  < forest.dimensions()) {
+            let prediction = forest.conditional_field(&likely_missing_indices, point, 1.0, false, 0).unwrap().median;
+            for i in likely_missing_indices{
+                answer[i] = prediction[i];
+            }
+        }
+        answer
+    }
+
+    fn trigger(&self, candidate: &DiVector, gap: usize, base_dimension: usize, ideal: Option<DiVector>,
+               previous: bool, last_anomaly_descriptor: &AnomalyDescriptor) -> bool {
+        match &last_anomaly_descriptor.attribution {
+            None => { return true; },
+            Some(x) => {
+                let last_score = last_anomaly_descriptor.score;
+                let dimensions = candidate.dimensions();
+                let difference = gap * base_dimension;
+                if difference < dimensions {
+                    match ideal {
+                        None => {
+                            let mut remainder = 0.0;
+                            for i in (dimensions - difference)..dimensions {
+                                remainder += candidate.high_low_sum(i);
+                            }
+                            return self.basic_thresholder.anomaly_grade_with_factor((remainder as f32) * dimensions as f32 / difference as f32, previous, self.trigger_factor) > 0.0;
+                        },
+                        Some(ref y) => {
+                            let mut differential_remainder = 0.0;
+                            for i in (dimensions - difference)..dimensions {
+                                let low_diff = candidate.low[i] - ideal.as_ref().unwrap().low[i];
+                                differential_remainder += if low_diff > 0.0 { low_diff } else { -low_diff };
+                                let high_diff = candidate.high[i] - ideal.as_ref().unwrap().high[i];
+                                differential_remainder += if high_diff > 0.0 { high_diff } else { -high_diff };
+                            }
+                            return (differential_remainder > self.ignore_similar as f64 * last_score as f64) &&
+                                self.basic_thresholder.anomaly_grade_with_factor((differential_remainder as f32) * (dimensions as f32) / difference as f32, previous, self.trigger_factor) > 0.0;
+                        }
+                    }
+                } else {
+                    return true;
+                }
+            }
+        }
+    }
+
+    pub fn apply_basic_corrector(point: &[f32], gap: usize, shingle_size: usize, base_dimension: usize,
+                                 last_anomaly_descriptor: &AnomalyDescriptor, use_difference: bool, time_augmented: bool) -> Vec<f32> {
+        assert!(gap <= shingle_size, "incorrect invocation");
+
+        let mut corrected_point = Vec::from(point);
+        let last_expected_point = last_anomaly_descriptor.expected_rcf_point.as_ref().unwrap();
+        let last_anomaly_point = last_anomaly_descriptor.rcf_point.as_ref().unwrap();
+        let last_relative_index = last_anomaly_descriptor.relative_index.unwrap();
+        if gap < shingle_size {
+            for i in gap * base_dimension..point.len() {
+                corrected_point[i - gap * base_dimension] = last_expected_point[i];
+            }
+        }
+        if last_relative_index == 0 { // is is possible to fix other cases, but is more complicated
+            if use_difference {
+                for y in 0..base_dimension {
+                    corrected_point[point.len() - gap * base_dimension + y] +=
+                        last_anomaly_point[point.len() - base_dimension + y] -
+                            last_expected_point[point.len() - base_dimension + y];
+                }
+            } else if time_augmented {
+                // definitely correct the time dimension which is always differenced
+                // this applies to the non-differenced cases
+                corrected_point[point.len() - (gap - 1) * base_dimension - 1] +=
+                    last_anomaly_point[point.len() - 1]
+                        - last_expected_point[point.len() - 1];
+            }
+        }
+        return corrected_point;
+    }
+
+
+    pub fn detect_and_modify(&mut self, result: &mut AnomalyDescriptor, last_anomaly_descriptor : &AnomalyDescriptor, shingle_size: usize, forest : &Box<dyn RCF>, use_difference: bool, time_augmented: bool) {
+        match &result.rcf_point {
+            None => return,
+            Some(point) => {
+                let score = forest.score(point).unwrap() as f32;
+                result.score = score;
+                if score == 0.0 {
+                    return;
+                }
+                let internal_timestamp = result.internal_timestamp;
+                let base_dimension = forest.dimensions() / shingle_size;
+                let mut start_position = (shingle_size - 1) * base_dimension;
+                result.threshold = self.basic_thresholder.threshold();
+                let previous = self.basic_thresholder.in_potential_anomaly();
+
+                if self.basic_thresholder.anomaly_grade(score, previous) == 0.0 {
+                    result.anomaly_grade = 0.0;
+                    result.in_high_score_region = Some(false);
+                    self.basic_thresholder.update(score, score, 0.0, false);
+                    return;
+                }
+
+                // the score is now high enough to be considered an anomaly
+                result.in_high_score_region = Some(true);
+
+                let gap = internal_timestamp - last_anomaly_descriptor.internal_timestamp;
+
+                let reasonable_forecast = result.forecast_reasonable;
+
+                if reasonable_forecast && gap > 0 && gap <= shingle_size {
+                    if let Some(_expected) = &last_anomaly_descriptor.expected_rcf_point {
+                        let corrected_point = Self::apply_basic_corrector(point, gap, shingle_size, base_dimension,
+                                                                          last_anomaly_descriptor, use_difference, time_augmented);
+                        let corrected_score = forest.score(&corrected_point).unwrap() as f32;
+                        // we know we are looking previous anomalies
+                        if self.basic_thresholder.anomaly_grade(corrected_score, true) == 0.0 {
+                            // fixing the past makes this anomaly go away; nothing to do but process the
+                            // score
+                            // we will not change inHighScoreRegion however, because the score has been
+                            // larger
+                            self.basic_thresholder.update(score, corrected_score, 0.0, false);
+                            result.expected_rcf_point = Some(corrected_point);
+                            result.anomaly_grade = 0.0;
+                            return;
+                        }
+                    }
+                }
+
+                let attribution = forest.attribution(point).unwrap();
+                // index is 0 .. (shingle_size - 1); this is a departure from java version
+                let mut index = attribution.max_contribution(base_dimension);
+
+                if !previous && self.trigger(&attribution, gap, base_dimension, None, false, last_anomaly_descriptor) {
+                    result.anomaly_grade = self.basic_thresholder.anomaly_grade(score, false);
+                    result.start_of_anomaly = Some(true);
+                    self.basic_thresholder.update(score, score, 0.0, true);
+                    let start_position = base_dimension * index;
+                    if reasonable_forecast {
+                        let new_point = Self::expected_point(&attribution, self.max_attributors, start_position, base_dimension, point, &forest);
+                        result.expected_rcf_point = Some(new_point);
+                    }
+                    result.relative_index = Some(index as i32 - shingle_size as i32 + 1);
+                    result.attribution = Some(attribution);
+                    return;
+                } else if reasonable_forecast {
+                    let start_position = base_dimension * index;
+                    let new_point = Self::expected_point(&attribution, self.max_attributors, start_position, base_dimension, point, &forest);
+                    let new_attribution = forest.attribution(&new_point).unwrap();
+                    let new_score = forest.score(&new_point).unwrap() as f32;
+
+
+                    if self.trigger(&attribution, gap, base_dimension, Some(new_attribution), previous,
+                                    &last_anomaly_descriptor) {
+                        result.anomaly_grade = self.basic_thresholder.anomaly_grade(score, previous);
+                        result.expected_rcf_point = Some(new_point);
+                        result.relative_index = Some(0);
+                        result.attribution = Some(attribution);
+                        self.basic_thresholder.update(score, new_score, 0.0, true);
+                    } else {
+                        // previousIsPotentialAnomaly is true now, but not calling it anomaly either
+                        self.basic_thresholder.update(score, new_score, 0.0, true);
+                        result.anomaly_grade = 0.0;
+                        return;
+                    }
+                }
+                // previousIsPotentialAnomaly is true now, but not calling it anomaly either
+                self.basic_thresholder.update(score, score, 0.0, true);
+                result.anomaly_grade = 0.0;
+                return;
+            },
+        }
+    }
+
+
+    pub fn set_z_factor(&mut self, factor: f32) {
+        self.basic_thresholder.set_z_factor(factor);
+        if factor > self.trigger_factor {
+            self.trigger_factor = factor;
+        }
+    }
+
+    pub fn set_lower_threshold(&mut self, lower :f32) {
+        self.basic_thresholder.set_absolute_threshold(lower);
+    }
+
+    pub fn set_horizon(&mut self, horizon : f32) {
+        self.basic_thresholder.set_horizon(horizon);
+    }
+
+    pub fn set_initial_threshold(&mut self, initial : f32) {
+        self.basic_thresholder.set_initial_threshold(initial);
+    }
+}

--- a/Rust/tests/anomalydetectionimputescoreupdate.rs
+++ b/Rust/tests/anomalydetectionimputescoreupdate.rs
@@ -66,7 +66,7 @@ fn anomalydetection_impute_score_and_update() {
 
     for i in 0..data_with_key.data.len() {
         if i > 200 {
-            let next_values = forest.extrapolate(1).unwrap();
+            let next_values = forest.extrapolate(1).unwrap().values;
             assert!(next_values.len() == base_dimension);
             error += next_values
                 .iter()

--- a/Rust/tests/basictrcftest.rs
+++ b/Rust/tests/basictrcftest.rs
@@ -1,0 +1,173 @@
+extern crate rand;
+extern crate rand_chacha;
+extern crate rcflib;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use rcflib::{
+    common::multidimdatawithkey,
+    rcf::{create_rcf, RCF},
+    trcf::basictrcf::BasicTRCF
+};
+
+
+#[test]
+fn test_basic_trcf() {
+    let shingle_size = 8;
+    let base_dimension = 5;
+    let data_size = 1000;
+    let number_of_trees = 30;
+    let capacity = 256;
+    let initial_accept_fraction = 0.1;
+    let dimensions = shingle_size * base_dimension;
+    let _point_store_capacity = capacity * number_of_trees + 1;
+    let time_decay = 0.1 / capacity as f64;
+    let bounding_box_cache_fraction = 1.0;
+    let random_seed = 17;
+    let parallel_enabled: bool = false;
+    let store_attributes: bool = false;
+    let internal_shingling: bool = true;
+    let internal_rotation = false;
+    let noise = 5.0;
+
+    let mut trcf = BasicTRCF::new(
+        dimensions,
+        shingle_size,
+        capacity,
+        number_of_trees,
+        random_seed, parallel_enabled,
+        time_decay,
+        0.01,
+        initial_accept_fraction,
+        bounding_box_cache_fraction,
+    );
+
+    let mut rng = ChaCha20Rng::seed_from_u64(42);
+    let mut amplitude = Vec::new();
+    for _i in 0..base_dimension {
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 60.0);
+    }
+
+    let data_with_key = multidimdatawithkey::MultiDimDataWithKey::multi_cosine(
+        data_size,
+        &vec![60; base_dimension],
+        &amplitude,
+        noise,
+        42,
+        base_dimension.into(),
+    );
+
+    let mut next_index = 0;
+
+    for i in 0..data_with_key.data.len() {
+        if next_index < data_with_key.change_indices.len() && data_with_key.change_indices[next_index] == i {
+            print!("timestamp {} INJECT [ {}", i, data_with_key.changes[next_index][0]);
+            for j in 1..base_dimension {
+                print!(", {}", data_with_key.changes[next_index][j]);
+            }
+            println!("]");
+            next_index += 1;
+        }
+        let result = trcf.process(&data_with_key.data[i], 0).unwrap();
+        if result.anomaly_grade > 0.0 {
+            print!("timestamp {} ", i);
+            if (result.relative_index.unwrap() != 0) {
+                let gap = -result.relative_index.unwrap();
+                if gap == 1 {
+                    print!("1 step ago, ");
+                } else {
+                    print!("{} steps ago, ", gap);
+                }
+            }
+            if result.forecast_reasonable {
+                if let Some(expected_list) = result.expected_values_list {
+                    let expected = &expected_list[0];
+                    let past = &result.past_values.unwrap();
+                    print!("DETECT [ {}", (past[0] - expected[0]));
+                    for j in 1..base_dimension {
+                        print!(", {}", (past[j] - expected[j]));
+                    }
+                    print!("]");
+                }
+            }
+            println!(" score {}, grade {}", result.score, result.anomaly_grade);
+        }
+    }
+}
+
+#[test]
+fn test_basic_trcf_scale() {
+    let shingle_size = 8;
+    let base_dimension = 5;
+    let data_size = 100000;
+    let number_of_trees = 30;
+    let capacity = 256;
+    let initial_accept_fraction = 0.1;
+    let dimensions = shingle_size * base_dimension;
+    let _point_store_capacity = capacity * number_of_trees + 1;
+    let time_decay = 0.1 / capacity as f64;
+    let bounding_box_cache_fraction = 1.0;
+    let random_seed = 17;
+    let parallel_enabled: bool = false;
+    let store_attributes: bool = false;
+    let internal_shingling: bool = true;
+    let internal_rotation = false;
+    let noise = 5.0;
+
+    let mut trcf = BasicTRCF::new(
+        dimensions,
+        shingle_size,
+        capacity,
+        number_of_trees,
+        random_seed, parallel_enabled,
+        time_decay,
+        0.01,
+        initial_accept_fraction,
+        bounding_box_cache_fraction,
+    );
+
+    let mut rng = ChaCha20Rng::from_entropy();
+    let mut amplitude = Vec::new();
+    for _i in 0..base_dimension {
+        amplitude.push((1.0 + 0.2 * rng.gen::<f32>()) * 60.0);
+    }
+    let data_with_key = multidimdatawithkey::MultiDimDataWithKey::multi_cosine(
+        data_size,
+        &vec![60; base_dimension],
+        &amplitude,
+        noise,
+        rng.gen::<u64>(),
+        base_dimension.into(),
+    );
+
+    let mut potential_anomalies:Vec<usize> = Vec::new();
+    let mut late= 0;
+
+    for i in 0..data_with_key.data.len() {
+        let result = trcf.process(&data_with_key.data[i], 0).unwrap();
+        if result.anomaly_grade > 0.0 {
+            // some anomalies will be detected late
+            // we will keep the vector unsorted, so out of order detection will be penalized
+            potential_anomalies.push((i as i32 + result.relative_index.unwrap()) as usize);
+        }
+    }
+
+    println!("{} anomalies injected in {} points", data_with_key.changes.len(), data_size);
+    let mut common =0;
+    let mut i:usize =0;
+    let mut j:usize =0;
+    while i<potential_anomalies.len() && j<data_with_key.change_indices.len() {
+        if potential_anomalies[i] == data_with_key.change_indices[j] {
+            i += 1;
+            j += 1;
+            common += 1;
+        } else if potential_anomalies[i] < data_with_key.change_indices[j] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+
+    println!("{} detected, precision {}, recall {}",potential_anomalies.len(),
+             common as f32/potential_anomalies.len() as f32,
+             common as f32/data_with_key.change_indices.len() as f32);
+}

--- a/Rust/tests/imputedifferentperiod.rs
+++ b/Rust/tests/imputedifferentperiod.rs
@@ -70,7 +70,7 @@ fn impute_different_period() {
 
     for i in 0..data_with_key.data.len() {
         if i > 200 {
-            let next_values = forest.extrapolate(1).unwrap();
+            let next_values = forest.extrapolate(1).unwrap().values;
             assert!(next_values.len() == base_dimension);
             error += next_values
                 .iter()

--- a/Rust/tests/imputesameperiod.rs
+++ b/Rust/tests/imputesameperiod.rs
@@ -65,7 +65,7 @@ fn impute_same_period() {
 
     for i in 0..data_with_key.data.len() {
         if i > 200 {
-            let next_values = forest.extrapolate(1).unwrap();
+            let next_values = forest.extrapolate(1).unwrap().values;
             assert!(next_values.len() == base_dimension);
             error += next_values
                 .iter()


### PR DESCRIPTION

*Description of changes:* ThresholdedRCF (TRCF) was introduced in Java/parkservices for easier thresholding and use of the anomaly scores. This PR extends the most basic TRCF (without transformations, time augmentation or impute on the fly) in Rust. Try out "cargo test --release --test basictrcftest -- --nocapture". 

The first test shows how to use 5 dimensional (multivariate) AD with synthetically injected changes. Note that predicting the expected value typically requires more observations than flagging something is wrong/potential anomaly. The second test with randomly chosen seeds gives some indication of scale and aggregate properties.

running 2 tests
 choosing RCF_Tiny
 choosing RCF_Tiny
timestamp 112 1 step ago,  score 1.0213785, grade 0.45268464
timestamp 136 INJECT [ 48.95336, 0, 0, 32.165417, 38.253647]
timestamp 138 2 steps ago,  score 1.0372964, grade 0.31086907
timestamp 143 INJECT [ 0, 0, 0, 35.515686, 0]
timestamp 146 INJECT [ 32.560028, 0, 49.118023, 0, -40.676575]
timestamp 146  score 1.1554488, grade 0.36780968
timestamp 220 INJECT [ 0, 0, -45.649166, 0, -35.209305]
timestamp 220 DETECT [ 0, 0, -44.42599, 0, -38.404728] score 1.0871096, grade 0.12089944
timestamp 452 INJECT [ 0, -36.279896, 48.58423, 0, 29.362373]
timestamp 452 DETECT [ 0, -37.53372, 49.176823, 0, 25.316154] score 1.1157002, grade 0.9562319
timestamp 562 INJECT [ -37.948364, 0, -33.879665, 0, 0]
timestamp 564 2 steps ago, DETECT [ -39.00741, 0, -35.184696, 0, 0] score 1.0166736, grade 0.26120678
timestamp 677 INJECT [ 0, 0, 39.818527, 0, 0]
timestamp 678 1 step ago, DETECT [ 0, 0, 41.49842, 0, 0] score 1.0293725, grade 0.42454648
timestamp 812 INJECT [ 0, 0, -44.44441, -38.252617, 0]
timestamp 812 DETECT [ 0, 0, -43.69323, -36.040146, 0] score 1.0507951, grade 0.6446359
timestamp 901 DETECT [ -2.0587616, 1.2649002, 0.038499832, -2.28574, -2.6345863] score 1.0408309, grade 0.49460888
test test_basic_trcf ... ok
829 anomalies injected in 100000 points
693 detected, precision 0.93362194, recall 0.7804584
test test_basic_trcf_scale ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.25s

