### PR TITLE
Upgrading nexus staging plugin version

### DIFF
--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.2</version>
     </dependency>
     <dependency>
       <groupId>io.protostuff</groupId>

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>io.protostuff</groupId>

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.0-rc1</version>
+      <version>2.14.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -184,7 +184,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
*Description of changes:*
Upgrading nexus-staging-maven-plugin due to receiving the following error on the latest workflow:  
```
Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:deploy (injected-nexus-deploy) on project randomcutforest-parent: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:deploy failed: 
An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.7:deploy: java.lang.ExceptionInInitializerError: null 
```

After looking around, I found this is an error specific to the compatibility of the nexus-staging-maven-plugin with JDK 17. There are multiple issues opened on Sonatype related to this (https://issues.sonatype.org/browse/OSSRH-77531, https://issues.sonatype.org/browse/OSSRH-66257, https://issues.sonatype.org/browse/NEXUS-26993) .

One of the workarounds is too add `MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED"` as an environment variable to the GitHub Actions. Another solution however was to upgrade the stream dependency which was done in the latest release of the plugin. Based on this comment it was solved for some of the user by upgrading the staging plugin to 1.6.13 (https://issues.sonatype.org/browse/NEXUS-27902?focusedId=1161045&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1161045) however people are still complaining as of January 2023 that there is no official solution for everyone. This has worked for me when testing against a local nexus server, however it would require paying money to get the nexus license that is identical to what the official release environment has so I am as confident as can be for now. Another option is to be okay with the workaround here of adding `MAVEN_OPTS`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
