### PR TITLE
Fixed more warnings with Rust library

### DIFF
--- a/Rust/src/common/cluster.rs
+++ b/Rust/src/common/cluster.rs
@@ -39,7 +39,7 @@ pub trait Cluster<Q, T: ?Sized> {
     fn representatives(&self) -> Vec<(Q, f32)>;
     // a function to distill all representatives into a single representative under a given
     // distance function over the base type of the points
-    fn primary_representative(&self, distance: fn(&T, &T) -> f64) -> Q;
+    fn primary_representative(&self, _distance: fn(&T, &T) -> f64) -> Q;
 }
 
 #[repr(C)]
@@ -189,7 +189,7 @@ impl Cluster<Vec<f32>, [f32]> for Center {
         vec![(self.representative.clone(), self.weight as f32); 1]
     }
 
-    fn primary_representative(&self, distance: fn(&[f32], &[f32]) -> f64) -> Vec<f32> {
+    fn primary_representative(&self, _distance: fn(&[f32], &[f32]) -> f64) -> Vec<f32> {
         self.representative.clone()
     }
 }

--- a/Rust/src/common/rangevector.rs
+++ b/Rust/src/common/rangevector.rs
@@ -43,32 +43,28 @@ impl RangeVector {
     }
 
     pub fn shift(&mut self, i:usize, shift: f32) {
-        for _ in 0..self.values.len() {
-            self.values[i] += shift;
-            self.upper[i] += shift;
-            self.lower[i] += shift;
-            // managing precision explicitly
-            if self.upper[i] < self.values[i] {
-                self.upper[i] = self.values[i];
-            }
-            if self.lower[i] > self.values[i] {
-                self.lower[i] = self.values[i];
-            }
+        self.values[i] += shift;
+        self.upper[i] += shift;
+        self.lower[i] += shift;
+        // managing precision explicitly
+        if self.upper[i] < self.values[i] {
+            self.upper[i] = self.values[i];
+        }
+        if self.lower[i] > self.values[i] {
+            self.lower[i] = self.values[i];
         }
     }
 
     pub fn scale(&mut self, i:usize, scale: f32) {
-        for _ in 0..self.values.len() {
-            self.values[i] *= scale;
-            self.upper[i] *= scale;
-            self.lower[i] *= scale;
-            // managing precision explicitly
-            if self.upper[i] < self.values[i] {
-                self.upper[i] = self.values[i];
-            }
-            if self.lower[i] > self.values[i] {
-                self.lower[i] = self.values[i];
-            }
+        self.values[i] *= scale;
+        self.upper[i] *= scale;
+        self.lower[i] *= scale;
+        // managing precision explicitly
+        if self.upper[i] < self.values[i] {
+            self.upper[i] = self.values[i];
+        }
+        if self.lower[i] > self.values[i] {
+            self.lower[i] = self.values[i];
         }
     }
 }

--- a/Rust/src/common/rangevector.rs
+++ b/Rust/src/common/rangevector.rs
@@ -43,7 +43,7 @@ impl RangeVector {
     }
 
     pub fn shift(&mut self, i:usize, shift: f32) {
-        for j in 0..self.values.len() {
+        for _ in 0..self.values.len() {
             self.values[i] += shift;
             self.upper[i] += shift;
             self.lower[i] += shift;
@@ -58,7 +58,7 @@ impl RangeVector {
     }
 
     pub fn scale(&mut self, i:usize, scale: f32) {
-        for j in 0..self.values.len() {
+        for _ in 0..self.values.len() {
             self.values[i] *= scale;
             self.upper[i] *= scale;
             self.lower[i] *= scale;

--- a/Rust/src/common/samplesummary.rs
+++ b/Rust/src/common/samplesummary.rs
@@ -26,7 +26,7 @@ use crate::common::cluster::{iterative_clustering, Center, Cluster};
 ///
 ///
 
-const max_number_per_dimension: usize = 5;
+const MAX_NUMBER_PER_DIMENSION: usize = 5;
 
 const PHASE2_THRESHOLD: usize = 2;
 
@@ -171,7 +171,7 @@ pub fn summarize(
 
     if max_number > 0 {
         let dimensions = points[0].0.len();
-        let max_allowed = min(dimensions * max_number_per_dimension, max_number);
+        let max_allowed = min(dimensions * MAX_NUMBER_PER_DIMENSION, max_number);
         let total_weight: f64 = points.iter().map(|x| x.1 as f64).sum();
         let mut rng = ChaCha20Rng::seed_from_u64(max_allowed as u64);
 

--- a/Rust/src/pointstore.rs
+++ b/Rust/src/pointstore.rs
@@ -351,7 +351,7 @@ where
         reverse_reference.sort();
         let mut fresh_start: usize = 0;
         let mut j_static: usize = 0;
-        let mut j_dynamic: usize = 0;
+        let mut j_dynamic: usize;
         let end: usize = reverse_reference.len();
         while j_static < end {
             let mut block_start: usize = reverse_reference[j_static].0;

--- a/Rust/src/rcf.rs
+++ b/Rust/src/rcf.rs
@@ -577,7 +577,7 @@ where
             point,
             &Vec::new(),
             visitor_info,
-            ScalarScoreVisitor::Default,
+            ScalarScoreVisitor::default,
             &0.0,
             &0.0,
             add_to,

--- a/Rust/src/samplerplustree/nodestore.rs
+++ b/Rust/src/samplerplustree/nodestore.rs
@@ -49,7 +49,7 @@ where
     pub internal_node_manager: IntervalStoreManager<usize>,
 }
 
-const switch_threshold: f64 = 0.5;
+const SWITCH_THRESHOLD: f64 = 0.5;
 
 pub trait NodeStore {
     fn get_mass(&self, index: usize) -> usize;
@@ -853,7 +853,7 @@ where
     }
 
     fn use_path_for_box(&self) -> bool {
-        self.bounding_box_cache_fraction < switch_threshold
+        self.bounding_box_cache_fraction < SWITCH_THRESHOLD
     }
 
     fn get_distribution(&self, index: usize) -> (usize, f32, usize, usize) {

--- a/Rust/src/trcf/basicthresholder.rs
+++ b/Rust/src/trcf/basicthresholder.rs
@@ -134,15 +134,15 @@ impl BasicThresholder {
             if score < self.longterm_threshold(factor) - elastic_addition {
                 return 0.0;
             }
-            let mut t_Factor = self.upper_z_factor;
+            let mut t_factor = self.upper_z_factor;
             let longterm_deviation = self.longterm_deviation();
             if longterm_deviation > 0.0 {
                 let t =  (score - self.primary_deviation.mean() as f32) / longterm_deviation;
-                if (t as f32) < t_Factor {
-                    t_Factor = t as f32;
+                if (t as f32) < t_factor {
+                    t_factor = t as f32;
                 }
             }
-            return (t_Factor - self.z_factor) / (self.upper_z_factor - self.z_factor);
+            return (t_factor - self.z_factor) / (self.upper_z_factor - self.z_factor);
         } else {
             let t = self.short_term_threshold(factor, intermediate_fraction);
             if score < t - elastic_addition {

--- a/Rust/src/trcf/predictorcorrector.rs
+++ b/Rust/src/trcf/predictorcorrector.rs
@@ -149,7 +149,6 @@ impl PredictorCorrector {
                 }
                 let internal_timestamp = result.internal_timestamp;
                 let base_dimension = forest.dimensions() / shingle_size;
-                let start_position = (shingle_size - 1) * base_dimension;
                 result.threshold = self.basic_thresholder.threshold();
                 let previous = self.basic_thresholder.in_potential_anomaly();
 

--- a/Rust/src/visitor/interpolationvisitor.rs
+++ b/Rust/src/visitor/interpolationvisitor.rs
@@ -46,7 +46,6 @@ impl Visitor<LargeNodeView, InterpolationMeasure> for InterpolationVisitor {
         node_view: &LargeNodeView,
     ) {
         let mass = node_view.get_mass();
-        let leaf_point = node_view.get_leaf_point();
         self.leaf_index = node_view.get_leaf_index();
         if mass > visitor_info.ignore_mass {
             if node_view.is_duplicate() {

--- a/Rust/src/visitor/scalarscorevisitor.rs
+++ b/Rust/src/visitor/scalarscorevisitor.rs
@@ -13,7 +13,7 @@ pub struct ScalarScoreVisitor {
 }
 
 impl ScalarScoreVisitor {
-    pub fn Default(tree_mass: usize, _parameters: &[usize], _visitor_info: &VisitorInfo) -> Self {
+    pub fn default(tree_mass: usize, _parameters: &[usize], _visitor_info: &VisitorInfo) -> Self {
         ScalarScoreVisitor {
             tree_mass,
             leaf_index: usize::MAX,

--- a/Rust/tests/anomalydetectionattributionupdate.rs
+++ b/Rust/tests/anomalydetectionattributionupdate.rs
@@ -76,7 +76,7 @@ fn anomalydetection_attribution_and_update() {
         */
 
         score += attribution.total();
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!(

--- a/Rust/tests/anomalydetectionimputescoreupdate.rs
+++ b/Rust/tests/anomalydetectionimputescoreupdate.rs
@@ -86,7 +86,7 @@ fn anomalydetection_impute_score_and_update() {
         */
 
         score += new_score;
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!(

--- a/Rust/tests/anomalydetectionscoreupdate.rs
+++ b/Rust/tests/anomalydetectionscoreupdate.rs
@@ -73,7 +73,7 @@ fn anomalydetection_score_and_update() {
         */
 
         score += new_score;
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!(

--- a/Rust/tests/basicrcftest.rs
+++ b/Rust/tests/basicrcftest.rs
@@ -70,8 +70,8 @@ fn two_distribution_test_static() {
     );
 
     for i in 0..data_with_key.data.len() {
-        forest.update(&data_with_key.data[i], 0);
-        another_forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
+        another_forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     let anomaly = vec![0.0f32; dimensions];

--- a/Rust/tests/basictrcftest.rs
+++ b/Rust/tests/basictrcftest.rs
@@ -5,7 +5,6 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rcflib::{
     common::multidimdatawithkey,
-    rcf::{create_rcf, RCF},
     trcf::basictrcf::BasicTRCF
 };
 
@@ -24,9 +23,6 @@ fn test_basic_trcf() {
     let bounding_box_cache_fraction = 1.0;
     let random_seed = 17;
     let parallel_enabled: bool = false;
-    let store_attributes: bool = false;
-    let internal_shingling: bool = true;
-    let internal_rotation = false;
     let noise = 5.0;
 
     let mut trcf = BasicTRCF::new(
@@ -70,7 +66,7 @@ fn test_basic_trcf() {
         let result = trcf.process(&data_with_key.data[i], 0).unwrap();
         if result.anomaly_grade > 0.0 {
             print!("timestamp {} ", i);
-            if (result.relative_index.unwrap() != 0) {
+            if result.relative_index.unwrap() != 0 {
                 let gap = -result.relative_index.unwrap();
                 if gap == 1 {
                     print!("1 step ago, ");
@@ -108,9 +104,6 @@ fn test_basic_trcf_scale() {
     let bounding_box_cache_fraction = 1.0;
     let random_seed = 17;
     let parallel_enabled: bool = false;
-    let store_attributes: bool = false;
-    let internal_shingling: bool = true;
-    let internal_rotation = false;
     let noise = 5.0;
 
     let mut trcf = BasicTRCF::new(
@@ -140,7 +133,6 @@ fn test_basic_trcf_scale() {
     );
 
     let mut potential_anomalies:Vec<usize> = Vec::new();
-    let mut late= 0;
 
     for i in 0..data_with_key.data.len() {
         let result = trcf.process(&data_with_key.data[i], 0).unwrap();

--- a/Rust/tests/dynamicdensitytest.rs
+++ b/Rust/tests/dynamicdensitytest.rs
@@ -53,7 +53,7 @@ fn dynamic_density() {
             forest.update(
                 &rotate_clockwise(&data[j], 2.0 * PI * degree as f32 / 360.0),
                 0,
-            );
+            ).unwrap();
         }
 
         let density = forest.directional_density(&query_point).unwrap();
@@ -143,8 +143,8 @@ fn generate_fan(num_per_blade: usize, blades: usize) -> Vec<Vec<f32>> {
     for point in data_with_key.data {
         let toss: f64 = rng.gen();
         let mut i = 0;
-        while (i < blades + 1) {
-            if (toss < i as f64 / blades as f64) {
+        while i < blades + 1 {
+            if toss < i as f64 / blades as f64 {
                 let theta = 2.0 * PI * i as f32 / blades as f32;
                 let mut vec = rotate_clockwise(&point, theta);
                 vec[0] += 0.6 * theta.sin();

--- a/Rust/tests/imputedifferentperiod.rs
+++ b/Rust/tests/imputedifferentperiod.rs
@@ -79,7 +79,7 @@ fn impute_different_period() {
                 .sum::<f64>();
             count += base_dimension;
         }
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!("Success! {}", forest.entries_seen());

--- a/Rust/tests/imputesameperiod.rs
+++ b/Rust/tests/imputesameperiod.rs
@@ -74,7 +74,7 @@ fn impute_same_period() {
                 .sum::<f64>();
             count += base_dimension;
         }
-        forest.update(&data_with_key.data[i], 0);
+        forest.update(&data_with_key.data[i], 0).unwrap();
     }
 
     println!("Success! {}", forest.entries_seen());

--- a/Rust/tests/samplesummarytest.rs
+++ b/Rust/tests/samplesummarytest.rs
@@ -19,12 +19,11 @@ assert!(core(1000000,test_dimension,0,distance));
 }}
 
 fn core(
-    _data_size: usize,
+    data_size: usize,
     test_dimension: usize,
     seed: u64,
     distance: fn(&[f32], &[f32]) -> f64,
 ) -> bool {
-    let data_size = 200000;
     let mut mean = Vec::new();
     let mut scale = Vec::new();
     let yard_stick = distance(&vec![0.0; test_dimension], &vec![1.0; test_dimension]) as f32;

--- a/Rust/tests/samplesummarytest.rs
+++ b/Rust/tests/samplesummarytest.rs
@@ -5,7 +5,6 @@ extern crate rcflib;
 use num::abs;
 /// try cargo test --release
 /// these tests are designed to be longish
-use parameterized_test::create;
 use rand::{prelude::ThreadRng, Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use rand_core::RngCore;
@@ -20,12 +19,11 @@ assert!(core(1000000,test_dimension,0,distance));
 }}
 
 fn core(
-    data_size: usize,
+    _data_size: usize,
     test_dimension: usize,
     seed: u64,
     distance: fn(&[f32], &[f32]) -> f64,
 ) -> bool {
-    let mut rng = ChaCha20Rng::seed_from_u64(seed);
     let data_size = 200000;
     let mut mean = Vec::new();
     let mut scale = Vec::new();
@@ -45,7 +43,7 @@ fn core(
         data_size,
         &mean,
         &scale,
-        &vec![(0.5 / test_dimension as f32); 2 * test_dimension],
+        &vec![0.5 / test_dimension as f32; 2 * test_dimension],
         seed,
     );
 
@@ -92,7 +90,7 @@ fn benchmark() {
     let mut rng = ChaCha20Rng::seed_from_u64(one_seed);
 
     let mut error = 0;
-    for i in 0..10 {
+    for _ in 0..10 {
         let seed = rng.next_u64();
         let d = rng.gen_range(3..23);
         error += (core(200000, d, seed, l1distance) == false) as i32;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Reduced `cargo build` warnings from 77 to 68 and fixed all the `cargo test` warnings. The remaining warnings are all for unused variables or functions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
