### PR TITLE
adding release notes workflow

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,45 @@
+# The overall template of the release notes
+template: |
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: "* $TITLE ([#$NUMBER]($URL))"
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
+
+# Organizing the tagged PRs into unified categories
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking change"
+  - title: "Features"
+    labels:
+      - "feature"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+      - "bug fix"
+  - title: "Infrastructure"
+    labels:
+      - "infra"
+      - "test"
+      - "dependencies"
+      - "github actions"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Maintenance"
+    labels:
+      - "version upgrade"
+      - "odfe release"
+  - title: "Refactoring"
+    labels:
+      - "refactor"
+      - "code quality"

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          name: Version (set here)
+          tag: (None)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         java-version: 17
         cache: maven
-        server-id: ossrh-release
+        server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/Java/RELEASING.md
+++ b/Java/RELEASING.md
@@ -1,0 +1,24 @@
+- [Overview](#overview)
+- [Feature Branches](#feature-branches)
+- [Release Labels](#release-labels)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for the Random Cut Forest project.
+
+## Feature Branches
+
+Do not create branches in the upstream repo, use your fork, for the exception of long lasting feature branches that require active collaboration from multiple developers. Name feature branches `feature/<thing>`. Once the work is merged to `main`, please make sure to delete the feature branch.
+
+## Release Labels
+
+Repositories create consistent release labels, such as `3.0.0-java`. Use release labels to target an issue or a PR for a given release.
+
+## Releasing
+
+The release process is run by a release manager volunteering from amongst the maintainers.
+
+1. Create a PR to bump version to desired release candidate (e.g. 3.0.0)
+2. Click run on the maven-release workflow in Github Actions which uploads the artifacts to our staging repository, creates a new tag, and a new Github release
+3. Login into the nexus staging repositor , verify artifact was signed succesfully and click release to officially push to maven central.

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -214,7 +214,7 @@
             <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh-release</id>
+            <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
*Description of changes:*

This PR adds a workflow to easily add release notes from any PRs after this (same as OpenSearch Org uses). If we want to correspond a PR to a specific type of change (infra, bug fix, enhancement and etc.) we can simply add a label to the PR. These can always be easily edited in the releases section of github as well. Also making a small change to server id for maven release as we use the staging plugin in our pom file which caused the issues with auto release that could only be caught in official releases. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
