### PR TITLE
ungrading thresholding and fixing RCFCaster errors for initial values

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/Version.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/Version.java
@@ -20,4 +20,5 @@ public class Version {
     public static final String V2_1 = "2.1";
     public static final String V3_0 = "3.0";
     public static final String V3_5 = "3.5";
+    public static final String V3_7 = "3.7";
 }

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedMultiDimensionalExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedMultiDimensionalExample.java
@@ -47,7 +47,7 @@ public class ThresholdedMultiDimensionalExample implements Example {
     public void run() throws Exception {
         // Create and populate a random cut forest
 
-        int shingleSize = 4;
+        int shingleSize = 8;
         int numberOfTrees = 50;
         int sampleSize = 256;
         Precision precision = Precision.FLOAT_32;
@@ -55,7 +55,7 @@ public class ThresholdedMultiDimensionalExample implements Example {
 
         // change this to try different number of attributes,
         // this parameter is not expected to be larger than 5 for this example
-        int baseDimensions = 2;
+        int baseDimensions = 3;
 
         int dimensions = baseDimensions * shingleSize;
         ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
@@ -64,21 +64,21 @@ public class ThresholdedMultiDimensionalExample implements Example {
                 .internalShinglingEnabled(true).transformMethod(TransformMethod.NORMALIZE).precision(precision)
                 .anomalyRate(0.01).forestMode(ForestMode.STANDARD).build();
 
-        long seed = new Random().nextLong();
+        long seed = 8720127486940943609L;
+        new Random().nextLong();
         System.out.println("seed = " + seed);
         // change the last argument seed for a different run
         MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(dataSize + shingleSize - 1, 50,
-                100, 5, seed, baseDimensions);
+                100, 5, seed, baseDimensions, 10.0, false);
         int keyCounter = 0;
         int count = 0;
         for (double[] point : dataWithKeys.data) {
 
             AnomalyDescriptor result = forest.process(point, 0L);
 
-            if (keyCounter < dataWithKeys.changeIndices.length
-                    && count + shingleSize - 1 == dataWithKeys.changeIndices[keyCounter]) {
-                System.out.println("timestamp " + (count + shingleSize - 1) + " CHANGE "
-                        + Arrays.toString(dataWithKeys.changes[keyCounter]));
+            if (keyCounter < dataWithKeys.changeIndices.length && count == dataWithKeys.changeIndices[keyCounter]) {
+                System.out.println(
+                        "timestamp " + (count) + " CHANGE " + Arrays.toString(dataWithKeys.changes[keyCounter]));
                 ++keyCounter;
             }
 

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedMultiDimensionalExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedMultiDimensionalExample.java
@@ -64,12 +64,26 @@ public class ThresholdedMultiDimensionalExample implements Example {
                 .internalShinglingEnabled(true).transformMethod(TransformMethod.NORMALIZE).precision(precision)
                 .anomalyRate(0.01).forestMode(ForestMode.STANDARD).build();
 
-        long seed = 8720127486940943609L;
-        new Random().nextLong();
+        long seed = new Random().nextLong();
         System.out.println("seed = " + seed);
+
+        // basic amplitude of the waves -- the parameter will be randomly scaled up
+        // betwee 0-20 percent
+        double amplitude = 100.0;
+
+        // the amplitude of random noise it will be +ve/-ve uniformly at random
+        double noise = 5.0;
+
+        // the following controls the ratio of anomaly magnitude to noise
+        // notice amplitude/noise would determine signal-to-noise ratio
+        double anomalyFactor = 5;
+
+        // the following determines if a random linear trend should be added
+        boolean useSlope = false;
+
         // change the last argument seed for a different run
         MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(dataSize + shingleSize - 1, 50,
-                100, 5, seed, baseDimensions, 10.0, false);
+                amplitude, noise, seed, baseDimensions, anomalyFactor, useSlope);
         int keyCounter = 0;
         int count = 0;
         for (double[] point : dataWithKeys.data) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ErrorHandler.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ErrorHandler.java
@@ -148,7 +148,7 @@ public class ErrorHandler {
                 pastForecasts[i] = new RangeVector(values, upper, lower);
                 System.arraycopy(actualsFlattened, i * inputLength, actuals[i], 0, inputLength);
             }
-            calibrate();
+            calibrate(null);
         }
     }
 
@@ -171,7 +171,7 @@ public class ErrorHandler {
             actuals[errorIndex][i] = (float) input[i];
         }
         ++sequenceIndex;
-        calibrate();
+        calibrate(descriptor.deviations);
         if (calibrationMethod != Calibration.NONE) {
             if (calibrationMethod == Calibration.SIMPLE) {
                 adjust(descriptor.timedForecast.rangeVector, errorDistribution);
@@ -260,8 +260,8 @@ public class ErrorHandler {
                         double fracRank = percentile * len;
                         Arrays.sort(copy);
                         values[pos] = interpolatedMedian(copy);
-                        lower[pos] = interpolatedLowerRank(copy, fracRank);
-                        upper[pos] = interpolatedUpperRank(copy, len, fracRank);
+                        lower[pos] = interpolatedLowerRank(copy, fracRank, 0);
+                        upper[pos] = interpolatedUpperRank(copy, len, fracRank, 0);
                     }
                 }
             }
@@ -286,8 +286,11 @@ public class ErrorHandler {
      * this method computes a lot of different quantities, some of which would be
      * useful in the future.In particular it splits the RMSE into positive and
      * negative contribution which is informative about directionality of error.
+     *
+     *
+     * @param errorDeviations the weighted standard deviations seen so far
      */
-    protected void calibrate() {
+    protected void calibrate(double[] errorDeviations) {
         int inputLength = actuals[0].length;
         int arrayLength = pastForecasts.length;
         int errorIndex = (sequenceIndex - 1 + arrayLength) % arrayLength;
@@ -328,15 +331,17 @@ public class ErrorHandler {
                     errorRMSE.low[pos] = (positiveCount < len) ? -Math.sqrt(negativeSqSum / (len - positiveCount)) : 0;
                     Arrays.sort(medianError, 0, len);
                     errorDistribution.values[pos] = interpolatedMedian(medianError);
-                    errorDistribution.upper[pos] = interpolatedUpperRank(medianError, len, len * percentile);
-                    errorDistribution.lower[pos] = interpolatedLowerRank(medianError, len * percentile);
+                    double deviation = (errorDeviations == null) ? 0 : errorDeviations[j];
+                    errorDistribution.upper[pos] = interpolatedUpperRank(medianError, len, len * percentile, deviation);
+                    errorDistribution.lower[pos] = interpolatedLowerRank(medianError, len * percentile, deviation);
                     intervalPrecision[pos] = intervalPrecision[pos] / len;
                 } else {
                     errorMean[pos] = 0;
                     errorRMSE.high[pos] = errorRMSE.low[pos] = 0;
                     errorDistribution.values[pos] = 0;
-                    errorDistribution.upper[pos] = Float.MAX_VALUE;
-                    errorDistribution.lower[pos] = -Float.MAX_VALUE;
+                    double deviation = (errorDeviations == null) ? 0 : errorDeviations[j];
+                    errorDistribution.upper[pos] = (float) (1.3 * deviation);
+                    errorDistribution.lower[pos] = -(float) (1.3 * deviation);
                     adders.upper[pos] = adders.lower[pos] = adders.values[pos] = 0;
                     intervalPrecision[pos] = 0;
                 }
@@ -354,9 +359,9 @@ public class ErrorHandler {
         }
     }
 
-    float interpolatedLowerRank(double[] array, double fracRank) {
+    float interpolatedLowerRank(double[] array, double fracRank, double deviation) {
         if (fracRank < 1) {
-            return -Float.MAX_VALUE;
+            return (float) (-1.3 * deviation * (1 - fracRank) + fracRank * array[0]);
         }
         int rank = (int) Math.floor(fracRank);
         if (!RCFCaster.USE_INTERPOLATION_IN_DISTRIBUTION) {
@@ -366,9 +371,9 @@ public class ErrorHandler {
         return (float) (array[rank - 1] + (fracRank - rank) * (array[rank] - array[rank - 1]));
     }
 
-    float interpolatedUpperRank(double[] array, int len, double fracRank) {
+    float interpolatedUpperRank(double[] array, int len, double fracRank, double deviation) {
         if (fracRank < 1) {
-            return Float.MAX_VALUE;
+            return (float) (1.3 * deviation * (1 - fracRank) + fracRank * array[len - 1]);
         }
         int rank = (int) Math.floor(fracRank);
         if (!RCFCaster.USE_INTERPOLATION_IN_DISTRIBUTION) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ErrorHandler.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ErrorHandler.java
@@ -330,6 +330,7 @@ public class ErrorHandler {
                     errorRMSE.high[pos] = (positiveCount > 0) ? Math.sqrt(positiveSqSum / positiveCount) : 0;
                     errorRMSE.low[pos] = (positiveCount < len) ? -Math.sqrt(negativeSqSum / (len - positiveCount)) : 0;
                     Arrays.sort(medianError, 0, len);
+                    // medianError array is now sorted
                     errorDistribution.values[pos] = interpolatedMedian(medianError);
                     double deviation = (errorDeviations == null) ? 0 : errorDeviations[j];
                     errorDistribution.upper[pos] = interpolatedUpperRank(medianError, len, len * percentile, deviation);
@@ -359,28 +360,30 @@ public class ErrorHandler {
         }
     }
 
-    float interpolatedLowerRank(double[] array, double fracRank, double deviation) {
+    float interpolatedLowerRank(double[] ascendingArray, double fracRank, double deviation) {
         if (fracRank < 1) {
-            return (float) (-1.3 * deviation * (1 - fracRank) + fracRank * array[0]);
+            return (float) (-1.3 * deviation * (1 - fracRank) + fracRank * ascendingArray[0]);
         }
         int rank = (int) Math.floor(fracRank);
         if (!RCFCaster.USE_INTERPOLATION_IN_DISTRIBUTION) {
             // turn off interpolation
             fracRank = rank;
         }
-        return (float) (array[rank - 1] + (fracRank - rank) * (array[rank] - array[rank - 1]));
+        return (float) (ascendingArray[rank - 1]
+                + (fracRank - rank) * (ascendingArray[rank] - ascendingArray[rank - 1]));
     }
 
-    float interpolatedUpperRank(double[] array, int len, double fracRank, double deviation) {
+    float interpolatedUpperRank(double[] ascendingArray, int len, double fracRank, double deviation) {
         if (fracRank < 1) {
-            return (float) (1.3 * deviation * (1 - fracRank) + fracRank * array[len - 1]);
+            return (float) (1.3 * deviation * (1 - fracRank) + fracRank * ascendingArray[len - 1]);
         }
         int rank = (int) Math.floor(fracRank);
         if (!RCFCaster.USE_INTERPOLATION_IN_DISTRIBUTION) {
             // turn off interpolation
             fracRank = rank;
         }
-        return (float) (array[len - rank] + (fracRank - rank) * (array[len - rank - 1] - array[len - rank]));
+        return (float) (ascendingArray[len - rank]
+                + (fracRank - rank) * (ascendingArray[len - rank - 1] - ascendingArray[len - rank]));
     }
 
     void adjust(RangeVector rangeVector, RangeVector other) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
@@ -450,13 +450,19 @@ public class PredictorCorrector {
             if (newPoint != null && result.getForestMode() != ForestMode.DISTANCE) {
                 newAttribution = forest.getAnomalyAttribution(newPoint);
                 newScore = newAttribution.getHighLowSum();
-                boolean significantScore = (score > 1.5 || score > thresholder.getPrimaryThreshold())
-                        || score > newScore + 0.25;
-                // ignore late anomalies for larger shingleSizes unless the score differential
-                // is large
+                // score is large, significantly over the threshold, or the change of a single
+                // entry
+                // causes a significant change in anomaly score
+                // and no anomaly has not yet been reported on this shingle
+                boolean significantScore = score > 1.5 || score > workingThreshold + 0.25
+                        || (score > newScore + 0.25 && gap > shingleSize);
+                // ignore late anomalies for larger shingleSizes unless the score
+                // is considered signficant
                 significant = (shingleSize > 4 && index + shingleSize / 2 > 0) || significantScore;
-                int base = (result.forestMode == ForestMode.TIME_AUGMENTED) ? baseDimensions - 1 : baseDimensions;
                 if (significant) {
+                    // time augmented mode will be improved later -- that would require extra
+                    // information
+                    int base = (result.forestMode == ForestMode.TIME_AUGMENTED) ? baseDimensions - 1 : baseDimensions;
                     significant = isSignificant(significantScore, point, newPoint, startPosition, base, result);
                 }
             }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
@@ -295,7 +295,10 @@ public class PredictorCorrector {
                 double delta = observedGap * scaleFactor;
                 double shiftBase = (shift == null) ? 0 : shift[y];
                 double shiftAmount = 0;
-                if (scaleFactor != 1.0 || shiftBase != 0) {
+
+                // the conditional below is redundant, since abs(shiftBase) is being multiplied
+                // but kept as a placeholder for tuning constants if desired
+                if (shiftBase != 0) {
                     double multiplier = (method == TransformMethod.NORMALIZE) ? 4 : 2;
                     shiftAmount += multiplier * DEFAULT_NORMALIZATION_PRECISION * Math.abs(shiftBase);
                 }
@@ -304,7 +307,9 @@ public class PredictorCorrector {
                 double a = Math.abs(scaleFactor * point[startPosition + y] + shiftBase);
                 double b = Math.abs(scaleFactor * newPoint[startPosition + y] + shiftBase);
 
-                // for non-trivial transformations
+                // for non-trivial transformations -- both transformations are used enable
+                // relative error
+                // the only transformation currently ruled out is TransformMethod.NONE
                 if (scaleFactor != 1.0 || shiftBase != 0) {
                     double multiplier = (method == TransformMethod.NORMALIZE) ? 2 : 1;
                     shiftAmount += multiplier * DEFAULT_NORMALIZATION_PRECISION * (scaleFactor + (a + b) / 2);
@@ -470,7 +475,7 @@ public class PredictorCorrector {
                 // score is large, significantly over the threshold, or the change of a single
                 // entry
                 // causes a significant change in anomaly score
-                // and no anomaly has not yet been reported on this shingle
+                // and no anomaly has yet been reported on this shingle
                 boolean significantScore = score > 1.5 || score > workingThreshold + 0.25
                         || (score > newScore + 0.25 && gap > shingleSize);
                 // significantScore is the signal sent; but can can be overruled by

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
@@ -185,7 +185,7 @@ public class RCFCaster extends ThresholdedRandomCutForest {
                     lastAnomalyDescriptor, forest);
             answer.setTimedForecast(timedForecast);
 
-            if (answer.internalTimeStamp > forest.getShingleSize() - 1 + forest.getOutputAfter()) {
+            if (answer.internalTimeStamp >= forest.getShingleSize() - 1 + forest.getOutputAfter()) {
                 errorHandler.update(answer, calibrationMethod);
             }
         } finally {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
@@ -90,8 +90,15 @@ public class RCFComputeDescriptor extends Point implements IRCFComputeDescriptor
      */
     int relativeIndex;
 
+    // useful for RCFCaster errors while the model is calibrating itself
+    // will be null except for RCFCaster
+    double[] deviations;
+
+    // the multiplication factors to convert RCF representation to actuals/input
     double[] scale;
 
+    // the addition performed (after multiplications) to convert RCF representation
+    // to actuals/input
     double[] shift;
 
     // expected RCFPoint for the current point

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -31,7 +31,7 @@ import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_AUTO_THRESHOLD;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_LOWER_THRESHOLD;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_LOWER_THRESHOLD_NORMALIZED;
-import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_THRESHOLD_PERSISTENCE;
+import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_SCORE_DIFFERENCING;
 
 import java.util.Arrays;
 import java.util.List;
@@ -141,7 +141,7 @@ public class ThresholdedRandomCutForest {
             predictorCorrector.setZfactor(2.5);
         }
 
-        predictorCorrector.setThresholdPersistence(builder.thresholdPersistence.orElse(DEFAULT_THRESHOLD_PERSISTENCE));
+        predictorCorrector.setScoreDifferencing(builder.scoreDifferencing.orElse(DEFAULT_SCORE_DIFFERENCING));
 
     }
 
@@ -347,11 +347,11 @@ public class ThresholdedRandomCutForest {
 
     @Deprecated
     public void setHorizon(double horizon) {
-        predictorCorrector.setThresholdPersistence(horizon);
+        predictorCorrector.setScoreDifferencing(horizon);
     }
 
-    public void setThresholdPersistence(double persistence) {
-        predictorCorrector.setThresholdPersistence(persistence);
+    public void setScoreDifferencing(double persistence) {
+        predictorCorrector.setScoreDifferencing(persistence);
     }
 
     @Deprecated
@@ -394,7 +394,7 @@ public class ThresholdedRandomCutForest {
         protected Optional<Integer> stopNormalization = Optional.empty();
         protected int numberOfTrees = DEFAULT_NUMBER_OF_TREES;
         protected Optional<Double> timeDecay = Optional.empty();
-        protected Optional<Double> thresholdPersistence = Optional.empty();
+        protected Optional<Double> scoreDifferencing = Optional.empty();
         protected Optional<Double> lowerThreshold = Optional.empty();
         protected Optional<Double> weightTime = Optional.empty();
         protected Optional<Long> randomSeed = Optional.empty();
@@ -608,8 +608,8 @@ public class ThresholdedRandomCutForest {
             return (T) this;
         }
 
-        public T thresholdPersistence(double persistence) {
-            this.thresholdPersistence = Optional.of(persistence);
+        public T scoreDifferencing(double persistence) {
+            this.scoreDifferencing = Optional.of(persistence);
             return (T) this;
         }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -28,6 +28,7 @@ import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SAMPLE_SIZE;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_STORE_SEQUENCE_INDEXES_ENABLED;
 import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
+import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_AUTO_THRESHOLD;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_LOWER_THRESHOLD;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_LOWER_THRESHOLD_NORMALIZED;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_THRESHOLD_PERSISTENCE;
@@ -414,7 +415,7 @@ public class ThresholdedRandomCutForest {
         protected double[] fillValues = null;
         protected double[] weights = null;
         protected Optional<Double> useImputedFraction = Optional.empty();
-        protected boolean adjustThreshold = false;
+        protected boolean adjustThreshold = DEFAULT_AUTO_THRESHOLD;
         protected Optional<Double> transformDecay = Optional.empty();
 
         void validate() {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
@@ -188,7 +188,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
         int savedNumberOfImputed = numberOfImputed;
         int lastActualInternal = internalTimeStamp;
 
-        double[] point = generateShingle(description, timeStampDeviation.getMean(), false, forest);
+        double[] point = generateShingle(description, timeStampDeviations[0].getMean(), false, forest);
 
         // restore state
         internalTimeStamp = lastActualInternal;
@@ -246,7 +246,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
             // two different points).
             return false;
         }
-        dataQuality.update(1 - fraction);
+        dataQuality[0].update(1 - fraction);
         return (fraction < useImputedFraction && internalTimeStamp >= shingleSize);
     }
 
@@ -304,7 +304,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
             addRelevantAttribution(result);
         }
 
-        generateShingle(result, timeStampDeviation.getMean(), true, forest);
+        generateShingle(result, timeStampDeviations[0].getMean(), true, forest);
         ++valuesSeen;
         return result;
     }
@@ -421,7 +421,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
 
         updateForest(changeForest, newInput, timestamp, forest, false);
         if (changeForest) {
-            timeStampDeviation.update(timestamp - lastInputTimeStamp);
+            timeStampDeviations[0].update(timestamp - lastInputTimeStamp);
             transformer.updateDeviation(newInput, savedInput);
         }
         return Arrays.copyOf(lastShingledPoint, lastShingledPoint.length);

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/InitialSegmentPreprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/InitialSegmentPreprocessor.java
@@ -55,11 +55,23 @@ public class InitialSegmentPreprocessor extends Preprocessor {
         if (valuesSeen < startNormalization) {
             storeInitial(description.getCurrentInput(), description.getInputTimestamp());
             return description;
-        } else if (valuesSeen == startNormalization) {
-            dischargeInitial(forest);
         }
 
         return super.preProcess(description, lastAnomalyDescriptor, forest);
+    }
+
+    // same for post process
+    @Override
+    public AnomalyDescriptor postProcess(AnomalyDescriptor description, IRCFComputeDescriptor lastAnomalyDescriptor,
+            RandomCutForest forest) {
+
+        AnomalyDescriptor answer = super.postProcess(description, lastAnomalyDescriptor, forest);
+
+        if (valuesSeen == startNormalization) {
+            dischargeInitial(forest);
+        }
+
+        return answer;
     }
 
     /**
@@ -112,7 +124,7 @@ public class InitialSegmentPreprocessor extends Preprocessor {
         for (int i = 0; i < valuesSeen; i++) {
             double[] scaledInput = getScaledInput(initialValues[i], initialTimeStamps[i], deviations, timeFactor);
             updateState(initialValues[i], scaledInput, initialTimeStamps[i], previousTimeStamps[shingleSize - 1]);
-            dataQuality.update(1.0);
+            dataQuality[0].update(1.0);
             forest.update(scaledInput);
         }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
@@ -86,8 +86,12 @@ public class Preprocessor implements IPreprocessor {
     // behavior
     public static int MINIMUM_OBSERVATIONS_FOR_EXPECTED = 100;
 
+    public static int DEFAULT_TIME_STATES = 3;
+
+    public static int DEFAULT_DATA_QUALITY_STATES = 1;
+
     // the input corresponds to timestamp data and this statistic helps align input
-    protected Deviation timeStampDeviation;
+    protected Deviation[] timeStampDeviations;
 
     // normalize time difference;
     protected boolean normalizeTime;
@@ -155,7 +159,7 @@ public class Preprocessor implements IPreprocessor {
     protected ForestMode mode;
 
     // measures the data quality in imputed modes
-    protected Deviation dataQuality;
+    protected Deviation[] dataQuality;
 
     protected ITransformer transformer;
 
@@ -209,33 +213,12 @@ public class Preprocessor implements IPreprocessor {
             lastShingledInput = new double[shingleSize * inputLength];
         }
         timeDecay = builder.timeDecay;
-        dataQuality = builder.dataQuality.orElse(new Deviation(timeDecay));
+        dataQuality = builder.dataQuality.orElse(new Deviation[] { new Deviation(timeDecay) });
 
         Deviation[] deviationList = new Deviation[NUMBER_OF_STATS * inputLength];
-        // we would use two different smoothing paramters reminiscent of
-        // doubly exponential smoothing
-        if (builder.deviations.isPresent()) {
-            Deviation[] list = builder.deviations.get();
-            // note the lengths can be different based on a different version of the model
-            // we will convert the model; and rely on RCF's ability to adjust to new data
-            for (int i = 0; i < min(list.length, deviationList.length); i++) {
-                deviationList[i] = list[i].copy();
-            }
-            for (int i = list.length; i < (NUMBER_OF_STATS - 1) * inputLength; i++) {
-                deviationList[i] = new Deviation(timeDecay);
-            }
-            for (int i = max(list.length, (NUMBER_OF_STATS - 1) * inputLength); i < NUMBER_OF_STATS
-                    * inputLength; i++) {
-                deviationList[i] = new Deviation(0.1 * timeDecay);
-            }
-        } else {
-            for (int i = 0; i < (NUMBER_OF_STATS - 1) * inputLength; i++) {
-                deviationList[i] = new Deviation(timeDecay);
-            }
-            for (int i = (NUMBER_OF_STATS - 1) * inputLength; i < NUMBER_OF_STATS * inputLength; i++) {
-                deviationList[i] = new Deviation(0.1 * timeDecay);
-            }
-        }
+        manageDeviations(deviationList, builder.deviations, timeDecay);
+        timeStampDeviations = new Deviation[DEFAULT_TIME_STATES];
+        manageDeviations(timeStampDeviations, builder.timeDeviations, timeDecay);
 
         if (transformMethod == TransformMethod.NONE) {
             for (int i = 0; i < inputLength; i++) {
@@ -254,8 +237,6 @@ public class Preprocessor implements IPreprocessor {
             transformer = new NormalizedDifferenceTransformer(weights, deviationList);
         }
 
-        timeStampDeviation = builder.timeDeviation.orElse(new Deviation(timeDecay));
-
         if (mode == ForestMode.STREAMING_IMPUTE) {
             imputationMethod = builder.imputationMethod;
             normalizeTime = true;
@@ -268,6 +249,31 @@ public class Preprocessor implements IPreprocessor {
                 this.defaultFill = Arrays.copyOf(builder.fillValues, builder.fillValues.length);
             }
             this.useImputedFraction = builder.useImputedFraction.orElse(0.5);
+        }
+    }
+
+    // the following fills the first argument as copies of the original
+    // but if the original is null or otherwise then new deviations are created; the
+    // last third
+    // are filled with 0.1 * timeDecay and are reserved for smoothing
+    void manageDeviations(Deviation[] deviationList, Optional<Deviation[]> original, double timeDecay) {
+        checkArgument(deviationList.length % 3 == 0, " has to be a multiple of three");
+        int usedDeviations = 0;
+        if (original.isPresent()) {
+            Deviation[] list = original.get();
+            usedDeviations = min(list.length, deviationList.length);
+            // note the lengths can be different based on a different version of the model
+            // we will convert the model; and rely on RCF's ability to adjust to new data
+            for (int i = 0; i < usedDeviations; i++) {
+                deviationList[i] = list[i].copy();
+            }
+        }
+        for (int i = usedDeviations; i < deviationList.length - deviationList.length / 3; i++) {
+            deviationList[i] = new Deviation(timeDecay);
+        }
+        usedDeviations = max(usedDeviations, deviationList.length - deviationList.length / 3);
+        for (int i = usedDeviations; i < deviationList.length; i++) {
+            deviationList[i] = new Deviation(0.1 * timeDecay);
         }
     }
 
@@ -300,7 +306,7 @@ public class Preprocessor implements IPreprocessor {
         description.setLastAnomalyInternalTimestamp(lastAnomalyDescriptor.getInternalTimeStamp());
         description.setLastExpectedRCFPoint(lastAnomalyDescriptor.getExpectedRCFPoint());
         description.setDataConfidence(forest.getTimeDecay(), valuesSeen, forest.getOutputAfter(),
-                dataQuality.getMean());
+                dataQuality[0].getMean());
         description.setShingleSize(shingleSize);
         description.setInputLength(inputLength);
         description.setDimension(dimension);
@@ -355,7 +361,10 @@ public class Preprocessor implements IPreprocessor {
         description.setRCFPoint(point);
         description.setInternalTimeStamp(internalTimeStamp); // no impute
         description.setScale(transformer.getScale());
-        description.setShift(transformer.getShift());
+        double[] previous = (inputPoint.length == lastShingledInput.length) ? lastShingledInput
+                : getShingledInput(shingleSize - 1);
+        description.setShift(transformer.getShift(previous));
+        description.setDeviations(transformer.getErrorDeviations());
         description.setNumberOfNewImputes(0);
         return description;
     }
@@ -383,7 +392,7 @@ public class Preprocessor implements IPreprocessor {
         long timestamp = result.getInputTimestamp();
         updateState(inputPoint, point, timestamp, previousTimeStamps[shingleSize - 1]);
         ++valuesSeen;
-        dataQuality.update(1.0);
+        dataQuality[0].update(1.0);
         if (forest.isInternalShinglingEnabled()) {
             int length = inputLength + ((mode == ForestMode.TIME_AUGMENTED) ? 1 : 0);
             double[] scaledInput = new double[length];
@@ -482,7 +491,7 @@ public class Preprocessor implements IPreprocessor {
         }
         if (normalizeTime) {
             return (long) Math.round(
-                    timestamp + timeStampDeviation.getMean() + 2 * gap * timeStampDeviation.getDeviation() / factor);
+                    timestamp + timeStampDeviations[0].getMean() + 2 * gap * timeStampDeviations[2].getMean() / factor);
         } else {
             return (long) Math.round(gap / factor + timestamp);
         }
@@ -584,8 +593,8 @@ public class Preprocessor implements IPreprocessor {
             // and therefore for STREAMING_INPUTE the timestamps values are not predicted
             // and kept at 0
             if (mode != ForestMode.STREAMING_IMPUTE) {
-                double timeGap = (normalizeTime) ? 0 : timeStampDeviation.getMean();
-                double timeBound = (normalizeTime) ? 2.5 : 2.5 * timeStampDeviation.getDeviation();
+                double timeGap = (normalizeTime) ? 0 : timeStampDeviations[0].getMean();
+                double timeBound = (normalizeTime) ? 2.5 : 2.5 * timeStampDeviations[2].getMean();
 
                 for (int i = 0; i < horizon; i++) {
                     timedRangeVector.timeStamps[i] = inverseMapTimeValue(timeGap, localTimeStamp);
@@ -684,8 +693,10 @@ public class Preprocessor implements IPreprocessor {
      * @param previous    the previous timestamp
      */
     protected void updateState(double[] inputPoint, double[] scaledInput, long timestamp, long previous) {
-        if (timeStampDeviation != null) {
-            timeStampDeviation.update(timestamp - previous);
+        if (timeStampDeviations != null) {
+            timeStampDeviations[0].update(timestamp - previous);
+            // smoothing
+            timeStampDeviations[2].update(timeStampDeviations[0].getDeviation());
         }
         updateTimestamps(timestamp);
         double[] previousInput = (inputLength == lastShingledInput.length) ? lastShingledInput
@@ -722,18 +733,19 @@ public class Preprocessor implements IPreprocessor {
      *
      * @param value     input value of dimension
      * @param deviation statistic
+     * @param factor    a control parameter for deviation
      * @return the normalized value
      */
-    protected double normalize(double value, Deviation deviation, double factor) {
-        double currentFactor = (factor != 0) ? factor : deviation.getDeviation();
-        if (value - deviation.getMean() >= 2 * clipFactor * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
+    protected double normalize(double value, Deviation[] deviation, double factor) {
+        double currentFactor = (factor != 0) ? factor : Math.abs(deviation[2].getMean());
+        if (value - deviation[0].getMean() >= 2 * clipFactor * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return clipFactor;
         }
-        if (value - deviation.getMean() < -2 * clipFactor * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
+        if (value - deviation[0].getMean() < -2 * clipFactor * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return -clipFactor;
         } else {
             // deviation cannot be 0
-            return (value - deviation.getMean()) / (2 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION));
+            return (value - deviation[0].getMean()) / (2 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION));
         }
     }
 
@@ -754,7 +766,7 @@ public class Preprocessor implements IPreprocessor {
         } else {
             double timeShift = timestamp - previousTimeStamps[shingleSize - 1];
             scaledInput[normalized.length] = weightTime
-                    * ((normalizeTime) ? normalize(timeShift, timeStampDeviation, timeFactor) : timeShift);
+                    * ((normalizeTime) ? normalize(timeShift, timeStampDeviations, timeFactor) : timeShift);
         }
         return scaledInput;
     }
@@ -822,8 +834,8 @@ public class Preprocessor implements IPreprocessor {
     }
 
     // mapper
-    public Deviation getTimeStampDeviation() {
-        return timeStampDeviation;
+    public Deviation[] getTimeStampDeviations() {
+        return timeStampDeviations;
     }
 
     // mapper
@@ -906,8 +918,8 @@ public class Preprocessor implements IPreprocessor {
         protected ThresholdedRandomCutForest thresholdedRandomCutForest = null;
         protected Optional<Double> useImputedFraction = Optional.empty();
         protected Optional<Deviation[]> deviations = Optional.empty();
-        protected Optional<Deviation> timeDeviation = Optional.empty();
-        protected Optional<Deviation> dataQuality = Optional.empty();
+        protected Optional<Deviation[]> timeDeviations = Optional.empty();
+        protected Optional<Deviation[]> dataQuality = Optional.empty();
 
         public Preprocessor build() {
             if (forestMode == ForestMode.STREAMING_IMPUTE) {
@@ -997,19 +1009,25 @@ public class Preprocessor implements IPreprocessor {
 
         // mapper
         public T deviations(Deviation[] deviations) {
-            this.deviations = Optional.of(deviations);
+            if (deviations != null) {
+                this.deviations = Optional.of(deviations);
+            }
             return (T) this;
         }
 
         // mapper
-        public T dataQuality(Deviation dataQuality) {
-            this.dataQuality = Optional.of(dataQuality);
+        public T dataQuality(Deviation[] dataQuality) {
+            if (dataQuality != null) {
+                this.dataQuality = Optional.of(dataQuality);
+            }
             return (T) this;
         }
 
         // mapper
-        public T timeDeviation(Deviation timeDeviation) {
-            this.timeDeviation = Optional.of(timeDeviation);
+        public T timeDeviations(Deviation[] timeDeviations) {
+            if (timeDeviations != null) {
+                this.timeDeviations = Optional.of(timeDeviations);
+            }
             return (T) this;
         }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/DifferenceTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/DifferenceTransformer.java
@@ -76,4 +76,12 @@ public class DifferenceTransformer extends WeightedTransformer {
         return super.transformValues(internalTimeStamp, input, null, initials, clipFactor);
     }
 
+    @Override
+    public double[] getShift(double[] previous) {
+        double[] answer = new double[weights.length];
+        for (int i = 0; i < weights.length; i++) {
+            answer[i] = getShift(i, deviations) + previous[i];
+        }
+        return answer;
+    }
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
@@ -91,5 +91,5 @@ public interface ITransformer {
     }
 
     // used for computing errors in RCFcaster before the model is callibrated
-    double[] getErrorDeviations();
+    double[] getSmoothedDeviations();
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
@@ -78,11 +78,18 @@ public interface ITransformer {
     double[] transformValues(int internalTimeStamp, double[] inputPoint, double[] previousInput, Deviation[] initials,
             double clipFactor);
 
-    default double[] getShift() {
+    // used for converting RCF representations to actuals, used in
+    // predictor-corrector
+    default double[] getShift(double[] previous) {
         return null;
     };
 
+    // used for converting RCF representations to actuals, used in
+    // predictor-corrector
     default double[] getScale() {
         return null;
     }
+
+    // used for computing errors in RCFcaster before the model is callibrated
+    double[] getErrorDeviations();
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/NormalizedDifferenceTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/NormalizedDifferenceTransformer.java
@@ -93,6 +93,15 @@ public class NormalizedDifferenceTransformer extends NormalizedTransformer {
     }
 
     @Override
+    public double[] getShift(double[] previous) {
+        double[] answer = new double[weights.length];
+        for (int i = 0; i < weights.length; i++) {
+            answer[i] = getShift(i, deviations) + previous[i];
+        }
+        return answer;
+    }
+
+    @Override
     protected double getShift(int i, Deviation[] devs) {
         return devs[i + weights.length].getMean();
     }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
@@ -202,10 +202,18 @@ public class WeightedTransformer implements ITransformer {
     }
 
     @Override
-    public double[] getShift() {
+    public double[] getShift(double[] previous) {
         double[] answer = new double[weights.length];
         for (int i = 0; i < weights.length; i++) {
             answer[i] = getShift(i, deviations);
+        }
+        return answer;
+    }
+
+    public double[] getErrorDeviations() {
+        double[] answer = new double[weights.length];
+        for (int i = 0; i < weights.length; i++) {
+            answer[i] = Math.abs(deviations[i + 2 * weights.length].getMean());
         }
         return answer;
     }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
@@ -15,15 +15,14 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor.transform;
 
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-
-import java.util.Arrays;
-
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.returntypes.RangeVector;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
-import com.amazon.randomcutforest.returntypes.RangeVector;
+import java.util.Arrays;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 
 /**
  * A weighted transformer maintains several data structures ( currently 3X) that
@@ -210,7 +209,8 @@ public class WeightedTransformer implements ITransformer {
         return answer;
     }
 
-    public double[] getErrorDeviations() {
+    public double[] getSmoothedDeviations() {
+        checkArgument(deviations.length >= 3* weights.length, "incorrect call");
         double[] answer = new double[weights.length];
         for (int i = 0; i < weights.length; i++) {
             answer[i] = Math.abs(deviations[i + 2 * weights.length].getMean());

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
@@ -69,6 +69,8 @@ public class ThresholdedRandomCutForestMapper
         PredictorCorrector predictorCorrector = new PredictorCorrector(thresholder, preprocessor.getInputLength());
         predictorCorrector.setNumberOfAttributors(state.getNumberOfAttributors());
         predictorCorrector.setLastScore(state.getLastScore());
+        predictorCorrector.setIgnoreNearExpectedFromAbove(state.getIgnoreSimilarFromAbove());
+        predictorCorrector.setIgnoreNearExpectedFromBelow(state.getIgnoreSimilarFromBelow());
 
         return new ThresholdedRandomCutForest(forestMode, transformMethod, forest, predictorCorrector, preprocessor,
                 descriptor);

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
@@ -15,7 +15,7 @@
 
 package com.amazon.randomcutforest.parkservices.state;
 
-import static com.amazon.randomcutforest.state.Version.V2_1;
+import static com.amazon.randomcutforest.state.Version.V3_7;
 
 import java.io.Serializable;
 
@@ -30,7 +30,7 @@ import com.amazon.randomcutforest.state.returntypes.DiVectorState;
 public class ThresholdedRandomCutForestState implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String version = V2_1;
+    private String version = V3_7;
     RandomCutForestState forestState;
     private BasicThresholderState thresholderState;
     private PreprocessorState[] preprocessorStates;
@@ -53,5 +53,7 @@ public class ThresholdedRandomCutForestState implements Serializable {
     private String transformMethod;
     private int lastRelativeIndex;
     private int lastReset;
+    private double[] ignoreSimilarFromAbove;
+    private double[] ignoreSimilarFromBelow;
 
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/preprocessor/PreprocessorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/preprocessor/PreprocessorState.java
@@ -15,7 +15,7 @@
 
 package com.amazon.randomcutforest.parkservices.state.preprocessor;
 
-import static com.amazon.randomcutforest.state.Version.V2_1;
+import static com.amazon.randomcutforest.state.Version.V3_7;
 
 import java.io.Serializable;
 
@@ -27,7 +27,7 @@ import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
 public class PreprocessorState implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String version = V2_1;
+    private String version = V3_7;
     private double useImputedFraction;
     private String imputationMethod;
     private String forestMode;
@@ -50,8 +50,12 @@ public class PreprocessorState implements Serializable {
     private long[] previousTimeStamps;
     private int valuesSeen;
     private int internalTimeStamp;
+    @Deprecated
     private DeviationState dataQualityState;
+    @Deprecated
     private DeviationState timeStampDeviationState;
     private DeviationState[] deviationStates;
 
+    private DeviationState[] dataQualityStates;
+    private DeviationState[] timeStampDeviationStates;
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/statistics/DeviationMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/statistics/DeviationMapper.java
@@ -42,4 +42,25 @@ public class DeviationMapper implements IStateMapper<Deviation, DeviationState> 
         return state;
     }
 
+    public static DeviationState[] getStates(Deviation[] list, DeviationMapper mapper) {
+        DeviationState[] states = null;
+        if (list != null) {
+            states = new DeviationState[list.length];
+            for (int i = 0; i < list.length; i++) {
+                states[i] = mapper.toState(list[i]);
+            }
+        }
+        return states;
+    }
+
+    public static Deviation[] getDeviations(DeviationState[] states, DeviationMapper mapper) {
+        Deviation[] deviations = null;
+        if (states != null) {
+            deviations = new Deviation[states.length];
+            for (int i = 0; i < states.length; i++) {
+                deviations[i] = mapper.toModel(states[i]);
+            }
+        }
+        return deviations;
+    }
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderMapper.java
@@ -15,6 +15,9 @@
 
 package com.amazon.randomcutforest.parkservices.state.threshold;
 
+import static com.amazon.randomcutforest.parkservices.state.statistics.DeviationMapper.getDeviations;
+import static com.amazon.randomcutforest.parkservices.state.statistics.DeviationMapper.getStates;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -30,20 +33,15 @@ public class BasicThresholderMapper implements IStateMapper<BasicThresholder, Ba
     @Override
     public BasicThresholder toModel(BasicThresholderState state, long seed) {
         DeviationMapper deviationMapper = new DeviationMapper();
-        Deviation primaryDeviation = deviationMapper.toModel(state.getPrimaryDeviationState());
-        Deviation secondaryDeviation = deviationMapper.toModel(state.getSecondaryDeviationState());
-        Deviation thresholdDeviation = deviationMapper.toModel(state.getThresholdDeviationState());
-        BasicThresholder thresholder = new BasicThresholder(primaryDeviation, secondaryDeviation, thresholdDeviation);
+        Deviation[] deviations = getDeviations(state.getDeviationStates(), deviationMapper);
+        BasicThresholder thresholder = new BasicThresholder(deviations);
         thresholder.setAbsoluteThreshold(state.getAbsoluteThreshold());
-        thresholder.setLowerThreshold(state.getLowerThreshold(), state.isAutoThreshold());
-        thresholder.setUpperThreshold(state.getUpperThreshold());
+        thresholder.setLowerThreshold(state.getLowerThreshold());
         thresholder.setInitialThreshold(state.getInitialThreshold());
-        thresholder.setElasticity(state.getElasticity());
         thresholder.setThresholdPersistence(state.getHorizon());
         thresholder.setCount(state.getCount());
+        thresholder.setAutoThreshold(state.isAutoThreshold());
         thresholder.setMinimumScores(state.getMinimumScores());
-        thresholder.setAbsoluteScoreFraction(state.getAbsoluteScoreFraction());
-        thresholder.setUpperZfactor(state.getUpperZfactor());
         thresholder.setZfactor(state.getZFactor());
         return thresholder;
     }
@@ -54,19 +52,13 @@ public class BasicThresholderMapper implements IStateMapper<BasicThresholder, Ba
         DeviationMapper deviationMapper = new DeviationMapper();
 
         state.setZFactor(model.getZFactor());
-        state.setUpperZfactor(model.getUpperZfactor());
-        state.setUpperThreshold(model.getUpperThreshold());
         state.setLowerThreshold(model.getLowerThreshold());
         state.setAbsoluteThreshold(model.getAbsoluteThreshold());
         state.setInitialThreshold(model.getInitialThreshold());
-        state.setAbsoluteScoreFraction(model.getAbsoluteScoreFraction());
-        state.setElasticity(model.getElasticity());
         state.setCount(model.getCount());
         state.setAutoThreshold(model.isAutoThreshold());
         state.setMinimumScores(model.getMinimumScores());
-        state.setPrimaryDeviationState(deviationMapper.toState(model.getPrimaryDeviation()));
-        state.setSecondaryDeviationState(deviationMapper.toState(model.getSecondaryDeviation()));
-        state.setThresholdDeviationState(deviationMapper.toState(model.getThresholdDeviation()));
+        state.setDeviationStates(getStates(model.getDeviations(), deviationMapper));
         state.setHorizon(model.getThresholdPersistence());
         return state;
     }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderMapper.java
@@ -33,12 +33,21 @@ public class BasicThresholderMapper implements IStateMapper<BasicThresholder, Ba
     @Override
     public BasicThresholder toModel(BasicThresholderState state, long seed) {
         DeviationMapper deviationMapper = new DeviationMapper();
-        Deviation[] deviations = getDeviations(state.getDeviationStates(), deviationMapper);
+        Deviation[] deviations = null;
+        if (state.getDeviationStates() != null) {
+            deviations = getDeviations(state.getDeviationStates(), deviationMapper);
+        } else if (state.getPrimaryDeviationState() != null) {
+            // backward compatility; will be deprecated in 4.0
+            deviations = new Deviation[3];
+            deviations[0] = deviationMapper.toModel(state.getPrimaryDeviationState());
+            deviations[1] = deviationMapper.toModel(state.getSecondaryDeviationState());
+            deviations[2] = deviationMapper.toModel(state.getThresholdDeviationState());
+        }
         BasicThresholder thresholder = new BasicThresholder(deviations);
         thresholder.setAbsoluteThreshold(state.getAbsoluteThreshold());
         thresholder.setLowerThreshold(state.getLowerThreshold());
         thresholder.setInitialThreshold(state.getInitialThreshold());
-        thresholder.setThresholdPersistence(state.getHorizon());
+        thresholder.setScoreDifferencing(state.getHorizon());
         thresholder.setCount(state.getCount());
         thresholder.setAutoThreshold(state.isAutoThreshold());
         thresholder.setMinimumScores(state.getMinimumScores());
@@ -59,7 +68,7 @@ public class BasicThresholderMapper implements IStateMapper<BasicThresholder, Ba
         state.setAutoThreshold(model.isAutoThreshold());
         state.setMinimumScores(model.getMinimumScores());
         state.setDeviationStates(getStates(model.getDeviations(), deviationMapper));
-        state.setHorizon(model.getThresholdPersistence());
+        state.setHorizon(model.getScoreDifferencing());
         return state;
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/threshold/BasicThresholderState.java
@@ -27,22 +27,29 @@ public class BasicThresholderState implements Serializable {
 
     private long randomseed;
 
+    @Deprecated
     private boolean inAnomaly;
 
+    @Deprecated
     private double elasticity;
 
+    @Deprecated
     private boolean attributionEnabled;
 
     private int count;
 
     private int minimumScores;
 
+    @Deprecated
     private DeviationState primaryDeviationState;
 
+    @Deprecated
     private DeviationState secondaryDeviationState;
 
+    @Deprecated
     private DeviationState thresholdDeviationState;
 
+    @Deprecated
     private double upperThreshold;
 
     private double lowerThreshold;
@@ -55,10 +62,14 @@ public class BasicThresholderState implements Serializable {
 
     private double zFactor;
 
+    @Deprecated
     private double upperZfactor;
 
+    @Deprecated
     private double absoluteScoreFraction;
 
     private double horizon;
+
+    private DeviationState[] deviationStates;
 
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
@@ -33,7 +33,7 @@ public class BasicThresholder {
     public static int DEFAULT_MINIMUM_SCORES = 10;
     public static double DEFAULT_LOWER_THRESHOLD = 0.9;
     public static double DEFAULT_LOWER_THRESHOLD_NORMALIZED = 0.8;
-    public static double DEFAULT_ABSOLUTE_THRESHOLD = 0.6;
+    public static double DEFAULT_ABSOLUTE_THRESHOLD = 0.7;
     public static double DEFAULT_INITIAL_THRESHOLD = 1.5;
     public static double DEFAULT_Z_FACTOR = 3.0;
     public static double MINIMUM_Z_FACTOR = 2.0;

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
@@ -212,9 +212,9 @@ public class BasicThresholder {
      * used then the scores (below the average) end up being close to the average
      * (an example of the asymmetry) and thus only standard deviation is used. But
      * for other distributions we could directly estimate the deviation of the
-     * scores above the dynamic mean in an online manner. An orthogonal component is
-     * the effect of shingling/differencing which connect up the scores from
-     * consecutive input.
+     * scores below the dynamic mean in an online manner, and we do so in
+     * thresholdDeviation. An orthogonal component is the effect of
+     * shingling/differencing which connect up the scores from consecutive input.
      * 
      * @param method      transformation method
      * @param shingleSize shinglesize used

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/RCFCasterTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/RCFCasterTest.java
@@ -82,7 +82,7 @@ public class RCFCasterTest {
                             double[] array = caster.errorHandler.getErrorVector(len, (i + 1), k, pos,
                                     RCFCaster.defaultError);
                             double mean = Arrays.stream(array).sum() / len;
-                            assertEquals(caster.errorHandler.errorMean[pos], mean, 1e-4);
+                            assertEquals(caster.errorHandler.errorMean[pos], mean, 1e-2);
                         }
                     }
                 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
@@ -391,17 +391,24 @@ public class ThresholdedRandomCutForestTest {
                 .precision(precision).parallelExecutionEnabled(false).outputAfter(32).internalShinglingEnabled(true)
                 .anomalyRate(0.005).initialAcceptFraction(0.125).timeDecay(0.0001).boundingBoxCacheFraction(0)
                 .forestMode(ForestMode.STANDARD).build();
+
+        double scoreSum = 0;
+
         for (double dataPoint : initialData) {
             AnomalyDescriptor result = forest.process(new double[] { dataPoint }, 0L);
-            System.out.println("result: " + result.getRCFScore());
+            scoreSum += result.getRCFScore();
         }
+
+        // checking average score < 1
+        assert (scoreSum < initialData.length);
 
         ThresholdedRandomCutForestMapper mapper = new ThresholdedRandomCutForestMapper();
         ThresholdedRandomCutForest second = mapper.toModel(mapper.toState(forest));
 
         for (double dataPoint : data) {
             AnomalyDescriptor result = second.process(new double[] { dataPoint }, 0L);
-            System.out.println("result post conversion: " + result.getRCFScore());
+            // average score jumps due to discontinuity, checking > 1
+            assert (result.getRCFScore() > 1.0);
         }
     }
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapperTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapperTest.java
@@ -240,7 +240,6 @@ public class ThresholdedRandomCutForestMapperTest {
             assertEquals(firstResult.getRCFScore(), forest.getAnomalyScore(point), 1e-4);
             if (firstResult.getAnomalyGrade() > 0) {
                 assertEquals(secondResult.getAnomalyGrade(), firstResult.getAnomalyGrade(), 1e-10);
-                assert (firstResult.getRCFScore() >= value);
             }
             forest.update(point);
         }
@@ -317,11 +316,6 @@ public class ThresholdedRandomCutForestMapperTest {
                 .shingleSize(shingleSize).anomalyRate(0.01).transformMethod(method).adjustThreshold(true)
                 .weights(new double[] { 1.0 }).build();
 
-        double value = 0.75 + 0.5 * new Random().nextDouble();
-        first.setLowerThreshold(value);
-        second.setLowerThreshold(value);
-
-        Random r = new Random();
         MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(10 * sampleSize, 50, 100, 5,
                 seed, baseDimensions);
 
@@ -332,7 +326,6 @@ public class ThresholdedRandomCutForestMapperTest {
             assertEquals(firstResult.getRCFScore(), secondResult.getRCFScore(), 1e-10);
             if (firstResult.getAnomalyGrade() > 0) {
                 assertEquals(secondResult.getAnomalyGrade(), firstResult.getAnomalyGrade(), 1e-10);
-                assert (firstResult.getRCFScore() >= value);
             }
 
         }
@@ -363,7 +356,7 @@ public class ThresholdedRandomCutForestMapperTest {
         int shingleSize = 8;
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
-        double value = 1.0;// 0.25 * new Random().nextDouble();
+        double value = 0.75 + 0.25 * new Random().nextDouble();
 
         ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
                 .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
@@ -378,8 +371,6 @@ public class ThresholdedRandomCutForestMapperTest {
 
         first.setLowerThreshold(value);
         second.setLowerThreshold(value);
-
-        int count = 0;
 
         MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(sampleSize, 50, 100, 5, seed,
                 baseDimensions);
@@ -406,7 +397,7 @@ public class ThresholdedRandomCutForestMapperTest {
         int shingleSize = 8;
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
-        double value = 1.0;// 0.25 * new Random().nextDouble();
+        double value = 0.75 + 0.25 * new Random().nextDouble();
 
         ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
                 .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
@@ -421,8 +412,6 @@ public class ThresholdedRandomCutForestMapperTest {
 
         first.setLowerThreshold(value);
         second.setLowerThreshold(value);
-
-        int count = 0;
 
         MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(sampleSize, 50, 100, 5, seed,
                 baseDimensions);
@@ -450,7 +439,7 @@ public class ThresholdedRandomCutForestMapperTest {
         int shingleSize = 8;
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
-        double value = 1.0 + 0.25 * new Random().nextDouble();
+        double value = 0.75 + 0.25 * new Random().nextDouble();
 
         ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
                 .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
@@ -476,7 +465,6 @@ public class ThresholdedRandomCutForestMapperTest {
             assertEquals(firstResult.getRCFScore(), secondResult.getRCFScore(), 1e-10);
             if (firstResult.getAnomalyGrade() > 0) {
                 assertEquals(secondResult.getAnomalyGrade(), firstResult.getAnomalyGrade(), 1e-10);
-                assert (firstResult.getRCFScore() >= value);
             }
         }
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
@@ -33,12 +33,12 @@ public class BasicThresholderTest {
     void horizonTest() {
         BasicThresholder basicThresholder = new BasicThresholder(0.01);
         assertThrows(IllegalArgumentException.class, () -> {
-            basicThresholder.setThresholdPersistence(-new Random().nextDouble());
+            basicThresholder.setScoreDifferencing(-new Random().nextDouble());
         });
         assertThrows(IllegalArgumentException.class, () -> {
-            basicThresholder.setThresholdPersistence(1 + 1e-10 + new Random().nextDouble());
+            basicThresholder.setScoreDifferencing(1 + 1e-10 + new Random().nextDouble());
         });
-        assertDoesNotThrow(() -> basicThresholder.setThresholdPersistence(new Random().nextDouble()));
+        assertDoesNotThrow(() -> basicThresholder.setScoreDifferencing(new Random().nextDouble()));
     }
 
     @Test
@@ -56,11 +56,11 @@ public class BasicThresholderTest {
         basicThresholder.updatePrimary(0.0);
         basicThresholder.updatePrimary(0.0);
         assertFalse(basicThresholder.isDeviationReady());
-        basicThresholder.setThresholdPersistence(0);
+        basicThresholder.setScoreDifferencing(0);
         assertFalse(basicThresholder.isDeviationReady());
         basicThresholder.setMinimumScores(5);
         assertFalse(basicThresholder.isDeviationReady());
-        basicThresholder.setThresholdPersistence(1.0);
+        basicThresholder.setScoreDifferencing(1.0);
         assertTrue(basicThresholder.isDeviationReady());
 
         basicThresholder.updatePrimary(0.0);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
@@ -30,32 +30,6 @@ import org.junit.jupiter.api.Test;
 public class BasicThresholderTest {
 
     @Test
-    void lowerThresholdTest() {
-        BasicThresholder basicThresholder = new BasicThresholder(0.01);
-
-        Random random = new Random();
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setLowerThreshold(1 + random.nextDouble(), false);
-        }
-        assert (basicThresholder.getLowerThreshold() * 2 < basicThresholder.getUpperThreshold() + 1e-10);
-    }
-
-    @Test
-    void initialThresholdTest() {
-        BasicThresholder basicThresholder = new BasicThresholder(0.01);
-
-        Random random = new Random();
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setLowerThreshold(1 + random.nextDouble(), false);
-        }
-        assert (basicThresholder.getLowerThreshold() < basicThresholder.getInitialThreshold() + 1e-10);
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setInitialThreshold(2 + random.nextDouble());
-        }
-        assert (basicThresholder.getInitialThreshold() < basicThresholder.getUpperThreshold() + 1e-10);
-    }
-
-    @Test
     void horizonTest() {
         BasicThresholder basicThresholder = new BasicThresholder(0.01);
         assertThrows(IllegalArgumentException.class, () -> {
@@ -65,25 +39,6 @@ public class BasicThresholderTest {
             basicThresholder.setThresholdPersistence(1 + 1e-10 + new Random().nextDouble());
         });
         assertDoesNotThrow(() -> basicThresholder.setThresholdPersistence(new Random().nextDouble()));
-    }
-
-    @Test
-    void zfactorTest() {
-        BasicThresholder basicThresholder = new BasicThresholder(0.01);
-
-        Random random = new Random();
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setZfactor(1 + random.nextDouble());
-        }
-        assertEquals(basicThresholder.getZFactor(), BasicThresholder.DEFAULT_Z_FACTOR, 1e-10);
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setZfactor(2 + random.nextDouble());
-        }
-        assert (basicThresholder.getZFactor() * 2 < basicThresholder.getUpperZfactor() + 1e-10);
-        for (int i = 0; i < 100; i++) {
-            basicThresholder.setUpperZfactor(6 + random.nextDouble());
-        }
-        assert (basicThresholder.getZFactor() * 2 < basicThresholder.getUpperZfactor() + 1e-10);
     }
 
     @Test

--- a/Java/testutils/src/main/java/com/amazon/randomcutforest/testutils/ShingledMultiDimDataWithKeys.java
+++ b/Java/testutils/src/main/java/com/amazon/randomcutforest/testutils/ShingledMultiDimDataWithKeys.java
@@ -118,7 +118,7 @@ public class ShingledMultiDimDataWithKeys {
                     data[i][j] += newChange[j] = change;
                     used = true;
                 } else {
-                    data[i][j] += noise * noiseprg.nextDouble();
+                    data[i][j] += noise * (2 * noiseprg.nextDouble() - 1);
                 }
             }
             if (used) {

--- a/Java/testutils/src/main/java/com/amazon/randomcutforest/testutils/ShingledMultiDimDataWithKeys.java
+++ b/Java/testutils/src/main/java/com/amazon/randomcutforest/testutils/ShingledMultiDimDataWithKeys.java
@@ -77,6 +77,11 @@ public class ShingledMultiDimDataWithKeys {
 
     public static MultiDimDataWithKey getMultiDimData(int num, int period, double amplitude, double noise, long seed,
             int baseDimension, boolean useSlope) {
+        return getMultiDimData(num, period, amplitude, noise, seed, baseDimension, 5.0, useSlope);
+    }
+
+    public static MultiDimDataWithKey getMultiDimData(int num, int period, double amplitude, double noise, long seed,
+            int baseDimension, double anomalyFactor, boolean useSlope) {
         double[][] data = new double[num][];
         double[][] changes = new double[num][];
         int[] changedIndices = new int[num];
@@ -105,13 +110,15 @@ public class ShingledMultiDimDataWithKeys {
             double[] newChange = new double[baseDimension];
             boolean used = false;
             for (int j = 0; j < baseDimension; j++) {
-                data[i][j] = amp[j] * Math.cos(2 * PI * (i + phase[j]) / period) + slope[j] * i
-                        + noise * noiseprg.nextDouble() + shift[j];
+                data[i][j] = amp[j] * Math.cos(2 * PI * (i + phase[j]) / period) + slope[j] * i + shift[j];
+                // ensures that the noise does not cancel the anomaly or change it's magnitude
                 if (flag && noiseprg.nextDouble() < 0.3) {
-                    double factor = 5 * (1 + noiseprg.nextDouble());
+                    double factor = anomalyFactor * (1 + noiseprg.nextDouble());
                     double change = noiseprg.nextDouble() < 0.5 ? factor * noise : -factor * noise;
                     data[i][j] += newChange[j] = change;
                     used = true;
+                } else {
+                    data[i][j] += noise * noiseprg.nextDouble();
                 }
             }
             if (used) {


### PR DESCRIPTION
*Issue #, if available:* #365

*Description of changes:* The main reason for ThresholdedRandomCutForest had been to manage the thresholding of RCF scores. An improvement in this regard had been to allow for different transformation methods. This PR adjusts the predictor corrector for each of those transformations, taking into account the new predictor corrector that uses forecasting. In addition the PR fixes issues with showing errors for the initial segment when the calibration has not been turned on. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
