### PR TITLE
A multi-centroid clustering based Global-Local-Anomaly-Detector and ForestMode.DISTANCE

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/ForestMode.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/ForestMode.java
@@ -37,6 +37,21 @@ public enum ForestMode {
      * have shingleSize greater than 1, typically larger shingle size is better, and
      * so is fewer input dimensions
      */
-    STREAMING_IMPUTE;
+    STREAMING_IMPUTE,
+    /**
+     * This is the same as STANDARD mode where the scoring function is switched to
+     * distances between the vectors. Since RCFs build a multiresolution tree, and
+     * in the aggregate, preserves distances to some approximation, this provides an
+     * alternate anomaly detection mechanism which can be useful for shingleSize = 1
+     * and (dynamic) population analysis via RCFs. Specifially it switches the
+     * scoring to be based on the distance computation in the Density Estimation
+     * (interpolation). This allows for a direct comparison of clustering based
+     * outlier detection and RCFs over numeric vectors. All transformations
+     * available to the STANDARD mode in the ThresholdedRCF are available for this
+     * mode as well; this does not affect RandomCutForest core in any way. For
+     * timeseries analysis the STANDARD mode is recommended, but this does provide
+     * another option in combination with the TransformMethods.
+     */
+    DISTANCE;
 
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/AbstractStreamSampler.java
@@ -107,7 +107,11 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
      */
     protected AcceptPointState acceptPointState;
 
-    public abstract boolean acceptPoint(long sequenceIndex);
+    public boolean acceptPoint(long sequenceIndex) {
+        return acceptPoint(sequenceIndex, 1.0f);
+    }
+
+    public abstract boolean acceptPoint(long sequenceIndex, float weight);
 
     @Override
     public abstract void addPoint(P pointIndex);
@@ -136,16 +140,18 @@ public abstract class AbstractStreamSampler<P> implements IStreamSampler<P> {
      *
      * @param sequenceIndex The sequenceIndex of the point whose score is being
      *                      computed.
+     * @param sampleWeight  the positive weight (often 1.0) used in sampling; the
+     *                      weight should be checked in the calling routine
      * @return the weight value used to define point priority
      */
-    protected float computeWeight(long sequenceIndex) {
+    protected float computeWeight(long sequenceIndex, float sampleWeight) {
         double randomNumber = 0d;
         while (randomNumber == 0d) {
             randomNumber = random.nextDouble();
         }
         maxSequenceIndex = (maxSequenceIndex < sequenceIndex) ? sequenceIndex : maxSequenceIndex;
         return (float) (-(sequenceIndex - mostRecentTimeDecayUpdate) * timeDecay - accumuluatedTimeDecay
-                + Math.log(-Math.log(randomNumber)));
+                + Math.log(-Math.log(randomNumber) / sampleWeight));
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/sampler/CompactSampler.java
@@ -140,18 +140,21 @@ public class CompactSampler extends AbstractStreamSampler<Integer> {
     }
 
     @Override
-    public boolean acceptPoint(long sequenceIndex) {
+    public boolean acceptPoint(long sequenceIndex, float samplingWeight) {
+        checkArgument(samplingWeight >= 0, " weight has to be non-negative");
         checkState(sequenceIndex >= mostRecentTimeDecayUpdate, "incorrect sequences submitted to sampler");
         evictedPoint = null;
-        float weight = computeWeight(sequenceIndex);
-        boolean initial = (size < capacity && random.nextDouble() < initialAcceptProbability(size));
-        if (initial || (weight < this.weight[0])) {
-            acceptPointState = new AcceptPointState(sequenceIndex, weight);
-            if (!initial) {
-                evictMax();
+        if (samplingWeight > 0) {
+            float weight = computeWeight(sequenceIndex, samplingWeight);
+            boolean initial = (size < capacity && random.nextDouble() < initialAcceptProbability(size));
+            if (initial || (weight < this.weight[0])) {
+                acceptPointState = new AcceptPointState(sequenceIndex, weight);
+                if (!initial) {
+                    evictMax();
+                }
+                return true;
             }
-            return true;
-        }
+        } // 0 weight implies ignore sample
         return false;
     }
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Center.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Center.java
@@ -15,6 +15,7 @@
 
 package com.amazon.randomcutforest.summarization;
 
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static java.lang.Math.exp;
 
 import java.util.ArrayList;
@@ -69,6 +70,10 @@ public class Center implements ICluster<float[]> {
         previousSumOFRadius = sumOfRadius;
     }
 
+    public double averageRadius() {
+        return (weight > 0) ? sumOfRadius / weight : 0;
+    }
+
     // average radius computation, provides an extent measure
     public double extentMeasure() {
         return (weight > 0) ? sumOfRadius / weight : 0;
@@ -112,8 +117,10 @@ public class Center implements ICluster<float[]> {
             representative[index] = getPoint.apply(assignedPoints.get(position).index)[index];
         }
         for (int j = 0; j < assignedPoints.size(); j++) {
-            sumOfRadius += distance.apply(representative, getPoint.apply(assignedPoints.get(j).index))
+            double addTerm = distance.apply(representative, getPoint.apply(assignedPoints.get(j).index))
                     * assignedPoints.get(j).weight;
+            checkArgument(addTerm >= 0, "distances or weights cannot be negative");
+            sumOfRadius += addTerm;
         }
         return (previousSumOFRadius - sumOfRadius);
 
@@ -134,6 +141,7 @@ public class Center implements ICluster<float[]> {
         double dist = Double.MAX_VALUE;
         for (Weighted<float[]> e : representatives) {
             double t = distance.apply(e.index, representative);
+            checkArgument(t >= 0, "distances cannot be negative");
             if (t < dist) {
                 dist = t;
                 closest = e.index;

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/ICluster.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/ICluster.java
@@ -39,6 +39,8 @@ public interface ICluster<R> {
     // restting statistics for a potential reassignment
     void reset();
 
+    double averageRadius();
+
     // a measure of the noise/blur around a cluster; for single centroid clustering
     // this is the average distance of a point from a cluster representative
     double extentMeasure();

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/MultiCenter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/MultiCenter.java
@@ -58,11 +58,6 @@ public class MultiCenter extends GenericMultiCenter<float[]> {
         assignedPoints = new ArrayList<>();
     }
 
-    // average radius computation
-    public double extentMeasure() {
-        return (weight > 0) ? sumOfRadius / weight : 0;
-    }
-
     // a standard reassignment using the median values and NOT the mean; the mean is
     // unlikely to
     // provide robust convergence
@@ -75,8 +70,10 @@ public class MultiCenter extends GenericMultiCenter<float[]> {
         previousSumOFRadius = sumOfRadius;
         sumOfRadius = 0;
         for (int j = 0; j < assignedPoints.size(); j++) {
-            sumOfRadius += distance(getPoint.apply(assignedPoints.get(j).index), distanceFunction)
+            double addTerm = distance(getPoint.apply(assignedPoints.get(j).index), distanceFunction)
                     * assignedPoints.get(j).weight;
+            checkArgument(addTerm >= 0, "distances or weights cannot be negative");
+            sumOfRadius += addTerm;
         }
         return (previousSumOFRadius - sumOfRadius);
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Summarizer.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Summarizer.java
@@ -106,6 +106,7 @@ public class Summarizer {
                 int minDistNbr = -1;
                 for (int i = 0; i < clusters.size(); i++) {
                     dist[i] = clusters.get(i).distance(getPoint.apply(point.index), distance);
+                    checkArgument(dist[i] >= 0, "distance cannot be negative");
                     if (minDist > dist[i]) {
                         minDist = dist[i];
                         minDistNbr = i;
@@ -346,7 +347,10 @@ public class Summarizer {
         checkArgument(maxAllowed <= initial, "initial parameter should be at least maximum allowed in final result");
         checkArgument(stopAt > 0 && stopAt <= maxAllowed, "lower bound set incorrectly");
 
-        double totalWeight = points.stream().map(e -> (double) e.weight).reduce(0.0, Double::sum);
+        double totalWeight = points.stream().map(e -> {
+            checkArgument(e.weight >= 0.0, "negative weights are not meaningful");
+            return (double) e.weight;
+        }).reduce(0.0, Double::sum);
         checkArgument(!Double.isNaN(totalWeight) && Double.isFinite(totalWeight),
                 " weights have to finite and non-NaN");
         Random rng = new Random(seed);
@@ -398,7 +402,10 @@ public class Summarizer {
         checkArgument(maxAllowed < 100, "are you sure you want more elements in the summary?");
         checkArgument(maxAllowed <= initial, "initial parameter should be at least maximum allowed in final result");
 
-        double totalWeight = points.stream().map(e -> (double) e.weight).reduce(0.0, Double::sum);
+        double totalWeight = points.stream().map(e -> {
+            checkArgument(e.weight >= 0.0, "negative weights are not meaningful");
+            return (double) e.weight;
+        }).reduce(0.0, Double::sum);
         checkArgument(!Double.isNaN(totalWeight) && Double.isFinite(totalWeight),
                 " weights have to finite and non-NaN");
         Random rng = new Random(seed);

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
@@ -136,7 +136,7 @@ public class NumericGLADexample implements Example {
 
         String name = "clustering_example";
         BufferedWriter file = new BufferedWriter(new FileWriter(name));
-        boolean printData = false;
+        boolean printData = true;
         boolean printAnomalies = false;
         // use one or the other prints below
         boolean printFlaggedRCF = false;

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.parkservices;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
+import static com.amazon.randomcutforest.testutils.ExampleDataSets.rotateClockWise;
+import static java.lang.Math.PI;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.util.Random;
+
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.parkservices.AnomalyDescriptor;
+import com.amazon.randomcutforest.parkservices.GlobalLocalAnomalyDetector;
+import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
+import com.amazon.randomcutforest.parkservices.returntypes.GenericAnomalyDescriptor;
+import com.amazon.randomcutforest.summarization.Summarizer;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+
+/**
+ * The following example demonstrates clustering based anomaly detection for
+ * numeric vectors. The clustering can use an arbitrary distance metric (but it
+ * has no mechanism to verify if the function provided is a metric beyond
+ * checking that distances are non-negative; improper implementations of
+ * distances can produce uninterpretable results). The clustering corresponds to
+ * clustering a recency biased sample of points (using the exact same as RCF)
+ * and clustering using multi-centroid method (CURE algorithm).
+ *
+ * There is a natural question that given that this is the RCF library, how does
+ * this clustering based algorithm perform vis-a-vis RCF. First, RCF is
+ * preferred/natural for shingled/sequenced data, e.g., in analysis of time
+ * series. Simple clustering of shingles do not seem to provide similar benefit.
+ * In fact, even for shinglesize 1, which correponds to time dependent
+ * population analysis, the recursive decomposition provided by RCF can provide
+ * a richer detail (even though RCF naturally considers the L1/Manhattan
+ * metric). That recursive decomposition can be viewed as a (randomized) partion
+ * based clustering. That distance function is used to compute the DensityOutput
+ * in RCF. Multilevel clustering is known to be more useful than simple
+ * clustering in many applications. Here we show such an application which
+ *
+ * (i) shows an example use of GlobalLocalAnomalyDetector (GLAD) for dynamic
+ * data as well as
+ *
+ * (ii) a comparable use using a new ForestMode.DISTANCE exposed for RCF.
+ *
+ * RCF seems to perform better for this simple two dimensional dynamic case. At
+ * the same time, the new clusering based algorithm works for generic types with
+ * just a distance function. In applications where distances are meaningful and
+ * key, such geo etc., user-defined distance based anomalies can be extremely
+ * beneficial. If the data can be mapped to explicit vectors then perhaps RCF
+ * and its multi-level partitioning can provide more useful insights.
+ *
+ * Try the following in a visualizer. For example in vanilla gnuplot try
+ *
+ * set terminal gif transparent animate delay 5
+ *
+ * set size square
+ *
+ * set output "test.gif"
+ *
+ * do for [i = 0:359] { plot [-15:15][-15:15] "clustering_example" i i u 1:2:3 w
+ * p palette pt 7 t "" }
+ *
+ *
+ * Try the above/equivalent for setting printFlaggedGLAD = true (setting
+ * printFlaggedRCF = false), or to see the data, printData = true. Try changing
+ * the number of blades in the fan, the zFactor setting etc.
+ */
+public class NumericGLADexample implements Example {
+
+    public static void main(String[] args) throws Exception {
+        new NumericGLADexample().run();
+    }
+
+    @Override
+    public String command() {
+        return "An example of Global-Local Anomaly Detector on numeric vectors";
+    }
+
+    @Override
+    public String description() {
+        return "An example of Global-Local Anomaly Detector on numeric vectors";
+    }
+
+    @Override
+    public void run() throws Exception {
+        long randomSeed = new Random().nextLong();
+        System.out.println("Seed " + randomSeed);
+        // we would be sending dataSize * 360 vectors
+        int dataSize = 2000;
+        double range = 10.0;
+        int numberOfFans = 3;
+        // corresponds to number of clusters
+        double[][] data = shiftedEllipse(dataSize, 7, range / 2, numberOfFans);
+        int truePos = 0;
+        int falsePos = 0;
+        int falseNeg = 0;
+
+        int truePosRCF = 0;
+        int falsePosRCF = 0;
+        int falseNegRCF = 0;
+
+        int reservoirSize = dataSize;
+
+        // this ensures that the points are flushed out (albeit randomly) duting the
+        // rotation
+        double timedecay = 1.0 / reservoirSize;
+
+        GlobalLocalAnomalyDetector<float[]> reservoir = GlobalLocalAnomalyDetector.builder().randomSeed(42)
+                .numberOfRepresentatives(3).timeDecay(timedecay).capacity(reservoirSize).build();
+        reservoir.setGlobalDistance(Summarizer::L2distance);
+
+        double zFactor = 6.0; // six sigma deviation; seems to work best
+        reservoir.setZfactor(zFactor);
+
+        ThresholdedRandomCutForest test = ThresholdedRandomCutForest.builder().dimensions(2).shingleSize(1)
+                .randomSeed(77).timeDecay(timedecay).forestMode(ForestMode.DISTANCE).build();
+        test.setZfactor(zFactor); // using the zFactor for same apples to apples comparison
+
+        String name = "clustering_example";
+        BufferedWriter file = new BufferedWriter(new FileWriter(name));
+        boolean printData = false;
+        boolean printAnomalies = false;
+        // use one or the other prints below
+        boolean printFlaggedRCF = false;
+        boolean printFlaggedGLAD = true;
+
+        Random noiseGen = new Random(randomSeed + 1);
+        for (int degree = 0; degree < 360; degree += 1) {
+            int index = 0;
+            while (index < data.length) {
+                boolean injected = false;
+                float[] vec;
+                if (noiseGen.nextDouble() < 0.005) {
+                    injected = true;
+                    double[] candAnomaly = new double[2];
+                    // generate points along x axis
+                    candAnomaly[0] = (range / 2 * noiseGen.nextDouble() + range / 2);
+                    candAnomaly[1] = 0.1 * (2.0 * noiseGen.nextDouble() - 1.0);
+                    int antiFan = noiseGen.nextInt(numberOfFans);
+                    // rotate to be 90-180 degrees away -- these are decidedly anomalous
+                    vec = toFloatArray(rotateClockWise(candAnomaly,
+                            -2 * PI * (degree + 180 * (1 + 2 * antiFan) / numberOfFans) / 360));
+                    if (printAnomalies) {
+                        file.append(vec[0] + " " + vec[1] + " " + 0.0 + "\n");
+                    }
+                } else {
+                    vec = toFloatArray(rotateClockWise(data[index], -2 * PI * degree / 360));
+                    if (printData) {
+                        file.append(vec[0] + " " + vec[1] + " " + 0.0 + "\n");
+                    }
+                    ++index;
+                }
+
+                GenericAnomalyDescriptor<float[]> result = reservoir.process(vec, 1.0f, null, true);
+
+                AnomalyDescriptor res = test.process(toDoubleArray(vec), 0L);
+                double grade = res.getAnomalyGrade();
+
+                if (injected) {
+                    if (result.getAnomalyGrade() > 0) {
+                        ++truePos;
+                    } else {
+                        ++falseNeg;
+                    }
+                    if (grade > 0) {
+                        ++truePosRCF;
+                    } else {
+                        ++falseNegRCF;
+                    }
+                } else {
+                    if (result.getAnomalyGrade() > 0) {
+                        ++falsePos;
+                    }
+                    if (grade > 0) {
+                        ++falsePosRCF;
+                    }
+                }
+                if (printFlaggedRCF && grade > 0) {
+                    file.append(vec[0] + " " + vec[1] + " " + grade + "\n");
+                } else if (printFlaggedGLAD && result.getAnomalyGrade() > 0) {
+                    file.append(vec[0] + " " + vec[1] + " " + result.getAnomalyGrade() + "\n");
+                }
+            }
+            if (printAnomalies || printData || printFlaggedRCF || printFlaggedGLAD) {
+                file.append("\n");
+                file.append("\n");
+            }
+
+            if (falsePos + truePos == 0) {
+                throw new IllegalStateException("");
+            }
+
+            checkArgument(falseNeg + truePos == falseNegRCF + truePosRCF, " incorrect accounting");
+            System.out.println(" at degree " + degree + " injected " + (truePos + falseNeg));
+            System.out.print("Precision = " + precision(truePos, falsePos));
+            System.out.println(" Recall = " + recall(truePos, falseNeg));
+            System.out.print("RCF Distance Mode Precision = " + precision(truePosRCF, falsePosRCF));
+            System.out.println(" RCF Distance Mode Recall = " + recall(truePosRCF, falseNegRCF));
+
+        }
+    }
+
+    public double[][] shiftedEllipse(int dataSize, int seed, double shift, int fans) {
+        NormalMixtureTestData generator = new NormalMixtureTestData(0.0, 1.0, 0.0, 1.0, 0.0, 1.0);
+        double[][] data = generator.generateTestData(dataSize, 2, seed);
+        Random prg = new Random(0);
+        for (int i = 0; i < dataSize; i++) {
+            int nextFan = prg.nextInt(fans);
+            // scale
+            data[i][1] *= 1.0 / fans;
+            data[i][0] *= 2.0;
+            // shift
+            data[i][0] += shift + 1.0 / fans;
+            data[i] = rotateClockWise(data[i], 2 * PI * nextFan / fans);
+        }
+
+        return data;
+    }
+
+    double precision(int truePos, int falsePos) {
+        return (truePos + falsePos > 0) ? 1.0 * truePos / (truePos + falsePos) : 1.0;
+    }
+
+    double recall(int truePos, int falseNeg) {
+        return (truePos + falseNeg > 0) ? 1.0 * truePos / (truePos + falseNeg) : 1.0;
+    }
+
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/StringGLADexample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/StringGLADexample.java
@@ -64,7 +64,7 @@ public class StringGLADexample implements Example {
         double anomalyRate = 0.05;
         char[][] points = new char[numberOfStrings][];
         boolean[] injected = new boolean[numberOfStrings];
-        boolean printClusters = false;
+        boolean printClusters = true;
         boolean printFalseNeg = false;
         boolean printFalsePos = false;
         int numberOfInjected = 0;
@@ -102,10 +102,11 @@ public class StringGLADexample implements Example {
             if (result.getAnomalyGrade() > 0) {
                 if (!injected[y]) {
                     ++falsePos;
+                    List<Weighted<char[]>> list = result.getRepresentativeList();
                     if (printFalsePos) {
                         System.out.println(result.getScore() + " " + injected[y] + " at " + y + " dist "
-                                + dist.apply(points[y], result.getRepresentative()) + " " + result.getThreshold());
-                        printCharArray(result.getRepresentative());
+                                + dist.apply(points[y], list.get(0).index) + " " + result.getThreshold());
+                        printCharArray(list.get(0).index);
                         System.out.println();
                         printCharArray(points[y]);
                         System.out.println();

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/StringGLADexample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/StringGLADexample.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.parkservices;
+
+import static java.lang.Math.min;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiFunction;
+
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.parkservices.GlobalLocalAnomalyDetector;
+import com.amazon.randomcutforest.parkservices.returntypes.GenericAnomalyDescriptor;
+import com.amazon.randomcutforest.summarization.ICluster;
+import com.amazon.randomcutforest.util.Weighted;
+
+/**
+ * A clustering based anomaly detection for strings for two characters using
+ * edit distance. Note that the algorithm does not have any inbuilt test for
+ * verifying if the distance is indeed a metric (other than checking for
+ * non-negative values.
+ */
+public class StringGLADexample implements Example {
+
+    public static void main(String[] args) throws Exception {
+        new StringGLADexample().run();
+    }
+
+    @Override
+    public String command() {
+        return "Clustering based Global-Local Anomaly Detection Example for strings";
+    }
+
+    @Override
+    public String description() {
+        return "Clustering based Global-Local Anomaly Detection Example for strings";
+    }
+
+    @Override
+    public void run() throws Exception {
+        long seed = new Random().nextLong();
+        System.out.println("seed : " + seed);
+        Random random = new Random(seed);
+        int stringSize = 70;
+        int numberOfStrings = 200000;
+        int reservoirSize = 2000;
+        boolean changeInMiddle = true;
+        // the following should be away from 0.5 in [0.5,1]
+        double gapProbOfA = 0.85;
+
+        double anomalyRate = 0.05;
+        char[][] points = new char[numberOfStrings][];
+        boolean[] injected = new boolean[numberOfStrings];
+        boolean printClusters = false;
+        boolean printFalseNeg = false;
+        boolean printFalsePos = false;
+        int numberOfInjected = 0;
+
+        for (int i = 0; i < numberOfStrings; i++) {
+            if (random.nextDouble() < anomalyRate && i > reservoirSize / 2) {
+                injected[i] = true;
+                ++numberOfInjected;
+                points[i] = getABArray(stringSize + 10, 0.5, random, false, 0);
+            } else {
+                boolean flag = changeInMiddle && random.nextDouble() < 0.25;
+                double prob = (random.nextDouble() < 0.5) ? gapProbOfA : (1 - gapProbOfA);
+                points[i] = getABArray(stringSize, prob, random, flag, 0.25 * i / numberOfStrings);
+            }
+        }
+
+        System.out.println("Injected " + numberOfInjected + " 'anomalies' in " + points.length);
+        int recluster = reservoirSize / 2;
+
+        BiFunction<char[], char[], Double> dist = (a, b) -> toyD(a, b, stringSize / 2.0);
+        GlobalLocalAnomalyDetector<char[]> reservoir = GlobalLocalAnomalyDetector.builder().randomSeed(42)
+                .numberOfRepresentatives(5).timeDecay(1.0 / reservoirSize).capacity(reservoirSize).build();
+        reservoir.setGlobalDistance(dist);
+        // for non-geometric bounded distances, such as for strings, keep the factor at
+        // 3.0 or below
+        // minimum is 2.5, set as default; uncomment to change
+        // reservoir.setZfactor(DEFAULT_Z_FACTOR);
+
+        int truePos = 0;
+        int falsePos = 0;
+        int falseNeg = 0;
+        for (int y = 0; y < points.length; y++) {
+
+            GenericAnomalyDescriptor<char[]> result = reservoir.process(points[y], 1.0f, null, true);
+            if (result.getAnomalyGrade() > 0) {
+                if (!injected[y]) {
+                    ++falsePos;
+                    if (printFalsePos) {
+                        System.out.println(result.getScore() + " " + injected[y] + " at " + y + " dist "
+                                + dist.apply(points[y], result.getRepresentative()) + " " + result.getThreshold());
+                        printCharArray(result.getRepresentative());
+                        System.out.println();
+                        printCharArray(points[y]);
+                        System.out.println();
+                    }
+                } else {
+                    ++truePos;
+                }
+            } else if (injected[y]) {
+                ++falseNeg;
+                if (printFalseNeg) {
+                    System.out.println(" missed " + result.getScore() + "  " + result.getThreshold());
+                }
+            }
+
+            if (printClusters && y % 10000 == 0 && y > 0) {
+                System.out.println(" at " + y);
+                printClusters(reservoir.getClusters());
+
+            }
+
+            if (10 * y % points.length == 0 && y > 0) {
+                System.out.println(" at " + y);
+                System.out.println("Precision = " + precision(truePos, falsePos));
+                System.out.println("Recall = " + recall(truePos, falseNeg));
+            }
+        }
+        System.out.println(" Final: ");
+        System.out.println("Precision = " + precision(truePos, falsePos));
+        System.out.println("Recall = " + recall(truePos, falseNeg));
+    }
+
+    public static double toyD(char[] a, char[] b, double u) {
+        if (a.length > b.length) {
+            return toyD(b, a, u);
+        }
+        double[][] dist = new double[2][b.length + 1];
+        for (int j = 0; j < b.length + 1; j++) {
+            dist[0][j] = j;
+        }
+
+        for (int i = 1; i < a.length + 1; i++) {
+            dist[1][0] = i;
+            for (int j = 1; j < b.length + 1; j++) {
+                double t = dist[0][j - 1] + ((a[i - 1] == b[j - 1]) ? 0 : 1);
+                dist[1][j] = min(min(t, dist[0][j] + 1), dist[1][j - 1] + 1);
+            }
+            for (int j = 0; j < b.length + 1; j++) {
+                dist[0][j] = dist[1][j];
+            }
+        }
+        return dist[1][b.length];
+    }
+
+    // colors
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+
+    public static void printCharArray(char[] a) {
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] == '-') {
+                System.out.print(ANSI_RED + a[i] + ANSI_RESET);
+            } else {
+                System.out.print(ANSI_BLUE + a[i] + ANSI_RESET);
+            }
+        }
+
+    }
+
+    public void printClusters(List<ICluster<char[]>> summary) {
+        for (int i = 0; i < summary.size(); i++) {
+            double weight = summary.get(i).getWeight();
+            System.out.println("Cluster " + i + " representatives, weight "
+                    + ((float) Math.round(1000 * weight) * 0.001) + " avg radius " + summary.get(i).averageRadius());
+            List<Weighted<char[]>> representatives = summary.get(i).getRepresentatives();
+            for (int j = 0; j < representatives.size(); j++) {
+                double t = representatives.get(j).weight;
+                t = Math.round(1000.0 * t / weight) * 0.001;
+                System.out
+                        .print("relative weight " + (float) t + " length " + representatives.get(j).index.length + " ");
+                printCharArray(representatives.get(j).index);
+                System.out.println();
+            }
+            System.out.println();
+        }
+    }
+
+    public char[] getABArray(int size, double probabilityOfA, Random random, Boolean changeInMiddle, double fraction) {
+
+        int newSize = size + random.nextInt(size / 5);
+        char[] a = new char[newSize];
+        for (int i = 0; i < newSize; i++) {
+            double toss = (changeInMiddle && (i > (1 - fraction) * newSize || i < newSize * fraction))
+                    ? (1 - probabilityOfA)
+                    : probabilityOfA;
+            if (random.nextDouble() < toss) {
+                a[i] = '-';
+            } else {
+                a[i] = '_';
+            }
+        }
+        return a;
+    }
+
+    double precision(int truePos, int falsePos) {
+        return (truePos + falsePos > 0) ? 1.0 * truePos / (truePos + falsePos) : 1.0;
+    }
+
+    double recall(int truePos, int falseNeg) {
+        return (truePos + falseNeg > 0) ? 1.0 * truePos / (truePos + falseNeg) : 1.0;
+    }
+
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/GlobalLocalAnomalyDetector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/GlobalLocalAnomalyDetector.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import com.amazon.randomcutforest.parkservices.returntypes.GenericAnomalyDescriptor;
+import com.amazon.randomcutforest.parkservices.threshold.BasicThresholder;
+import com.amazon.randomcutforest.summarization.GenericMultiCenter;
+import com.amazon.randomcutforest.summarization.ICluster;
+import com.amazon.randomcutforest.summarization.Summarizer;
+import com.amazon.randomcutforest.util.Weighted;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.summarization.GenericMultiCenter.DEFAULT_NUMBER_OF_REPRESENTATIVES;
+import static com.amazon.randomcutforest.summarization.GenericMultiCenter.DEFAULT_SHRINKAGE;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
+
+public class GlobalLocalAnomalyDetector<P> extends StreamSampler<P> {
+
+    // default maximum number of clusters to consider
+    public static int DEFAULT_MAX = 10;
+
+    // an upper bound on the score
+    public static float FLOAT_MAX = 10;
+
+    // the relative weight of small clusters which should not be used in anomaly
+    // detection
+    // this controls masking effects
+    public static double DEFAULT_IGNORE_SMALL_CLUSTER_REPRESENTATIVE = 0.005;
+
+    // the number of steps we have to wait before reclustering; in principle this
+    // can be 1, but that would be
+    // neither be meaningful nor efficient; it is set to a default of the capacity/2
+    protected int doNotreclusterWithin;
+
+    // a thresholder for flagging anomalies (same thresholder as in TRCF)
+    protected final BasicThresholder thresholder;
+
+    // remembering when the last clustering was performed
+    protected long lastCluster = 0L;
+
+    // remembers when the mean of the scores were just above a certain threshold
+    // acts as a calibration mechanism
+    protected double lastMean = 1;
+
+    // actual list of clusters
+    List<ICluster<P>> clusters;
+
+    // the number of maximum clusters to be considered; this is configurable and can
+    // be chaned dynamically
+    protected int maxAllowed;
+
+    // the shrinkage parameter in multi-centroid clustering such as CURE. Shrinkage
+    // of 0 provides
+    // non-spherical shapes, whereas shrinkage of 1 corresponds to choosing single
+    // centroid (not recommended)
+    protected double shrinkage;
+
+    // number of representatives used in multi-centroidal clustering
+    protected int numberOfRepresentatives;
+
+    // threshold of weight for small clusters so that masking can be averted, can be
+    // changed dynamically
+    protected double ignoreBelow;
+
+    // the global function used in clustering, can be changed dynamically (but
+    // clustering would be controlled
+    // automatically due to efficiency reasons)
+    protected BiFunction<P, P, Double> globalDistance;
+
+    public static Builder<?> builder() {
+        return new Builder<>();
+    }
+
+    protected GlobalLocalAnomalyDetector(Builder<?> builder) {
+        super(builder);
+        thresholder = new BasicThresholder(builder.timeDecay);
+        thresholder.setAbsoluteThreshold(1.2);
+        doNotreclusterWithin = builder.doNotReclusterWithin.orElse(builder.capacity / 2);
+        shrinkage = builder.shrinkage;
+        maxAllowed = builder.maxAllowed;
+        numberOfRepresentatives = builder.numberOfRepresentatives;
+    }
+
+    protected GlobalLocalAnomalyDetector(Builder<?> builder, BiFunction<P, P, Double> distance) {
+        this(builder);
+        globalDistance = distance;
+    }
+
+    public void setGlobalDistance(BiFunction<P, P, Double> dist) {
+        globalDistance = dist;
+    }
+
+    // sets the zFactor; increasing this number should increase precision (and will
+    // likely lower recall)
+    // this is the same as in BasicThresholder class
+    public void setZfactor(double factor) {
+        thresholder.setZfactor(factor);
+    }
+
+    public double getZfactor() {
+        return thresholder.getZFactor();
+    }
+
+    // as in BasicThresholder class, useful in tuning
+    public void setLowerThreshold(double lowerThreshold) {
+        thresholder.setLowerThreshold(lowerThreshold);
+    }
+
+    public double getLowerThreshold() {
+        return thresholder.getLowerThreshold();
+    }
+
+    public int getDoNotreclusterWithin() {
+        return doNotreclusterWithin;
+    }
+
+    public void setDoNotreclusterWithin(int value) {
+        checkArgument(value > 0, " has to be positive, recommended as 1/2 the capacity");
+        doNotreclusterWithin = value;
+    }
+
+    public int getNumberOfRepresentatives() {
+        return numberOfRepresentatives;
+    }
+
+    public void setNumberOfRepresentatives(int reps) {
+        checkArgument(reps > 0, " has to be positive");
+    }
+
+    public double getShrinkage() {
+        return shrinkage;
+    }
+
+    public void setShrinkage(double value) {
+        checkArgument(value >= 0 && value <= 1, " has to be in [0,1]");
+        shrinkage = value;
+    }
+
+    public double getIgnoreBelow() {
+        return ignoreBelow;
+    }
+
+    public void setIgnoreBelow(double value) {
+        checkArgument(value >= 0 && value < 0.1, " relative weight has to be in range [0,0.1] ");
+        ignoreBelow = value;
+    }
+
+    public int getMaxAllowed() {
+        return maxAllowed;
+    }
+
+    public void setMaxAllowed(int value) {
+        checkArgument(value >= 5 && value < 100,
+                " too few or too many clusters are not " + "meaningful to this algorithm");
+        maxAllowed = value;
+    }
+
+    /**
+     * The following provides a single invocation for scoring and updating.
+     * Semantics of the recency biased sampling (sequentiality in decision making)
+     * and efficient automatic reclustering demand that scoring and updating be
+     * simultaneous. While scoring is provided as a separate function to let future
+     * preditor-corrector methods reuse this code, it is strongly recommneded that
+     * only the process() function be invoked.
+     * 
+     * @param object            current object being considered
+     * @param weight            weight of the object (for clustering purposes as
+     *                          well as recency biased sampling)
+     * @param localDistance     a local distance metric that determines the order in
+     *                          which different clusters are considered; can be
+     *                          null, in which case the global distance would be
+     *                          used
+     * @param considerOcclusion consider occlusion by smaller dense clusters, when
+     *                          adjacent to larger and more spread out clusters
+     * @return a generic descriptor with score, anomaly grade, nearest
+     *         representative and threshold (anomaly grade greater than zero is
+     *         likely anomalous; anomaly grade can be -ve to allow down stream
+     *         correction using semi-supervision or other means)
+     */
+    public GenericAnomalyDescriptor<P> process(P object, float weight, BiFunction<P, P, Double> localDistance,
+            boolean considerOcclusion) {
+        checkArgument(weight >= 0, "weight cannot be negative");
+        // recompute clusters first; this enables easier merges and deserialization
+        if (sequenceNumber > lastCluster + doNotreclusterWithin) {
+            checkArgument(globalDistance != null, "set global distance function");
+            double currentMean = thresholder.getPrimaryDeviation().getMean();
+            if (abs(currentMean - lastMean) > 0.1 || currentMean > 1.7
+                    || sequenceNumber > lastCluster + 20 * doNotreclusterWithin) {
+                lastCluster = sequenceNumber;
+                lastMean = currentMean;
+                clusters = getClusters(maxAllowed, 4 * maxAllowed, 1, numberOfRepresentatives, shrinkage,
+                        globalDistance, null);
+            }
+        }
+        Weighted<P> result = score(object, localDistance, considerOcclusion);
+
+        double threshold = thresholder.threshold();
+        double grade = 0;
+        if (result.weight > 0) {
+            grade = thresholder.getAnomalyGrade(result.weight, false);
+        }
+
+        // note average score would be 1
+        thresholder.update(result.weight, min(result.weight, thresholder.getZFactor()));
+        sample(object, weight);
+
+        return new GenericAnomalyDescriptor<>(result.index, result.weight, threshold, grade);
+    }
+
+    /**
+     * The following function scores a point -- it considers an ordering of the
+     * representatives based on the local distance; and considers occlusion --
+     * namely, should an asteroid between moon and the earth be considered to be a
+     * part of a cluster around the moon or the earth? The below provides some
+     * initial geometric take on the three objects. We deliberately avoid explicit
+     * density computation since it would be difficult to define uniform definition
+     * of density.
+     * 
+     * @param current           the object being scored
+     * @param localDistance     a distance function that we wish to use for this
+     *                          specific score. This can be null, and in that case
+     *                          the global distance would be used
+     * @param considerOcclusion a boolean that determines if closeby dense clusters
+     *                          can occlude membership in further away "less dense
+     *                          cluster"
+     * @return A Weighted type where the index is the closest representative (based
+     *         on local distance) and the weight is the score (which may be due to a
+     *         different representative in a different cluster which has larger
+     *         radius). Both of these pieces of information are likely to be of use.
+     */
+    public Weighted<P> score(P current, BiFunction<P, P, Double> localDistance, boolean considerOcclusion) {
+        if (clusters == null) {
+            return new Weighted<>(null, 0f);
+        } else {
+            BiFunction<P, P, Double> local = (localDistance != null) ? localDistance : globalDistance;
+            double totalWeight = clusters.stream().map(e -> e.getWeight()).reduce(0.0, Double::sum);
+            ArrayList<Candidate> candidateList = new ArrayList<>();
+            for (ICluster<P> cluster : clusters) {
+                double wt = cluster.averageRadius();
+                double tempMinimum = Double.MAX_VALUE;
+                P closestInCluster = null;
+                for (Weighted<P> rep : cluster.getRepresentatives()) {
+                    if (rep.weight > ignoreBelow * totalWeight) {
+                        double tempDist = local.apply(current, rep.index);
+                        if (tempDist < 0) {
+                            throw new IllegalArgumentException(" distance cannot be negative ");
+                        }
+                        if (tempMinimum > tempDist) {
+                            tempMinimum = tempDist;
+                            closestInCluster = rep.index;
+                        }
+                    }
+                }
+                if (closestInCluster != null) {
+                    candidateList.add(new Candidate(closestInCluster, wt, tempMinimum));
+                }
+            }
+            candidateList.sort((o1, o2) -> Double.compare(o1.distance, o2.distance));
+            checkArgument(candidateList.size() > 0, " should not happen");
+            Float measure = FLOAT_MAX;
+            P closest = candidateList.get(0).representative;
+            if (candidateList.get(0).distance == 0.0) {
+                return new Weighted<P>(closest, 0.0f);
+            }
+            int index = 0;
+            while (index < candidateList.size()) {
+                Candidate head = candidateList.get(index);
+                double dist = (localDistance == null) ? head.distance
+                        : globalDistance.apply(current, head.representative);
+                float tempMeasure = (head.averageRadiusOfCluster > 0.0)
+                        ? min(FLOAT_MAX, (float) (dist / head.averageRadiusOfCluster))
+                        : FLOAT_MAX;
+                measure = min(measure, tempMeasure);
+                if (considerOcclusion) {
+                    for (int j = index + 1; j < candidateList.size(); j++) {
+                        double occludeDistance = local.apply(head.representative, candidateList.get(j).representative);
+                        double candidateDistance = candidateList.get(j).distance;
+                        if (occludeDistance < candidateDistance && head.distance > Math
+                                .sqrt(head.distance * head.distance + candidateDistance * candidateDistance)) {
+                            // delete element
+                            candidateList.remove(j);
+                        }
+                    }
+                }
+                ++index;
+            }
+            return new Weighted<P>(closest, measure);
+        }
+    }
+
+    /**
+     * a merging routine for the mopdels which would be used in the future for
+     * distributed analysis. Note that there is no point of storing sequence indices
+     * explicitly in case of a merge.
+     * 
+     * @param first    the first model
+     * @param second   the second model
+     * @param builder  the parameters of the new clustering
+     * @param distance the distance function of the new clustering
+     */
+    public GlobalLocalAnomalyDetector(GlobalLocalAnomalyDetector first, GlobalLocalAnomalyDetector second,
+            Builder<?> builder, BiFunction<P, P, Double> distance) {
+        super(first, second, builder.capacity, builder.timeDecay, builder.randomSeed);
+        thresholder = new BasicThresholder(builder.timeDecay);
+        thresholder.setAbsoluteThreshold(1.2);
+        doNotreclusterWithin = builder.doNotReclusterWithin.orElse(builder.capacity / 2);
+        shrinkage = builder.shrinkage;
+        maxAllowed = builder.maxAllowed;
+        numberOfRepresentatives = builder.numberOfRepresentatives;
+        globalDistance = distance;
+    }
+
+    /**
+     * an inner class that is useful for the scoring procedure to avoid
+     * recomputation of fields.
+     */
+    class Candidate {
+        P representative;
+        double averageRadiusOfCluster;
+        double distance;
+
+        Candidate(P representative, double averageRadiusOfCluster, double distance) {
+            this.representative = representative;
+            this.averageRadiusOfCluster = averageRadiusOfCluster;
+            this.distance = distance;
+        }
+    }
+
+    public ArrayList<Weighted<P>> getObjectList() {
+        return objectList;
+    }
+
+    public List<ICluster<P>> getClusters() {
+        return clusters;
+    }
+
+    public List<ICluster<P>> getClusters(int maxAllowed, int initial, int stopAt, int representatives, double shrink,
+            BiFunction<P, P, Double> distance, List<ICluster<P>> previousClusters) {
+        BiFunction<P, Float, ICluster<P>> clusterInitializer = (a, b) -> GenericMultiCenter.initialize(a, b, shrink,
+                representatives);
+        return Summarizer.summarize(objectList, maxAllowed, initial, stopAt, false, 0.8, distance, clusterInitializer,
+                0L, false, previousClusters);
+    }
+
+    /**
+     * a builder
+     */
+    public static class Builder<T extends Builder<T>> extends StreamSampler.Builder<T> {
+        protected double shrinkage = DEFAULT_SHRINKAGE;
+        protected double ignoreBelow = DEFAULT_IGNORE_SMALL_CLUSTER_REPRESENTATIVE;
+        protected int numberOfRepresentatives = DEFAULT_NUMBER_OF_REPRESENTATIVES;
+        protected Optional<Integer> doNotReclusterWithin = Optional.empty();
+        protected int maxAllowed = DEFAULT_MAX;
+
+        // ignores small clusters with population weight below this threshold
+        public T ignoreBelow(double ignoreBelow) {
+            this.ignoreBelow = ignoreBelow;
+            return (T) this;
+        }
+
+        // parameters of the multi-representative CURE algorithm
+        public T shrinkage(double shrinkage) {
+            this.shrinkage = shrinkage;
+            return (T) this;
+        }
+
+        // a parameter that ensures that clustering is not recomputed too frequently,
+        // which can be both inefficient as well as jittery
+        public T doNotReclusterWithin(int refresh) {
+            this.doNotReclusterWithin = Optional.of(refresh);
+            return (T) this;
+        }
+
+        // maximum number of clusters to consider
+        public T maxAllowed(int maxAllowed) {
+            this.maxAllowed = maxAllowed;
+            return (T) this;
+        }
+
+        // parameters of the multi-representative CURE algorithm
+        public T numberOfRepresentatives(int number) {
+            this.numberOfRepresentatives = number;
+            return (T) this;
+        }
+
+        @Override
+        public GlobalLocalAnomalyDetector build() {
+            return new GlobalLocalAnomalyDetector<>(this);
+        }
+    }
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/GlobalLocalAnomalyDetector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/GlobalLocalAnomalyDetector.java
@@ -99,6 +99,7 @@ public class GlobalLocalAnomalyDetector<P> extends StreamSampler<P> {
         shrinkage = builder.shrinkage;
         maxAllowed = builder.maxAllowed;
         numberOfRepresentatives = builder.numberOfRepresentatives;
+        ignoreBelow = builder.ignoreBelow;
     }
 
     protected GlobalLocalAnomalyDetector(Builder<?> builder, BiFunction<P, P, Double> distance) {
@@ -342,7 +343,7 @@ public class GlobalLocalAnomalyDetector<P> extends StreamSampler<P> {
     public GlobalLocalAnomalyDetector(GlobalLocalAnomalyDetector first, GlobalLocalAnomalyDetector second,
             Builder<?> builder, boolean recluster, BiFunction<P, P, Double> distance) {
         super(first, second, builder.capacity, builder.timeDecay, builder.randomSeed);
-        thresholder = new BasicThresholder(builder.timeDecay);
+        thresholder = new BasicThresholder(builder.timeDecay, builder.anomalyRate, false);
         thresholder.setAbsoluteThreshold(1.2);
         doNotreclusterWithin = builder.doNotReclusterWithin.orElse(builder.capacity / 2);
         shrinkage = builder.shrinkage;
@@ -397,6 +398,7 @@ public class GlobalLocalAnomalyDetector<P> extends StreamSampler<P> {
         protected int numberOfRepresentatives = DEFAULT_NUMBER_OF_REPRESENTATIVES;
         protected Optional<Integer> doNotReclusterWithin = Optional.empty();
         protected int maxAllowed = DEFAULT_MAX;
+        protected double anomalyRate = 0.01;
 
         // ignores small clusters with population weight below this threshold
         public T ignoreBelow(double ignoreBelow) {
@@ -426,6 +428,12 @@ public class GlobalLocalAnomalyDetector<P> extends StreamSampler<P> {
         // parameters of the multi-representative CURE algorithm
         public T numberOfRepresentatives(int number) {
             this.numberOfRepresentatives = number;
+            return (T) this;
+        }
+
+        // a flag that can adjust to the burstiness of anomalies
+        public T anomalyRate(double anomalyRate) {
+            this.anomalyRate = anomalyRate;
             return (T) this;
         }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
@@ -348,7 +348,7 @@ public class PredictorCorrector {
         // the forecast may not be reasonable with less data
         boolean reasonableForecast = result.isReasonableForecast();
 
-        // note that the following is bupassed for shingleSize = 1 because it would not
+        // note that the following is bypassed for shingleSize = 1 because it would not
         // make
         // sense to connect the current evaluation with a previous value
         if (reasonableForecast && lastAnomalyDescriptor.getRCFPoint() != null && shingleSize > 1

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/StreamSampler.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/StreamSampler.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_INITIAL_ACCEPT_FRACTION;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SAMPLE_SIZE;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_TIME_DECAY;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Random;
+
+import com.amazon.randomcutforest.sampler.CompactSampler;
+import com.amazon.randomcutforest.sampler.ISampled;
+import com.amazon.randomcutforest.store.IndexIntervalManager;
+import com.amazon.randomcutforest.util.Weighted;
+
+/**
+ * The following class is a sampler for generic objects that allow weighted time
+ * dependent sampling. It is an encapsulation of CompactSampler in
+ * RandomCutForest core and is meant to be extended in multiple ways. Hence the
+ * functions are protected and should be overriden/not used arbirarily.
+ */
+public class StreamSampler<P> {
+
+    // basic time dependent sampler
+    protected final CompactSampler sampler;
+
+    // list of objects
+    protected final ArrayList<Weighted<P>> objectList;
+
+    // managing indices
+    protected final IndexIntervalManager intervalManager;
+
+    // accounting for evicted items
+    protected Optional<P> evicted;
+
+    // sequence number used in sequential sampling
+    protected long sequenceNumber = -1L;
+
+    // number of items seen, different from sequenceNumber in case of merge
+    protected long entriesSeen = 0L;
+
+    public static Builder<?> builder() {
+        return new Builder<>();
+    }
+
+    public StreamSampler(Builder<?> builder) {
+        sampler = new CompactSampler.Builder<>().capacity(builder.capacity)
+                .storeSequenceIndexesEnabled(builder.storeSequenceIndexesEnabled).randomSeed(builder.randomSeed)
+                .initialAcceptFraction(builder.initialAcceptFraction).timeDecay(builder.timeDecay).build();
+        objectList = new ArrayList<>(builder.capacity);
+        intervalManager = new IndexIntervalManager(builder.capacity);
+        evicted = Optional.empty();
+    }
+
+    /**
+     * a basic sampling operation that accounts for weights of items. This function
+     * will be overriden in future classes.
+     * 
+     * @param object to be sampled
+     * @param weight weight of object (non-negative); although 0 weight implies do
+     *               not sample
+     * @return true if the object is sampled and false if the object is not sampled;
+     *         if true then there may have been an eviction which is updated
+     */
+    protected boolean sample(P object, float weight) {
+        ++sequenceNumber;
+        ++entriesSeen;
+        if (sampler.acceptPoint(sequenceNumber, weight)) {
+            Optional<ISampled<Integer>> samplerEvicted = sampler.getEvictedPoint();
+
+            if (samplerEvicted.isPresent()) {
+                int oldIndex = samplerEvicted.get().getValue();
+                evicted = Optional.of(objectList.get(oldIndex).index);
+                intervalManager.releaseIndex(oldIndex);
+            }
+            int index = intervalManager.takeIndex();
+            if (index < objectList.size()) {
+                objectList.set(index, new Weighted<>(object, weight));
+            } else {
+                checkArgument(index == objectList.size(), "incorrect behavior");
+                objectList.add(new Weighted<>(object, weight));
+            }
+            sampler.addPoint(index);
+            return true;
+        }
+        evicted = Optional.empty();
+        return false;
+    }
+
+    public StreamSampler(StreamSampler<P> first, StreamSampler<P> second, int capacity, double timeDecay, long seed) {
+        checkArgument(capacity > 0, "capacity has to be positive");
+        double initialAcceptFraction = max(first.sampler.getInitialAcceptFraction(),
+                second.sampler.getInitialAcceptFraction());
+        // merge would remove sequenceIndex information
+
+        objectList = new ArrayList<>(capacity);
+        int[] pointList = new int[capacity];
+        float[] weightList = new float[capacity];
+        intervalManager = new IndexIntervalManager(capacity);
+        evicted = Optional.empty();
+        double firstUpdate = -(first.sampler.getMaxSequenceIndex() - first.sampler.getMostRecentTimeDecayUpdate())
+                * first.sampler.getTimeDecay();
+        ArrayList<Weighted<Integer>> list = new ArrayList<>();
+        int offset = first.sampler.size();
+        int[] firstList = first.sampler.getPointIndexArray();
+        float[] firstWeightList = first.sampler.getWeightArray();
+        checkArgument(firstList.length == offset, " incorrect length");
+        checkArgument(firstWeightList.length == offset, " incorrect length");
+        for (int i = 0; i < firstList.length; i++) {
+
+            checkArgument(firstList[i] < offset, "incorrect heap numbering");
+            list.add(new Weighted<>(firstList[i], (float) (firstWeightList[i] + firstUpdate)));
+        }
+        double secondUpdate = -(second.sampler.getMaxSequenceIndex() - second.sampler.getMostRecentTimeDecayUpdate())
+                * second.sampler.getTimeDecay();
+        int[] secondList = second.sampler.getPointIndexArray();
+        float[] secondWeightList = second.sampler.getWeightArray();
+        checkArgument(secondList.length == secondWeightList.length, " incorrect length");
+        for (int i = 0; i < secondList.length; i++) {
+            list.add(new Weighted<>(secondList[i] + offset, (float) (secondWeightList[i] + secondUpdate)));
+        }
+        list.sort((o1, o2) -> Float.compare(o1.weight, o2.weight));
+        int size = min(capacity, list.size());
+        for (int j = size - 1; j >= 0; j--) {
+            int index = intervalManager.takeIndex();
+            checkArgument(index == size - j - 1, "error in behavior");
+            pointList[index] = index;
+            weightList[index] = list.get(j).weight;
+            if (list.get(j).index < offset) {
+                objectList.add(first.objectList.get(list.get(j).index));
+            } else {
+                objectList.add(second.objectList.get(list.get(j).index - offset));
+            }
+        }
+        // sequence number corresponds to linear order of time
+        this.sequenceNumber = max(first.sequenceNumber, second.sequenceNumber);
+        // entries seen is the sum
+        this.entriesSeen = first.entriesSeen + second.entriesSeen;
+        sampler = new CompactSampler.Builder<>().capacity(capacity).storeSequenceIndexesEnabled(false).randomSeed(seed)
+                .initialAcceptFraction(initialAcceptFraction).timeDecay(timeDecay).pointIndex(pointList)
+                .weight(weightList).randomSeed(seed).maxSequenceIndex(this.sequenceNumber)
+                .mostRecentTimeDecayUpdate(this.sequenceNumber).build();
+    }
+
+    public ArrayList<Weighted<P>> getObjectList() {
+        return objectList;
+    }
+
+    public int getCapacity() {
+        return sampler.getCapacity();
+    }
+
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public long getEntriesSeen() {
+        return entriesSeen;
+    }
+
+    public static class Builder<T extends Builder<T>> {
+
+        private boolean storeSequenceIndexesEnabled = DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
+        protected int capacity = DEFAULT_SAMPLE_SIZE;
+        protected double timeDecay = 1.0 / (DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_TIME_DECAY * capacity);
+        protected long randomSeed = new Random().nextLong();
+        protected double initialAcceptFraction = DEFAULT_INITIAL_ACCEPT_FRACTION;
+
+        public T capacity(int capacity) {
+            this.capacity = capacity;
+            return (T) this;
+        }
+
+        public T randomSeed(long seed) {
+            this.randomSeed = seed;
+            return (T) this;
+        }
+
+        public T initialAcceptFraction(double initialAcceptFraction) {
+            this.initialAcceptFraction = initialAcceptFraction;
+            return (T) this;
+        }
+
+        public T timeDecay(double timeDecay) {
+            this.timeDecay = timeDecay;
+            return (T) this;
+        }
+
+        public T storeSequenceIndexesEnabled(boolean storeSequenceIndexesEnabled) {
+            this.storeSequenceIndexesEnabled = storeSequenceIndexesEnabled;
+            return (T) this;
+        }
+
+        public StreamSampler build() {
+            return new StreamSampler<>(this);
+        }
+    }
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -101,6 +101,7 @@ public class ThresholdedRandomCutForest {
             builder.internalShinglingEnabled = Optional.of(false);
             preprocessorBuilder.useImputedFraction(builder.useImputedFraction.orElse(0.5));
         } else {
+            // applies to both STANDARD and DISTANCE
             boolean smallInput = builder.internalShinglingEnabled.orElse(DEFAULT_INTERNAL_SHINGLING_ENABLED);
             preprocessorBuilder
                     .inputLength((smallInput) ? builder.dimensions / builder.shingleSize : builder.dimensions);
@@ -118,7 +119,8 @@ public class ThresholdedRandomCutForest {
                 .startNormalization(builder.startNormalization.orElse(Preprocessor.DEFAULT_START_NORMALIZATION));
 
         preprocessor = preprocessorBuilder.build();
-        predictorCorrector = new PredictorCorrector(new BasicThresholder(builder.anomalyRate, builder.adjustThreshold));
+        predictorCorrector = new PredictorCorrector(
+                new BasicThresholder(forest.getTimeDecay(), builder.anomalyRate, builder.adjustThreshold));
         lastAnomalyDescriptor = new RCFComputeDescriptor(null, 0, builder.forestMode, builder.transformMethod,
                 builder.imputationMethod);
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
@@ -15,6 +15,19 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor;
 
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
+import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
+import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.ImputationMethod;
@@ -33,18 +46,6 @@ import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
 import com.amazon.randomcutforest.parkservices.statistics.Deviation;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.returntypes.RangeVector;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.Arrays;
-import java.util.Optional;
-
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
-import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
-import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 @Getter
 @Setter

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/returntypes/GenericAnomalyDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/returntypes/GenericAnomalyDescriptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.returntypes;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GenericAnomalyDescriptor<P> {
+
+    P representative;
+
+    double score;
+
+    double threshold;
+
+    double anomalyGrade;
+
+    public GenericAnomalyDescriptor(P representative, double score, double threshold, double anomalyGrade) {
+        this.representative = representative;
+        this.score = score;
+        this.threshold = threshold;
+        this.anomalyGrade = anomalyGrade;
+    }
+
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/returntypes/GenericAnomalyDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/returntypes/GenericAnomalyDescriptor.java
@@ -15,23 +15,43 @@
 
 package com.amazon.randomcutforest.parkservices.returntypes;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
+
+import com.amazon.randomcutforest.util.Weighted;
 
 @Getter
 @Setter
 public class GenericAnomalyDescriptor<P> {
 
-    P representative;
+    // the following corresponds to the list of extected points in AnomalyDetector,
+    // which is returned from
+    // TRCF. The list corresponds to plausible values (cluster centers) and a weight
+    // representing the likelihood
+    // The list is sorted in decreasing order of likelihood. Most often, the first
+    // element should suffice.
+    // in case of an anomalous point, however the information here can provide more
+    // insight
+    List<Weighted<P>> representativeList;
 
+    // standard, as in AnomalyDetector; we do not recommend attempting to
+    // disambiguate scores of non-anomalous
+    // points. Note that scores can be low.
     double score;
 
+    // standard as in AnomalyDetector
     double threshold;
 
+    // a value between [0,1] indicating the strength of the anomaly, it can be
+    // viewed as a confidence score
+    // projected by the algorithm.
     double anomalyGrade;
 
-    public GenericAnomalyDescriptor(P representative, double score, double threshold, double anomalyGrade) {
-        this.representative = representative;
+    public GenericAnomalyDescriptor(List<Weighted<P>> representative, double score, double threshold,
+            double anomalyGrade) {
+        this.representativeList = representativeList;
         this.score = score;
         this.threshold = threshold;
         this.anomalyGrade = anomalyGrade;

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TestGlobalLocalAnomalyDetector.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TestGlobalLocalAnomalyDetector.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
+import static com.amazon.randomcutforest.testutils.ExampleDataSets.rotateClockWise;
+import static java.lang.Math.PI;
+import static java.lang.Math.min;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.parkservices.returntypes.GenericAnomalyDescriptor;
+import com.amazon.randomcutforest.summarization.ICluster;
+import com.amazon.randomcutforest.summarization.Summarizer;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+import com.amazon.randomcutforest.util.Weighted;
+
+public class TestGlobalLocalAnomalyDetector {
+
+    @Test
+    void testDynamicStringClustering() {
+        long seed = new Random().nextLong();
+        System.out.println("String summarization seed : " + seed);
+        Random random = new Random(seed);
+        int stringSize = 70;
+        int numberOfStrings = 200000;
+        int reservoirSize = 2000;
+        boolean changeInMiddle = true;
+        // the following should be away from 0.5 in [0.5,1]
+        double gapProbOfA = 0.85;
+
+        double anomalyRate = 0.05;
+        char[][] points = new char[numberOfStrings][];
+        boolean[] injected = new boolean[numberOfStrings];
+        int numberOfInjected = 0;
+
+        for (int i = 0; i < numberOfStrings; i++) {
+            if (random.nextDouble() < anomalyRate && i > reservoirSize / 2) {
+                injected[i] = true;
+                ++numberOfInjected;
+                points[i] = getABArray(stringSize + 10, 0.5, random, false, 0);
+            } else {
+                boolean flag = changeInMiddle && random.nextDouble() < 0.25;
+                double prob = (random.nextDouble() < 0.5) ? gapProbOfA : (1 - gapProbOfA);
+                points[i] = getABArray(stringSize, prob, random, flag, 0.25 * i / numberOfStrings);
+            }
+        }
+
+        System.out.println("Injected " + numberOfInjected + " 'anomalies' in " + points.length);
+        int recluster = reservoirSize / 2;
+
+        BiFunction<char[], char[], Double> dist = (a, b) -> toyD(a, b, stringSize / 2.0);
+        GlobalLocalAnomalyDetector<char[]> reservoir = GlobalLocalAnomalyDetector.builder().randomSeed(42)
+                .numberOfRepresentatives(5).timeDecay(1.0 / reservoirSize).capacity(reservoirSize).build();
+        reservoir.setGlobalDistance(dist);
+
+        int truePos = 0;
+        int falsePos = 0;
+        int falseNeg = 0;
+        for (int y = 0; y < points.length; y++) {
+
+            if (y % 200 == 100 && y > reservoirSize) {
+                char[] temp = points[y];
+                // check for malformed distance function, to the extent we can check efficiently
+                BiFunction<char[], char[], Double> badDistance = (a, b) -> -1.0;
+                assertThrows(IllegalArgumentException.class, () -> {
+                    reservoir.process(temp, 1.0f, badDistance, true);
+                });
+            }
+            GenericAnomalyDescriptor<char[]> result = reservoir.process(points[y], 1.0f, null, true);
+            if (result.getAnomalyGrade() > 0) {
+                if (!injected[y]) {
+                    ++falsePos;
+                } else {
+                    ++truePos;
+                }
+            } else if (injected[y]) {
+                ++falseNeg;
+            }
+
+            if (10 * y % points.length == 0 && y > 0) {
+                System.out.println(" at " + y);
+                System.out.println("Precision = " + precision(truePos, falsePos));
+                System.out.println("Recall = " + recall(truePos, falseNeg));
+            }
+        }
+        System.out.println(" Final: ");
+        System.out.println("Precision = " + precision(truePos, falsePos));
+        System.out.println("Recall = " + recall(truePos, falseNeg));
+    }
+
+    public static double toyD(char[] a, char[] b, double u) {
+        if (a.length > b.length) {
+            return toyD(b, a, u);
+        }
+        double[][] dist = new double[2][b.length + 1];
+        for (int j = 0; j < b.length + 1; j++) {
+            dist[0][j] = j;
+        }
+
+        for (int i = 1; i < a.length + 1; i++) {
+            dist[1][0] = i;
+            for (int j = 1; j < b.length + 1; j++) {
+                double t = dist[0][j - 1] + ((a[i - 1] == b[j - 1]) ? 0 : 1);
+                dist[1][j] = min(min(t, dist[0][j] + 1), dist[1][j - 1] + 1);
+            }
+            for (int j = 0; j < b.length + 1; j++) {
+                dist[0][j] = dist[1][j];
+            }
+        }
+        return dist[1][b.length];
+    }
+
+    // colors
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+
+    public static void printCharArray(char[] a) {
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] == '-') {
+                System.out.print(ANSI_RED + a[i] + ANSI_RESET);
+            } else {
+                System.out.print(ANSI_BLUE + a[i] + ANSI_RESET);
+            }
+        }
+
+    }
+
+    public void printClusters(List<ICluster<char[]>> summary) {
+        for (int i = 0; i < summary.size(); i++) {
+            double weight = summary.get(i).getWeight();
+            System.out.println("Cluster " + i + " representatives, weight "
+                    + ((float) Math.round(1000 * weight) * 0.001) + " avg radius " + summary.get(i).averageRadius());
+            List<Weighted<char[]>> representatives = summary.get(i).getRepresentatives();
+            for (int j = 0; j < representatives.size(); j++) {
+                double t = representatives.get(j).weight;
+                t = Math.round(1000.0 * t / weight) * 0.001;
+                System.out
+                        .print("relative weight " + (float) t + " length " + representatives.get(j).index.length + " ");
+                printCharArray(representatives.get(j).index);
+                System.out.println();
+            }
+            System.out.println();
+        }
+    }
+
+    public char[] getABArray(int size, double probabilityOfA, Random random, Boolean changeInMiddle, double fraction) {
+
+        int newSize = size + random.nextInt(size / 5);
+        char[] a = new char[newSize];
+        for (int i = 0; i < newSize; i++) {
+            double toss = (changeInMiddle && (i > (1 - fraction) * newSize || i < newSize * fraction))
+                    ? (1 - probabilityOfA)
+                    : probabilityOfA;
+            if (random.nextDouble() < toss) {
+                a[i] = '-';
+            } else {
+                a[i] = '_';
+            }
+        }
+        return a;
+    }
+
+    public double[][] shiftedEllipse(int dataSize, int seed, double shift, int fans) {
+        NormalMixtureTestData generator = new NormalMixtureTestData(0.0, 1.0, 0.0, 1.0, 0.0, 1.0);
+        double[][] data = generator.generateTestData(dataSize, 2, seed);
+        Random prg = new Random(0);
+        for (int i = 0; i < dataSize; i++) {
+            int nextFan = prg.nextInt(fans);
+            // scale
+            data[i][1] *= 1.0 / fans;
+            data[i][0] *= 2.0;
+            // shift
+            data[i][0] += shift + 1.0 / fans;
+            data[i] = rotateClockWise(data[i], 2 * PI * nextFan / fans);
+        }
+
+        return data;
+    }
+
+    @Test
+    void testDynamicNumericClustering() throws IOException {
+        long randomSeed = new Random().nextLong();
+        System.out.println("Seed " + randomSeed);
+        // we would be sending dataSize * 360 vectors
+        int dataSize = 2000;
+        double range = 10.0;
+        int numberOfFans = 3;
+        // corresponds to number of clusters
+        double[][] data = shiftedEllipse(dataSize, 7, range / 2, numberOfFans);
+        int truePos = 0;
+        int falsePos = 0;
+        int falseNeg = 0;
+
+        int truePosRCF = 0;
+        int falsePosRCF = 0;
+        int falseNegRCF = 0;
+
+        int reservoirSize = dataSize;
+        double timedecay = 1.0 / reservoirSize;
+        GlobalLocalAnomalyDetector<float[]> reservoir = GlobalLocalAnomalyDetector.builder().randomSeed(42)
+                .numberOfRepresentatives(3).timeDecay(timedecay).capacity(reservoirSize).build();
+        reservoir.setGlobalDistance(Summarizer::L2distance);
+
+        double zFactor = 6.0; // six sigma deviation; seems to work best
+        reservoir.setZfactor(zFactor);
+
+        ThresholdedRandomCutForest test = ThresholdedRandomCutForest.builder().dimensions(2).shingleSize(1)
+                .randomSeed(77).timeDecay(timedecay).forestMode(ForestMode.DISTANCE).build();
+        test.setZfactor(zFactor); // using the same apples to apples comparison
+
+        String name = "clustering_example";
+        BufferedWriter file = new BufferedWriter(new FileWriter(name));
+
+        Random noiseGen = new Random(randomSeed + 1);
+        for (int degree = 0; degree < 360; degree += 1) {
+            int index = 0;
+            while (index < data.length) {
+                boolean injected = false;
+                float[] vec;
+                if (noiseGen.nextDouble() < 0.005) {
+                    injected = true;
+                    double[] candAnomaly = new double[2];
+                    // generate points along x axis
+                    candAnomaly[0] = (range / 2 * noiseGen.nextDouble() + range / 2);
+                    candAnomaly[1] = 0.1 * (2.0 * noiseGen.nextDouble() - 1.0);
+                    int antiFan = noiseGen.nextInt(numberOfFans);
+                    // rotate to be 90-180 degrees away -- these are decidedly anomalous
+                    vec = toFloatArray(rotateClockWise(candAnomaly,
+                            -2 * PI * (degree + 180 * (1 + 2 * antiFan) / numberOfFans) / 360));
+                } else {
+                    vec = toFloatArray(rotateClockWise(data[index], -2 * PI * degree / 360));
+                    ++index;
+                }
+
+                GenericAnomalyDescriptor<float[]> result = reservoir.process(vec, 1.0f, null, true);
+
+                AnomalyDescriptor res = test.process(toDoubleArray(vec), 0L);
+                double grade = res.getAnomalyGrade();
+
+                if (injected) {
+                    if (result.getAnomalyGrade() > 0) {
+                        ++truePos;
+                    } else {
+                        ++falseNeg;
+                    }
+                    if (grade > 0) {
+                        ++truePosRCF;
+                        assert (res.attribution != null);
+                        // even though scoring is different, we should see attribution add up to score
+                        assertEquals(res.attribution.getHighLowSum(), res.getRCFScore(), 1e-6);
+                    } else {
+                        ++falseNegRCF;
+                    }
+                } else {
+                    if (result.getAnomalyGrade() > 0) {
+                        ++falsePos;
+                    }
+                    if (grade > 0) {
+                        ++falsePosRCF;
+                        assert (res.attribution != null);
+                        // even though scoring is different, we should see attribution add up to score
+                        assertEquals(res.attribution.getHighLowSum(), res.getRCFScore(), 1e-6);
+                    }
+                }
+            }
+
+            if (falsePos + truePos == 0) {
+                throw new IllegalStateException("");
+            }
+
+            checkArgument(falseNeg + truePos == falseNegRCF + truePosRCF, " incorrect accounting");
+            System.out.println(" at degree " + degree + " injected " + (truePos + falseNeg));
+            System.out.print("Precision = " + precision(truePos, falsePos));
+            System.out.println(" Recall = " + recall(truePos, falseNeg));
+            System.out.print("RCF Distance Mode Precision = " + precision(truePosRCF, falsePosRCF));
+            System.out.println(" RCF Distance Mode Recall = " + recall(truePosRCF, falseNegRCF));
+
+        }
+        // attempting merge
+        long number = new Random().nextLong();
+        int size = reservoirSize - new Random().nextInt(100);
+        double newShrinkage = new Random().nextDouble();
+        int reps = new Random().nextInt(10);
+        GlobalLocalAnomalyDetector.Builder builder = GlobalLocalAnomalyDetector.builder().capacity(size)
+                .shrinkage(newShrinkage).numberOfRepresentatives(reps).timeDecay(timedecay).randomSeed(number);
+        GlobalLocalAnomalyDetector<float[]> newDetector = new GlobalLocalAnomalyDetector<>(reservoir, reservoir,
+                builder, Summarizer::L1distance);
+        assertEquals(newDetector.getCapacity(), size);
+        assertEquals(newDetector.getClusters(), null);
+        assertEquals(newDetector.numberOfRepresentatives, reps);
+        assertEquals(newDetector.shrinkage, newShrinkage);
+        float[] weight = newDetector.sampler.getWeightArray();
+        for (int i = 0; i < size - 1; i += 2) {
+            assert (weight[i] >= weight[i + 1]);
+        }
+        file.close();
+    }
+
+    double precision(int truePos, int falsePos) {
+        return (truePos + falsePos > 0) ? 1.0 * truePos / (truePos + falsePos) : 1.0;
+    }
+
+    double recall(int truePos, int falseNeg) {
+        return (truePos + falseNeg > 0) ? 1.0 * truePos / (truePos + falseNeg) : 1.0;
+    }
+
+}

--- a/Rust/Cargo.toml
+++ b/Rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rcf"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/Rust/src/common/conditionalfieldsummarizer.rs
+++ b/Rust/src/common/conditionalfieldsummarizer.rs
@@ -63,7 +63,7 @@ impl FieldSummarizer {
         let mut threshold = 0.0;
         if self.centrality > 0.0 {
             let mut always_include = 0;
-            while always_include < point_list_with_distance.len()
+            while always_include < point_list_with_distance.len() - 1
                 && distance_list[always_include] == 0.0
             {
                 always_include += 1;


### PR DESCRIPTION

*Description of changes:* This PR (i) extends the RCFMultiSummarize to operate on a time decay reservoir sample with periodic (self determined) recompilation of the clustering and provides an anomaly detector for an arbitrary type provided a distance function can be defined (and input). That input distance function is the global distance function. At the same time each point can be scored based on a reordering of the cluster representatives based on a local distance from the point being scored -- such a local distance can be based on the point being scored and can be useful in semi-supervision or similar strategies. This reuses components of TRCF and provides a single process() function that simultaneously returns a score/anomaly descriptor and updates internal state similar to TRCF.  (ii) It raises a natural question if this new generic algorithm should be applied to numeric vectors -- towards that end the PR also introduced a forest mode DISTANCE for TRCF where the distance function computed in the existing density estimation is exposed as an alternative score (and attribution, whose components sum to the score). It is worth noting that RCF corresponds to a recursive partitioning based strategy which is not unlike partition based clustering. Examples are provided that compare both of these in a dynamic setting. Overall the PR enables the use of the existing pieces of the RCF machinery to provide alternatives and comparisons.

