### PR TITLE
fixing gpg signing

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -20,9 +20,9 @@ jobs:
     name: Build project and publish release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 1.8
         server-id: ossrh-release
@@ -37,7 +37,7 @@ jobs:
       run: mvn -B package --file pom.xml
     - name: Publish to Maven central
       if: ${{ !endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
-      run: mvn --batch-mode -Dgpg.passphrase=${{ secrets.MAVEN_GPG_PASSPHRASE }} deploy --file pom.xml
+      run: mvn -B deploy --file pom.xml -Pgpg-sign
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
       - name: Publish to snapshot repo
         if: ${{ endsWith(steps.project.outputs.version, '-SNAPSHOT') }}
-        run: mvn clean --batch-mode -Dgpg.passphrase=${{ secrets.MAVEN_GPG_PASSPHRASE }} deploy 
+        run: mvn -B deploy --file pom.xml -Pgpg-sign
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -157,26 +157,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>
                 <executions>
@@ -244,4 +224,33 @@
         <developerConnection>scm:git:ssh://github.com/aws/random-cut-forest-by-aws.git</developerConnection>
         <url>https://github.com/aws/random-cut-forest-by-aws/tree/main</url>
     </scm>
+    <profiles>
+    <profile>
+      <id>gpg-sign</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION

*Description of changes:*
Fixing gpg signing as the official release script failed for 2.5 because it didn't recognize the mvn deploy command. Tried this fix locally with mvn install but no way to officially test it all the way as it would require actually releasing to staging first. took inspiration from change that was made in this PR, https://github.com/acm19/aws-request-signing-apache-interceptor/pull/44/files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
