### PR TITLE
cleanup and initiating 3.7.0-SNAPSHOT

### DIFF
--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>

--- a/Java/core/pom.xml
+++ b/Java/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/AbstractForestUpdateExecutor.java
@@ -15,8 +15,6 @@
 
 package com.amazon.randomcutforest.executor;
 
-import static com.amazon.randomcutforest.util.ArrayUtils.cleanCopy;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -60,20 +58,19 @@ public abstract class AbstractForestUpdateExecutor<PointReference, Point> {
      *
      * @param point The point used to update the forest.
      */
-    public void update(float[] point) {
+    public void update(Point point) {
         long internalSequenceNumber = updateCoordinator.getTotalUpdates();
-        IPointStore<?> store = updateCoordinator.getStore();
+        IPointStore<?, ?> store = updateCoordinator.getStore();
         if (store != null && store.isInternalShinglingEnabled()) {
             internalSequenceNumber -= store.getShingleSize() - 1;
         }
         update(point, internalSequenceNumber);
     }
 
-    public void update(float[] point, long sequenceNumber) {
-        float[] pointCopy = cleanCopy(point);
-        PointReference updateInput = updateCoordinator.initUpdate(pointCopy, sequenceNumber);
+    public void update(Point point, long sequenceNumber) {
+        PointReference updateInput = updateCoordinator.initUpdate(point, sequenceNumber);
         List<UpdateResult<PointReference>> results = (updateInput == null) ? Collections.emptyList()
-                : update(updateInput, sequenceNumber);
+                : updateInternal(updateInput, sequenceNumber);
         updateCoordinator.completeUpdate(results, updateInput);
     }
 
@@ -87,6 +84,6 @@ public abstract class AbstractForestUpdateExecutor<PointReference, Point> {
      * @return a list of points that were deleted from the model as part of the
      *         update.
      */
-    protected abstract List<UpdateResult<PointReference>> update(PointReference updateInput, long currentIndex);
+    protected abstract List<UpdateResult<PointReference>> updateInternal(PointReference updateInput, long currentIndex);
 
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/IStateCoordinator.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/IStateCoordinator.java
@@ -38,11 +38,11 @@ public interface IStateCoordinator<PointReference, Point> {
      * @return The point transformed into the representation expected by an
      *         IUpdatable instance.
      */
-    PointReference initUpdate(float[] point, long sequenceNumber);
+    PointReference initUpdate(Point point, long sequenceNumber);
 
     /**
      * Complete the update. This method is called by IStateCoordinator after all
-     * IUpdabale instances have completed their individual updates. This method
+     * IUpdatable instances have completed their individual updates. This method
      * receives the list of points that were deleted IUpdatable instances for
      * further processing if needed.
      *
@@ -56,7 +56,7 @@ public interface IStateCoordinator<PointReference, Point> {
 
     void setTotalUpdates(long totalUpdates);
 
-    default IPointStore<Point> getStore() {
+    default IPointStore<PointReference, Point> getStore() {
         return null;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/ParallelForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/ParallelForestUpdateExecutor.java
@@ -43,7 +43,7 @@ public class ParallelForestUpdateExecutor<PointReference, Point>
     }
 
     @Override
-    protected List<UpdateResult<PointReference>> update(PointReference point, long seqNum) {
+    protected List<UpdateResult<PointReference>> updateInternal(PointReference point, long seqNum) {
         return submitAndJoin(() -> components.parallelStream().map(t -> t.update(point, seqNum))
                 .filter(UpdateResult::isStateChange).collect(Collectors.toList()));
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/PointStoreCoordinator.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/PointStoreCoordinator.java
@@ -30,15 +30,15 @@ import com.amazon.randomcutforest.store.PointStore;
 
 public class PointStoreCoordinator<Point> extends AbstractUpdateCoordinator<Integer, Point> {
 
-    private final IPointStore<Point> store;
+    private final IPointStore<Integer, Point> store;
 
-    public PointStoreCoordinator(IPointStore<Point> store) {
+    public PointStoreCoordinator(IPointStore<Integer, Point> store) {
         checkNotNull(store, "store must not be null");
         this.store = store;
     }
 
     @Override
-    public Integer initUpdate(float[] point, long sequenceNumber) {
+    public Integer initUpdate(Point point, long sequenceNumber) {
         int index = store.add(point, sequenceNumber);
         return (index == PointStore.INFEASIBLE_POINTSTORE_INDEX) ? null : index;
     }
@@ -55,7 +55,7 @@ public class PointStoreCoordinator<Point> extends AbstractUpdateCoordinator<Inte
         totalUpdates++;
     }
 
-    public IPointStore<Point> getStore() {
+    public IPointStore<Integer, Point> getStore() {
         return store;
     }
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/executor/SequentialForestUpdateExecutor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/executor/SequentialForestUpdateExecutor.java
@@ -35,7 +35,7 @@ public class SequentialForestUpdateExecutor<PointReference, Point>
     }
 
     @Override
-    protected List<UpdateResult<PointReference>> update(PointReference point, long seqNum) {
+    protected List<UpdateResult<PointReference>> updateInternal(PointReference point, long seqNum) {
         return components.stream().map(t -> t.update(point, seqNum)).filter(UpdateResult::isStateChange)
                 .collect(Collectors.toList());
     }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/RandomCutForestMapper.java
@@ -300,7 +300,7 @@ public class RandomCutForestMapper
     }
 
     public RandomCutForest singlePrecisionForest(RandomCutForest.Builder<?> builder, RandomCutForestState state,
-            IPointStore<float[]> extPointStore, List<ITree<Integer, float[]>> extTrees,
+            IPointStore<Integer, float[]> extPointStore, List<ITree<Integer, float[]>> extTrees,
             List<IStreamSampler<Integer>> extSamplers) {
 
         checkArgument(builder != null, "builder cannot be null");
@@ -313,7 +313,7 @@ public class RandomCutForestMapper
         Random random = builder.getRandom();
         ComponentList<Integer, float[]> components = new ComponentList<>();
         CompactRandomCutTreeContext context = new CompactRandomCutTreeContext();
-        IPointStore<float[]> pointStore = (extPointStore == null)
+        IPointStore<Integer, float[]> pointStore = (extPointStore == null)
                 ? new PointStoreMapper().toModel(state.getPointStoreState())
                 : extPointStore;
         PointStoreCoordinator<float[]> coordinator = new PointStoreCoordinator<>(pointStore);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeContext.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/tree/CompactRandomCutTreeContext.java
@@ -24,6 +24,6 @@ import com.amazon.randomcutforest.store.IPointStore;
 public class CompactRandomCutTreeContext {
     private int maxSize;
     private int dimension;
-    private IPointStore<?> pointStore;
+    private IPointStore<?, ?> pointStore;
     private Precision precision;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStore.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStore.java
@@ -20,9 +20,9 @@ package com.amazon.randomcutforest.store;
  * which can be added to a store by the update coordinator and made accessible
  * to the trees in a read only manner.
  * 
- * @param <Point> precision type
+ * @param <Point> type of input point
  */
-public interface IPointStore<Point> extends IPointStoreView<Point> {
+public interface IPointStore<PointReference, Point> extends IPointStoreView<Point> {
     /**
      * Adds to the store; there may be a loss of precision if enableFloat is on in
      * the Forest level. But external interface of the forest is double[]
@@ -31,11 +31,9 @@ public interface IPointStore<Point> extends IPointStoreView<Point> {
      * 
      * @param point       point to be added
      * @param sequenceNum sequence number of the point
-     * @return index of the stored point
+     * @return reference of the stored point
      */
-    int add(float[] point, long sequenceNum);
-
-    int add(double[] point, long sequenceNum);
+    PointReference add(Point point, long sequenceNum);
 
     // increments and returns the incremented value
     int incrementRefCount(int index);

--- a/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/store/IPointStoreView.java
@@ -24,19 +24,18 @@ import com.amazon.randomcutforest.summarization.ICluster;
  * A view of the PointStore that forces a read only access to the store.
  */
 public interface IPointStoreView<Point> {
+
     int getDimensions();
 
     int getCapacity();
 
-    boolean pointEquals(int index, Point point);
-
-    Point get(int index);
+    float[] getNumericVector(int index);
 
     float[] getInternalShingle();
 
     long getNextSequenceIndex();
 
-    float[] transformToShingledPoint(float[] input);
+    float[] transformToShingledPoint(Point input);
 
     boolean isInternalRotationEnabled();
 
@@ -45,17 +44,6 @@ public interface IPointStoreView<Point> {
     int getShingleSize();
 
     int[] transformIndices(int[] indexList);
-
-    /**
-     * useful for managing points, convex combinations, etc., e.g. needed for center
-     * of mass
-     * 
-     * @param index  identifier of the point
-     * @param factor multiplier
-     * @return the new point; or raises an exception if such an object cannot be
-     *         defined
-     */
-    Point getScaledPoint(int index, double factor);
 
     /**
      * Prints the point given the index, irrespective of the encoding of the point.

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/HyperTree.java
@@ -69,9 +69,9 @@ public class HyperTree extends RandomCutTree {
         if (pointList.size() == 0)
             return Null;
 
-        BoundingBox thisBox = new BoundingBox(pointStoreView.get(pointList.get(0)));
+        BoundingBox thisBox = new BoundingBox(pointStoreView.getNumericVector(pointList.get(0)));
         for (int i = 1; i < pointList.size(); i++) {
-            thisBox = (BoundingBox) thisBox.getMergedBox(pointStoreView.get(pointList.get(i)));
+            thisBox = (BoundingBox) thisBox.getMergedBox(pointStoreView.getNumericVector(pointList.get(i)));
         }
         if (thisBox.getRangeSum() <= 0) {
             return pointList.get(0) + nodeStore.getCapacity() + 1;
@@ -86,7 +86,8 @@ public class HyperTree extends RandomCutTree {
         List<Integer> rightList = new ArrayList<>();
 
         for (int j = 0; j < pointList.size(); j++) {
-            if (nodeStore.leftOf((float) cut.getValue(), cut.getDimension(), pointStoreView.get(pointList.get(j)))) {
+            if (nodeStore.leftOf((float) cut.getValue(), cut.getDimension(),
+                    pointStoreView.getNumericVector(pointList.get(j)))) {
                 leftList.add(pointList.get(j));
             } else
                 rightList.add(pointList.get(j));

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/NodeView.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/NodeView.java
@@ -89,7 +89,7 @@ public class NodeView implements INodeView {
 
     protected void setCurrentNode(int newNode, int index, boolean setBox) {
         currentNodeOffset = newNode;
-        leafPoint = tree.pointStoreView.get(index);
+        leafPoint = tree.pointStoreView.getNumericVector(index);
         if (setBox && tree.boundingBoxCacheFraction < SWITCH_FRACTION) {
             currentBox = new BoundingBox(leafPoint, leafPoint);
         }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -253,7 +253,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
             return pointIndex;
         } else {
 
-            float[] point = projectToTree(pointStoreView.get(pointIndex));
+            float[] point = projectToTree(pointStoreView.getNumericVector(pointIndex));
             checkArgument(point.length == dimension, () -> " mismatch in dimensions for " + pointIndex);
             Stack<int[]> pathToRoot = nodeStore.getPath(root, point, false);
             int[] first = pathToRoot.pop();
@@ -262,7 +262,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
             int leafSavedSibling = first[1];
             int sibling = leafSavedSibling;
             int leafPointIndex = getPointIndex(leafNode);
-            float[] oldPoint = projectToTree(pointStoreView.get(leafPointIndex));
+            float[] oldPoint = projectToTree(pointStoreView.getNumericVector(leafPointIndex));
             checkArgument(oldPoint.length == dimension, () -> " mismatch in dimensions for " + pointIndex);
 
             Stack<int[]> parentPath = new Stack<>();
@@ -372,7 +372,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
     public void addPointToPartialTree(Integer pointIndex, long sequenceIndex) {
 
         checkArgument(root != Null, " a null root is not a partial tree");
-        float[] point = projectToTree(pointStoreView.get(pointIndex));
+        float[] point = projectToTree(pointStoreView.getNumericVector(pointIndex));
         checkArgument(point.length == dimension, () -> " incorrect projection at index " + pointIndex);
 
         Stack<int[]> pathToRoot = nodeStore.getPath(root, point, false);
@@ -390,7 +390,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
             return;
         }
         int leafPointIndex = getPointIndex(leafNode);
-        float[] oldPoint = projectToTree(pointStoreView.get(leafPointIndex));
+        float[] oldPoint = projectToTree(pointStoreView.getNumericVector(leafPointIndex));
 
         checkArgument(oldPoint.length == dimension && Arrays.equals(point, oldPoint),
                 () -> "incorrect state on adding " + pointIndex);
@@ -404,7 +404,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
     public Integer deletePoint(Integer pointIndex, long sequenceIndex) {
 
         checkArgument(root != Null, " deleting from an empty tree");
-        float[] point = projectToTree(pointStoreView.get(pointIndex));
+        float[] point = projectToTree(pointStoreView.getNumericVector(pointIndex));
         checkArgument(point.length == dimension, () -> " incorrect projection at index " + pointIndex);
         Stack<int[]> pathToRoot = nodeStore.getPath(root, point, false);
         int[] first = pathToRoot.pop();
@@ -594,7 +594,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
 
     public BoundingBox getBox(int index) {
         if (isLeaf(index)) {
-            float[] point = projectToTree(pointStoreView.get(getPointIndex(index)));
+            float[] point = projectToTree(pointStoreView.getNumericVector(getPointIndex(index)));
             checkArgument(point.length == dimension, () -> "failure in projection at index " + index);
             return new BoundingBox(point, point);
         } else {
@@ -669,7 +669,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
 
     void growNodeBox(BoundingBox box, IPointStoreView<float[]> pointStoreView, int node, int sibling) {
         if (isLeaf(sibling)) {
-            float[] point = projectToTree(pointStoreView.get(getPointIndex(sibling)));
+            float[] point = projectToTree(pointStoreView.getNumericVector(getPointIndex(sibling)));
             checkArgument(point.length == dimension, () -> " incorrect projection at index " + sibling);
             box.addPoint(point);
         } else {
@@ -725,7 +725,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
     public float[] getPointSum(int index) {
         checkArgument(centerOfMassEnabled, " enable center of mass");
         if (isLeaf(index)) {
-            float[] point = projectToTree(pointStoreView.get(getPointIndex(index)));
+            float[] point = projectToTree(pointStoreView.getNumericVector(getPointIndex(index)));
             checkArgument(point.length == dimension, () -> " incorrect projection");
             int mass = getMass(index);
             for (int i = 0; i < point.length; i++) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/executor/ForestUpdateExecutorTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/executor/ForestUpdateExecutorTest.java
@@ -83,7 +83,7 @@ public class ForestUpdateExecutorTest {
 
     @ParameterizedTest
     @ArgumentsSource(TestExecutorProvider.class)
-    public void testUpdate(AbstractForestUpdateExecutor<Integer, ?> executor) {
+    public void testUpdate(AbstractForestUpdateExecutor<Integer, float[]> executor) {
         int addAndDelete = 4;
         int addOnly = 4;
 

--- a/Java/core/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/tree/RandomCutTreeTest.java
@@ -124,7 +124,8 @@ public class RandomCutTreeTest {
         assertThat(tree.getMass(), is(5));
         assertArrayEquals(new double[] { -1, 2 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, -1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, -1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(1L), 1);
 
@@ -137,7 +138,8 @@ public class RandomCutTreeTest {
         assertArrayEquals(new double[] { 0.0, 3.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 1, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 1, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(2L), 1);
 
@@ -150,12 +152,14 @@ public class RandomCutTreeTest {
         assertThat(tree.getMass(node), is(3));
         assertArrayEquals(new double[] { -1.0, 2.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, 0 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, 0 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(3L), 1);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 0, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 0, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(2));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(4L), 1);
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(5L), 1);
@@ -179,7 +183,8 @@ public class RandomCutTreeTest {
         assertArrayEquals(new double[] { 0.0, 2.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, -1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, -1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(1L), 1);
         // sibling node moves up and bounding box recomputed
@@ -193,13 +198,15 @@ public class RandomCutTreeTest {
         assertArrayEquals(new double[] { 1.0, 3.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { 0, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { 0, 1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(2));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(4L), 1);
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(5L), 1);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 1, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 1, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(2L), 1);
     }
@@ -218,7 +225,8 @@ public class RandomCutTreeTest {
         assertThat(tree.getMass(), is(4));
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, -1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, -1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(1L), 1);
 
@@ -231,12 +239,14 @@ public class RandomCutTreeTest {
         assertThat(tree.getCutValue(node), closeTo(-0.5, EPSILON));
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, 0 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, 0 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(3L), 1);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 0, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 0, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(2));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(4L), 1);
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(5L), 1);
@@ -256,13 +266,15 @@ public class RandomCutTreeTest {
         assertThat(tree.getMass(), is(4));
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, -1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, -1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(1L), 1);
         assertArrayEquals(new double[] { -1.0, 1.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, -1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, -1 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(1L), 1);
 
@@ -276,7 +288,8 @@ public class RandomCutTreeTest {
         assertArrayEquals(new double[] { 0.0, 2.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 1, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 1, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(2L), 1);
 
@@ -291,12 +304,14 @@ public class RandomCutTreeTest {
         assertArrayEquals(new double[] { -1.0, 1.0 }, toDoubleArray(tree.getPointSum(node)), EPSILON);
 
         assertThat(tree.isLeaf(tree.getLeftChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getLeftChild(node))), is(new float[] { -1, 0 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getLeftChild(node))),
+                is(new float[] { -1, 0 }));
         assertThat(tree.getMass(tree.getLeftChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getLeftChild(node))).get(3L), 1);
 
         assertThat(tree.isLeaf(tree.getRightChild(node)), is(true));
-        assertThat(tree.pointStoreView.get(tree.getPointIndex(tree.getRightChild(node))), is(new float[] { 0, 1 }));
+        assertThat(tree.pointStoreView.getNumericVector(tree.getPointIndex(tree.getRightChild(node))),
+                is(new float[] { 0, 1 }));
         assertThat(tree.getMass(tree.getRightChild(node)), is(1));
         assertEquals(tree.getSequenceMap(tree.getPointIndex(tree.getRightChild(node))).get(5L), 1);
     }
@@ -325,7 +340,7 @@ public class RandomCutTreeTest {
         pointStoreFloat.add(toFloatArray(points.get(1).getValue()), 1);
         tree.addPoint(0, points.get(0).getSequenceIndex());
         tree.addPoint(1, points.get(1).getSequenceIndex());
-        assertNotEquals(pointStoreFloat.get(0)[0], pointStoreFloat.get(1)[0]);
+        assertNotEquals(pointStoreFloat.getNumericVector(0)[0], pointStoreFloat.getNumericVector(1)[0]);
 
         for (int i = 0; i < 10000; i++) {
             Weighted<double[]> point = points.get(i % points.size());

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>randomcutforest-examples</artifactId>

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-parkservices</artifactId>

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
@@ -16,6 +16,8 @@
 package com.amazon.randomcutforest.parkservices.preprocessor;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
 import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
 import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
@@ -320,7 +322,7 @@ public class Preprocessor implements IPreprocessor {
 
         double[] point;
         if (forest.isInternalShinglingEnabled()) {
-            point = forest.transformToShingledPoint(scaledInput);
+            point = toDoubleArray(forest.transformToShingledPoint(toFloatArray(scaledInput)));
         } else {
             int dimension = forest.getDimensions();
             if (scaledInput.length == dimension) {

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>software.amazon.randomcutforest:randomcutforest</name>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>randomcutforest-serialization</artifactId>

--- a/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV3StateConverter.java
+++ b/Java/serialization/src/main/java/com/amazon/randomcutforest/serialize/json/v1/V1JsonToV3StateConverter.java
@@ -16,6 +16,7 @@
 package com.amazon.randomcutforest.serialize.json.v1;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -81,10 +82,10 @@ public class V1JsonToV3StateConverter {
     }
 
     static class SamplerConverter {
-        private final IPointStore pointStore;
+        private final IPointStore<Integer, float[]> pointStore;
         private final List<CompactSamplerState> compactSamplerStates;
         private final Precision precision;
-        private final ITree globalTree;
+        private final ITree<Integer, float[]> globalTree;
         private final int maxNumberOfTrees;
 
         public SamplerConverter(int dimensions, int capacity, Precision precision, int maxNumberOfTrees) {
@@ -113,9 +114,9 @@ public class V1JsonToV3StateConverter {
 
                 for (int i = 0; i < samples.length; i++) {
                     V1SerializedRandomCutForest.WeightedSamples sample = samples[i];
-                    double[] point = sample.getPoint();
-                    int index = pointStore.add(point, sample.getSequenceIndex());
-                    pointIndex[i] = (Integer) globalTree.addPoint(index, 0L);
+                    float[] point = toFloatArray(sample.getPoint());
+                    Integer index = pointStore.add(point, sample.getSequenceIndex());
+                    pointIndex[i] = globalTree.addPoint(index, 0L);
                     if (pointIndex[i] != index) {
                         pointStore.incrementRefCount(pointIndex[i]);
                         pointStore.decrementRefCount(index);

--- a/Java/testutils/pom.xml
+++ b/Java/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>3.6.0</version>
+    <version>3.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION

*Description of changes:* The goal of the changes in this PR (and subsequent ones) leading up to 4.0 is to enable RCF to handle generic numeric as well as non-numeric objects. It has been known that RCFs can implement most functions of random forests over a stream https://opensearch.org/blog/random-cut-forests/

Much of that scaffolding was built in the in-situ transition from RCF 1.0 to RCF 3.0 to enable simultaneously running different precision forests (RCF 1.0 was double precision), as well as pointer based versus compact representations, using the same code. At the same time other functionalities such as ParkServices used double precision and it seemed prudent to not change too many facets. Double precision has been deprecated and will not be available in RCF 4.0. This PR begins cleanup alongside doubling down on generics. Subsequent PRs will handle ParkServices. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
