### PR TITLE
Reduced warnings with Rust library

### DIFF
--- a/Rust/src/common/anomalydescriptor.rs
+++ b/Rust/src/common/anomalydescriptor.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use crate::common::divector::DiVector;
 
 /**

--- a/Rust/src/common/cluster.rs
+++ b/Rust/src/common/cluster.rs
@@ -1,10 +1,8 @@
-use std::cmp::{max, min};
+use std::cmp::max;
 
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-
-use crate::common::samplesummary::SampleSummary;
 
 const PHASE2_THRESHOLD: usize = 2;
 const SEPARATION_RATIO_FOR_MERGE: f64 = 0.8;
@@ -144,7 +142,7 @@ impl Cluster<Vec<f32>, [f32]> for Center {
             self.sum_of_radii += self.points[j].1 as f64
                 * distance(&self.representative, points[self.points[j].0].0) as f64;
         }
-        (old_value - self.sum_of_radii)
+        old_value - self.sum_of_radii
     }
 
     fn distance_to_point(&self, point: &[f32], distance: fn(&[f32], &[f32]) -> f64) -> f64 {
@@ -223,8 +221,6 @@ where
     for j in 0..centers.len() {
         centers[j].reset();
     }
-    // the generator will keep varying as the number changes
-    let mut rng = ChaCha20Rng::seed_from_u64(centers.len() as u64);
     for i in 0..points.len() {
         let mut dist = vec![0.0; centers.len()];
         let mut min_distance = f64::MAX;

--- a/Rust/src/common/conditionalfieldsummarizer.rs
+++ b/Rust/src/common/conditionalfieldsummarizer.rs
@@ -1,5 +1,3 @@
-use num::abs;
-
 use crate::{
     common::samplesummary::{summarize, SampleSummary},
     pointstore::PointStore,

--- a/Rust/src/common/deviation.rs
+++ b/Rust/src/common/deviation.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 /**
  * This class maintains a simple discounted statistics. Setters are avoided
  * except for discount rate which is useful as initialization from raw scores
@@ -58,7 +56,7 @@ impl Deviation {
         let factor = if self.discount == 0.0 {1.0} else {
             let a = 1.0 - self.discount;
             let b= 1.0 - 1.0 / (self.count + 2) as f64;
-            if (a<b) {a} else {b}
+            if a<b {a} else {b}
         };
         self.sum = self.sum * factor + score;
         self.sum_squared = self.sum_squared * factor + score * score;

--- a/Rust/src/common/samplesummary.rs
+++ b/Rust/src/common/samplesummary.rs
@@ -1,6 +1,5 @@
-use std::cmp::{max, min};
+use std::cmp::min;
 
-use num::abs;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 

--- a/Rust/src/example.rs
+++ b/Rust/src/example.rs
@@ -83,7 +83,7 @@ fn main() {
         */
 
         score += new_score;
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!(

--- a/Rust/src/samplerplustree/boundingbox.rs
+++ b/Rust/src/samplerplustree/boundingbox.rs
@@ -1,5 +1,3 @@
-use crate::common::divector::DiVector;
-
 #[repr(C)]
 pub struct BoundingBox {
     range_sum: f64,

--- a/Rust/src/trcf/basictrcf.rs
+++ b/Rust/src/trcf/basictrcf.rs
@@ -1,10 +1,8 @@
 
 use crate::common::anomalydescriptor::AnomalyDescriptor;
 use crate::common::rangevector::RangeVector;
-use crate::common::samplesummary::SampleSummary;
 use crate::rcf::{create_rcf, RCF};
-use crate::types::{Location, Result};
-use crate::errors::RCFError;
+use crate::types::Result;
 use crate::trcf::predictorcorrector::PredictorCorrector;
 
 pub struct BasicTRCF {
@@ -64,7 +62,7 @@ impl BasicTRCF {
             self.last_anomaly_descriptor = result.clone();
         }
 
-        self.rcf.update(point,timestamp as u64);
+        self.rcf.update(point,timestamp as u64)?;
         Ok(result)
     }
 

--- a/Rust/src/trcf/predictorcorrector.rs
+++ b/Rust/src/trcf/predictorcorrector.rs
@@ -149,7 +149,7 @@ impl PredictorCorrector {
                 }
                 let internal_timestamp = result.internal_timestamp;
                 let base_dimension = forest.dimensions() / shingle_size;
-                let mut start_position = (shingle_size - 1) * base_dimension;
+                let start_position = (shingle_size - 1) * base_dimension;
                 result.threshold = self.basic_thresholder.threshold();
                 let previous = self.basic_thresholder.in_potential_anomaly();
 
@@ -188,7 +188,7 @@ impl PredictorCorrector {
 
                 let attribution = forest.attribution(point).unwrap();
                 // index is 0 .. (shingle_size - 1); this is a departure from java version
-                let mut index = attribution.max_contribution(base_dimension);
+                let index = attribution.max_contribution(base_dimension);
 
                 if !previous && self.trigger(&attribution, gap, base_dimension, None, false, last_anomaly_descriptor) {
                     result.anomaly_grade = self.basic_thresholder.anomaly_grade(score, false);

--- a/Rust/src/visitor/imputevisitor.rs
+++ b/Rust/src/visitor/imputevisitor.rs
@@ -1,5 +1,5 @@
 use num::abs;
-use rand::{random, Rng, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
 use crate::{

--- a/Rust/src/visitor/interpolationvisitor.rs
+++ b/Rust/src/visitor/interpolationvisitor.rs
@@ -1,7 +1,5 @@
-use num::abs;
-
 use crate::{
-    common::{directionaldensity::InterpolationMeasure, divector::DiVector},
+    common::{directionaldensity::InterpolationMeasure},
     samplerplustree::nodeview::LargeNodeView,
     visitor::visitor::{Visitor, VisitorInfo},
 };


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Reduced warnings from 98 to 77 with `rcf` lib and 1 to 0 with `example` bin (with rustc 1.64.0).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
