### PR TITLE
introducing multi-mode(l) operation and initiating rcf 3.8

### DIFF
--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.7.0</version>
+    <version>3.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>

--- a/Java/core/pom.xml
+++ b/Java/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.7.0</version>
+    <version>3.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/RandomCutForest.java
@@ -292,7 +292,7 @@ public class RandomCutForest {
             ITree<Integer, float[]> tree = new RandomCutTree.Builder().capacity(sampleSize)
                     .randomSeed(random.nextLong()).pointStoreView(tempStore)
                     .boundingBoxCacheFraction(boundingBoxCacheFraction).centerOfMassEnabled(centerOfMassEnabled)
-                    .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).outputAfter(outputAfter).build();
+                    .storeSequenceIndexesEnabled(storeSequenceIndexesEnabled).outputAfter(1).build();
 
             IStreamSampler<Integer> sampler = CompactSampler.builder().capacity(sampleSize).timeDecay(timeDecay)
                     .randomSeed(random.nextLong()).storeSequenceIndexesEnabled(storeSequenceIndexesEnabled)
@@ -332,7 +332,6 @@ public class RandomCutForest {
         checkArgument(builder.sampleSize > 0, "sampleSize must be greater than 0");
         builder.outputAfter.ifPresent(n -> {
             checkArgument(n > 0, "outputAfter must be greater than 0");
-            checkArgument(n <= builder.sampleSize, "outputAfter must be smaller or equal to sampleSize");
         });
         checkArgument(builder.dimensions > 0, "dimensions must be greater than 0");
         builder.timeDecay.ifPresent(timeDecay -> {
@@ -1267,7 +1266,8 @@ public class RandomCutForest {
      * @return true if all samplers are ready to output results.
      */
     public boolean isOutputReady() {
-        return outputReady || (outputReady = components.stream().allMatch(IComponentModel::isOutputReady));
+        return outputReady || (outputReady = stateCoordinator.getTotalUpdates() >= outputAfter
+                && components.stream().allMatch(IComponentModel::isOutputReady));
     }
 
     /**

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/ForestMode.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/ForestMode.java
@@ -37,21 +37,5 @@ public enum ForestMode {
      * have shingleSize greater than 1, typically larger shingle size is better, and
      * so is fewer input dimensions
      */
-    STREAMING_IMPUTE,
-    /**
-     * This is the same as STANDARD mode where the scoring function is switched to
-     * distances between the vectors. Since RCFs build a multiresolution tree, and
-     * in the aggregate, preserves distances to some approximation, this provides an
-     * alternate anomaly detection mechanism which can be useful for shingleSize = 1
-     * and (dynamic) population analysis via RCFs. Specifially it switches the
-     * scoring to be based on the distance computation in the Density Estimation
-     * (interpolation). This allows for a direct comparison of clustering based
-     * outlier detection and RCFs over numeric vectors. All transformations
-     * available to the STANDARD mode in the ThresholdedRCF are available for this
-     * mode as well; this does not affect RandomCutForest core in any way. For
-     * timeseries analysis the STANDARD mode is recommended, but this does provide
-     * another option in combination with the TransformMethods.
-     */
-    DISTANCE;
-
+    STREAMING_IMPUTE;
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/config/ScoringStrategy.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/config/ScoringStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.config;
+
+/**
+ * Options for using RCF, specially with thresholds
+ */
+public enum ScoringStrategy {
+
+    /**
+     * default behavior to be optimized; currently EXPECTED_INVERSE_DEPTH
+     */
+    EXPECTED_INVERSE_DEPTH,
+
+    /**
+     * This is the same as STANDARD mode where the scoring function is switched to
+     * distances between the vectors. Since RCFs build a multiresolution tree, and
+     * in the aggregate, preserves distances to some approximation, this provides an
+     * alternate anomaly detection mechanism which can be useful for shingleSize = 1
+     * and (dynamic) population analysis via RCFs. Specifically it switches the
+     * scoring to be based on the distance computation in the Density Estimation
+     * (interpolation). This allows for a direct comparison of clustering based
+     * outlier detection and RCFs over numeric vectors. All transformations
+     * available to the STANDARD mode in the ThresholdedRCF are available for this
+     * mode as well; this does not affect RandomCutForest core in any way. For
+     * timeseries analysis the STANDARD mode is recommended, but this does provide
+     * another option in combination with the TransformMethods.
+     */
+    DISTANCE,
+
+    /**
+     * RCFs are an updatable data structure that can support multiple difference
+     * inference methods. Given the longstanding interest in ensembles of different
+     * models, this strategy uses the multiple inference capabilities to increase
+     * precision. It does not escape our attention that multi-mode allows the
+     * functionality of multi-models yet use a significantly smaller state/memory
+     * footprint since all the modes use RCF. The different modes are probed with
+     * computational efficiency in mind.
+     */
+
+    MULTI_MODE,
+
+    /**
+     * Same as above, except optimized for increasing recall.
+     */
+
+    MULTI_MODE_RECALL;
+
+}

--- a/Java/core/src/main/java/com/amazon/randomcutforest/state/Version.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/state/Version.java
@@ -21,4 +21,5 @@ public class Version {
     public static final String V3_0 = "3.0";
     public static final String V3_5 = "3.5";
     public static final String V3_7 = "3.7";
+    public static final String V3_8 = "3.8";
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/RandomCutTree.java
@@ -19,6 +19,7 @@ import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.checkNotNull;
 import static com.amazon.randomcutforest.CommonUtils.checkState;
 import static com.amazon.randomcutforest.tree.AbstractNodeStore.Null;
+import static java.lang.Math.max;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -81,7 +82,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
         numberOfLeaves = builder.capacity;
         randomSeed = builder.randomSeed;
         testRandom = builder.random;
-        outputAfter = builder.outputAfter.orElse(numberOfLeaves / 4);
+        outputAfter = builder.outputAfter.orElse(max(1, numberOfLeaves / 4));
         dimension = (builder.dimension != 0) ? builder.dimension : pointStoreView.getDimensions();
         nodeStore = (builder.nodeStore != null) ? builder.nodeStore
                 : AbstractNodeStore.builder().capacity(numberOfLeaves - 1).dimension(dimension).build();
@@ -580,7 +581,7 @@ public class RandomCutTree implements ITree<Integer, float[]> {
                 boundingBoxData[base + i] = Math.min(boundingBoxData[base + i], point[i]);
             }
             for (int i = 0; i < dimension; i++) {
-                boundingBoxData[mid + i] = Math.max(boundingBoxData[mid + i], point[i]);
+                boundingBoxData[mid + i] = max(boundingBoxData[mid + i], point[i]);
             }
             for (int i = 0; i < dimension; i++) {
                 rangeSum += boundingBoxData[mid + i] - boundingBoxData[base + i];
@@ -701,10 +702,10 @@ public class RandomCutTree implements ITree<Integer, float[]> {
             double minsum = 0;
             double maxsum = 0;
             for (int i = 0; i < dimension; i++) {
-                minsum += Math.max(boundingBoxData[base + i] - point[i], 0);
+                minsum += max(boundingBoxData[base + i] - point[i], 0);
             }
             for (int i = 0; i < dimension; i++) {
-                maxsum += Math.max(point[i] - boundingBoxData[mid + i], 0);
+                maxsum += max(point[i] - boundingBoxData[mid + i], 0);
             }
             double sum = maxsum + minsum;
 

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
@@ -144,7 +144,7 @@ public class RandomCutForestBuilderTest {
     }
 
     @Test
-    public void testIllegalExceptionIsThrownWhenOutputAfterIsGreaterThanSample() {
+    public void testIllegalExceptionIsNotThrownWhenOutputAfterIsGreaterThanSample() {
         assertDoesNotThrow(() -> RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .outputAfter(sampleSize + 1).dimensions(dimensions).timeDecay(lambda).build());
     }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestBuilderTest.java
@@ -15,7 +15,11 @@
 
 package com.amazon.randomcutforest;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,8 +145,8 @@ public class RandomCutForestBuilderTest {
 
     @Test
     public void testIllegalExceptionIsThrownWhenOutputAfterIsGreaterThanSample() {
-        assertThrows(IllegalArgumentException.class, () -> RandomCutForest.builder().numberOfTrees(numberOfTrees)
-                .sampleSize(sampleSize).outputAfter(sampleSize + 1).dimensions(dimensions).timeDecay(lambda).build());
+        assertDoesNotThrow(() -> RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
+                .outputAfter(sampleSize + 1).dimensions(dimensions).timeDecay(lambda).build());
     }
 
     @Test

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Random;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -36,6 +37,8 @@ import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.state.RandomCutForestMapper;
 import com.amazon.randomcutforest.state.RandomCutForestState;
 import com.amazon.randomcutforest.store.PointStore;
+import com.amazon.randomcutforest.summarization.ICluster;
+import com.amazon.randomcutforest.summarization.Summarizer;
 import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
 import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
 import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
@@ -71,7 +74,7 @@ public class RandomCutForestShingledFunctionalTest {
 
         forest = RandomCutForest.builder().numberOfTrees(numberOfTrees).sampleSize(sampleSize)
                 .dimensions(shingleBuilder.getShingledPointSize()).randomSeed(randomSeed).centerOfMassEnabled(true)
-                .storeSequenceIndexesEnabled(true).build();
+                .initialAcceptFraction(0.5).storeSequenceIndexesEnabled(true).build();
 
         dataSize = 10_000;
 
@@ -121,7 +124,7 @@ public class RandomCutForestShingledFunctionalTest {
         System.out.println(seed);
         Random rng = new Random(seed);
 
-        int numTrials = 5; // test is exact equality, reducing the number of trials
+        int numTrials = 3; // test is exact equality, reducing the number of trials
         int length = 40 * sampleSize;
 
         for (int i = 0; i < numTrials; i++) {
@@ -174,10 +177,25 @@ public class RandomCutForestShingledFunctionalTest {
             }
             PointStore store = (PointStore) first.getUpdateCoordinator().getStore();
             assertEquals(store.getCurrentStoreCapacity() * dimensions, store.getStore().length);
+            List<ICluster<float[]>> firstSummary = store.summarize(5, 0.5, 3, 0.8, Summarizer::L2distance, null);
+
             store = (PointStore) second.getUpdateCoordinator().getStore();
             assertEquals(store.getCurrentStoreCapacity() * dimensions, store.getStore().length);
+            List<ICluster<float[]>> secondSummary = store.summarize(5, 0.5, 3, 0.8, Summarizer::L2distance, null);
+            assert (secondSummary.size() == firstSummary.size());
+            for (int j = 0; j < firstSummary.size(); j++) {
+                assertEquals(firstSummary.get(j).getWeight(), secondSummary.get(j).getWeight(), 1e-3);
+                assertEquals(firstSummary.get(j).averageRadius(), secondSummary.get(j).averageRadius(), 1e-3);
+            }
+
             store = (PointStore) third.getUpdateCoordinator().getStore();
             assertEquals(store.getCurrentStoreCapacity() * dimensions, store.getStore().length);
+            List<ICluster<float[]>> thirdSummary = store.summarize(5, 0.5, 3, 0.8, Summarizer::L2distance, null);
+            assert (thirdSummary.size() == firstSummary.size());
+            for (int j = 0; j < firstSummary.size(); j++) {
+                assertEquals(firstSummary.get(j).getWeight(), thirdSummary.get(j).getWeight(), 1e-3);
+                assertEquals(firstSummary.get(j).averageRadius(), thirdSummary.get(j).averageRadius(), 1e-3);
+            }
         }
     }
 

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestShingledFunctionalTest.java
@@ -119,23 +119,27 @@ public class RandomCutForestShingledFunctionalTest {
         int dimensions = baseDimensions * shingleSize;
         long seed = new Random().nextLong();
         System.out.println(seed);
+        Random rng = new Random(seed);
 
-        int numTrials = 1; // test is exact equality, reducing the number of trials
-        int length = 400 * sampleSize;
+        int numTrials = 5; // test is exact equality, reducing the number of trials
+        int length = 40 * sampleSize;
 
         for (int i = 0; i < numTrials; i++) {
 
+            int outputAfter = 1 + rng.nextInt(10 * sampleSize);
+            long newSeed = rng.nextLong();
             RandomCutForest first = new RandomCutForest.Builder<>().compact(true).dimensions(dimensions)
-                    .precision(Precision.FLOAT_32).randomSeed(seed).internalShinglingEnabled(true)
-                    .internalRotationEnabled(rotation).shingleSize(shingleSize).build();
-
-            RandomCutForest second = new RandomCutForest.Builder<>().compact(true).dimensions(dimensions)
-                    .precision(Precision.FLOAT_32).randomSeed(seed).internalShinglingEnabled(false)
+                    .precision(Precision.FLOAT_32).randomSeed(newSeed).internalShinglingEnabled(true)
+                    .outputAfter(outputAfter + shingleSize - 1).internalRotationEnabled(rotation)
                     .shingleSize(shingleSize).build();
 
+            RandomCutForest second = new RandomCutForest.Builder<>().compact(true).dimensions(dimensions)
+                    .precision(Precision.FLOAT_32).randomSeed(newSeed).internalShinglingEnabled(false)
+                    .outputAfter(outputAfter).shingleSize(shingleSize).build();
+
             RandomCutForest third = new RandomCutForest.Builder<>().compact(true).dimensions(dimensions)
-                    .precision(Precision.FLOAT_32).randomSeed(seed).internalShinglingEnabled(false).shingleSize(1)
-                    .build();
+                    .precision(Precision.FLOAT_32).randomSeed(newSeed).internalShinglingEnabled(false).shingleSize(1)
+                    .outputAfter(outputAfter).build();
 
             MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(length, 50, 100, 5,
                     seed + i, baseDimensions);

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -762,6 +762,8 @@ public class RandomCutForestTest {
         for (int i = 0; i < numberOfTrees; i++) {
             doReturn(true).when(components.get(i)).isOutputReady();
         }
+        assertFalse(forest.isOutputReady());
+        when(updateCoordinator.getTotalUpdates()).thenReturn((long) sampleSize);
         assertTrue(forest.isOutputReady());
 
         // After forest.isOutputReady() returns true once, the result should be cached

--- a/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/RandomCutForestTest.java
@@ -610,6 +610,23 @@ public class RandomCutForestTest {
 
         float[] expectedResult = new float[] { 2.0f, -3.0f, 4.0f, -5.0f, 6.0f, -7.0f };
         assertArrayEquals(expectedResult, result.values);
+        // test properties of RangeVector as well
+        for (int i = 0; i < 6; i++) {
+            assert (result.upper[i] >= result.values[i]);
+            assert (result.lower[i] <= result.values[i]);
+        }
+        // validate subsequent operations (typically used in parkservices)
+        expectedResult[0] = 0f;
+        RangeVector newVector = new RangeVector(expectedResult);
+        RangeVector another = new RangeVector(result);
+        another.shift(0, -2.0f);
+        another.scale(2, 0.25f);
+        newVector.scale(2, 0.25f);
+        assertArrayEquals(newVector.values, another.values, 1e-6f);
+        for (int i = 0; i < 6; i++) {
+            assert (another.upper[i] >= another.values[i]);
+            assert (another.lower[i] <= another.values[i]);
+        }
     }
 
     @Test
@@ -630,6 +647,11 @@ public class RandomCutForestTest {
 
         float[] expectedResult = new float[] { -3.0f, 2.0f, -5.0f, 4.0f, -7.0f, 6.0f };
         assertArrayEquals(expectedResult, result.values);
+        // test properties of RangeVector as well
+        for (int i = 0; i < 6; i++) {
+            assert (result.upper[i] >= result.values[i]);
+            assert (result.lower[i] <= result.values[i]);
+        }
     }
 
     @Test
@@ -811,7 +833,7 @@ public class RandomCutForestTest {
     }
 
     @Test
-    public void testUpdateAfterRoundTripLargeNodeStore() {
+    public void testUpdateAfterRoundTripMediumNodeStore() {
         int dimensions = 5;
         for (int trials = 0; trials < 10; trials++) {
             RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).numberOfTrees(1)
@@ -829,6 +851,36 @@ public class RandomCutForestTest {
             RandomCutForestState state = mapper.toState(forest);
             RandomCutForest forest2 = mapper.toModel(state);
 
+            // update re-instantiated forest
+            for (int i = 0; i < 10000; i++) {
+                double[] point = r.ints(dimensions, 0, 50).asDoubleStream().toArray();
+                double score = forest.getAnomalyScore(point);
+                assertEquals(score, forest2.getAnomalyScore(point), 1E-10);
+                forest2.update(point);
+                forest.update(point);
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateAfterRoundTripLargeNodeStore() {
+        int dimensions = 5;
+        for (int trials = 0; trials < 1; trials++) {
+            RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions).numberOfTrees(1)
+                    .sampleSize(200000).centerOfMassEnabled(true).build();
+
+            Random r = new Random();
+            for (int i = 0; i < 300000 + new Random().nextInt(300); i++) {
+                forest.update(r.ints(dimensions, 0, 50).asDoubleStream().toArray());
+            }
+
+            // serialize + deserialize
+            RandomCutForestMapper mapper = new RandomCutForestMapper();
+            mapper.setSaveTreeStateEnabled(true);
+            mapper.setSaveExecutorContextEnabled(true);
+            RandomCutForestState state = mapper.toState(forest);
+            RandomCutForest forest2 = mapper.toModel(state);
+            assert (forest2.isCenterOfMassEnabled());
             // update re-instantiated forest
             for (int i = 0; i < 10000; i++) {
                 double[] point = r.ints(dimensions, 0, 50).asDoubleStream().toArray();

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>randomcutforest-examples</artifactId>

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/NumericGLADexample.java
@@ -25,7 +25,7 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.util.Random;
 
-import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.examples.Example;
 import com.amazon.randomcutforest.parkservices.AnomalyDescriptor;
 import com.amazon.randomcutforest.parkservices.GlobalLocalAnomalyDetector;
@@ -131,7 +131,7 @@ public class NumericGLADexample implements Example {
         reservoir.setZfactor(zFactor);
 
         ThresholdedRandomCutForest test = ThresholdedRandomCutForest.builder().dimensions(2).shingleSize(1)
-                .randomSeed(77).timeDecay(timedecay).forestMode(ForestMode.DISTANCE).build();
+                .randomSeed(77).timeDecay(timedecay).scoringStrategy(ScoringStrategy.DISTANCE).build();
         test.setZfactor(zFactor); // using the zFactor for same apples to apples comparison
 
         String name = "clustering_example";

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ScoringStrategyExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ScoringStrategyExample.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.parkservices;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.config.TransformMethod;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.parkservices.AnomalyDescriptor;
+import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
+import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
+import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+
+public class ScoringStrategyExample implements Example {
+
+    public static void main(String[] args) throws Exception {
+        new ScoringStrategyExample().run();
+    }
+
+    @Override
+    public String command() {
+        return "Scoring_strategy_example";
+    }
+
+    @Override
+    public String description() {
+        return "Scoring Strategy Example";
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Create and populate a random cut forest
+
+        int shingleSize = 4;
+        int numberOfTrees = 50;
+        int sampleSize = 256;
+        int dataSize = 4 * sampleSize;
+
+        // change this to try different number of attributes,
+        // this parameter is not expected to be larger than 5 for this example
+        int baseDimensions = 1;
+
+        long seed = new Random().nextLong();
+        long count = 0;
+        int dimensions = baseDimensions * shingleSize;
+        TransformMethod transformMethod = TransformMethod.NORMALIZE;
+        ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
+                .randomSeed(seed).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
+                .internalShinglingEnabled(true).scoringStrategy(ScoringStrategy.EXPECTED_INVERSE_DEPTH)
+                .transformMethod(transformMethod).outputAfter(32).initialAcceptFraction(0.125).build();
+        ThresholdedRandomCutForest second = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
+                .randomSeed(seed).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
+                .internalShinglingEnabled(true).scoringStrategy(ScoringStrategy.MULTI_MODE)
+                .transformMethod(transformMethod).outputAfter(32).initialAcceptFraction(0.125).build();
+        ThresholdedRandomCutForest third = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
+                .randomSeed(seed).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
+                .internalShinglingEnabled(true).scoringStrategy(ScoringStrategy.MULTI_MODE_RECALL)
+                .transformMethod(transformMethod).outputAfter(32).initialAcceptFraction(0.125).build();
+
+        System.out.println("seed = " + seed);
+        // change the last argument seed for a different run
+        MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(dataSize + shingleSize - 1, 50,
+                100, 5, seed, baseDimensions);
+
+        int keyCounter = 0;
+        for (double[] point : dataWithKeys.data) {
+
+            AnomalyDescriptor result = forest.process(point, 0L);
+            AnomalyDescriptor multi_mode = second.process(point, 0L);
+            AnomalyDescriptor multi_mode_recall = third.process(point, 0L);
+
+            checkArgument(Math.abs(result.getRCFScore() - multi_mode.getRCFScore()) < 1e-10, " error");
+            checkArgument(Math.abs(result.getRCFScore() - multi_mode_recall.getRCFScore()) < 1e-10, " error");
+
+            if (keyCounter < dataWithKeys.changeIndices.length && count == dataWithKeys.changeIndices[keyCounter]) {
+                System.out
+                        .println("timestamp " + count + " CHANGE " + Arrays.toString(dataWithKeys.changes[keyCounter]));
+                ++keyCounter;
+            }
+
+            printResult("MULTI_MODE_RECALL", multi_mode_recall, count, baseDimensions);
+            printResult("EXPECTED_INVERSE_DEPTH", result, count, baseDimensions);
+            printResult("MULTI_MODE", multi_mode, count, baseDimensions);
+            ++count;
+        }
+    }
+
+    void printResult(String description, AnomalyDescriptor result, long count, int baseDimensions) {
+        if (result.getAnomalyGrade() != 0) {
+            System.out.print(description + " timestamp " + count + " RESULT value ");
+            for (int i = 0; i < baseDimensions; i++) {
+                System.out.print(result.getCurrentInput()[i] + ", ");
+            }
+            System.out.print("score " + result.getRCFScore() + ", grade " + result.getAnomalyGrade() + ", ");
+            if (result.getRelativeIndex() != 0) {
+                System.out.print(-result.getRelativeIndex() + " steps ago, ");
+            }
+            if (result.isExpectedValuesPresent()) {
+                if (result.getRelativeIndex() != 0) {
+                    System.out.print("instead of ");
+                    for (int i = 0; i < baseDimensions; i++) {
+                        System.out.print(result.getPastValues()[i] + ", ");
+                    }
+                    System.out.print("expected ");
+                    for (int i = 0; i < baseDimensions; i++) {
+                        System.out.print(result.getExpectedValuesList()[0][i] + ", ");
+                        if (result.getPastValues()[i] != result.getExpectedValuesList()[0][i]) {
+                            System.out.print(
+                                    "( " + (result.getPastValues()[i] - result.getExpectedValuesList()[0][i]) + " ) ");
+                        }
+                    }
+                } else {
+                    System.out.print("expected ");
+                    for (int i = 0; i < baseDimensions; i++) {
+                        System.out.print(result.getExpectedValuesList()[0][i] + ", ");
+                        if (result.getCurrentInput()[i] != result.getExpectedValuesList()[0][i]) {
+                            System.out.print("( " + (result.getCurrentInput()[i] - result.getExpectedValuesList()[0][i])
+                                    + " ) ");
+                        }
+                    }
+                }
+            } else {
+                System.out.print("insufficient data to provide expected values");
+            }
+            System.out.println();
+        }
+    }
+
+}

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedRCFJsonExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/ThresholdedRCFJsonExample.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.examples.parkservices;
+
+import java.util.Random;
+
+import com.amazon.randomcutforest.config.TransformMethod;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.parkservices.AnomalyDescriptor;
+import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
+import com.amazon.randomcutforest.parkservices.state.ThresholdedRandomCutForestMapper;
+import com.amazon.randomcutforest.parkservices.state.ThresholdedRandomCutForestState;
+import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Serialize a Random Cut Forest to JSON using
+ * <a href="https://github.com/FasterXML/jackson">Jackson</a>.
+ */
+public class ThresholdedRCFJsonExample implements Example {
+
+    public static void main(String[] args) throws Exception {
+        new ThresholdedRCFJsonExample().run();
+    }
+
+    @Override
+    public String command() {
+        return "json";
+    }
+
+    @Override
+    public String description() {
+        return "serialize a Thresholded Random Cut Forest as a JSON string";
+    }
+
+    @Override
+    public void run() throws Exception {
+        // Create and populate a random cut forest
+
+        int baseDimension = 2;
+        int shingleSize = 8;
+        int numberOfTrees = 50;
+        int sampleSize = 256;
+        long seed = new Random().nextLong();
+        System.out.println("seed :" + seed);
+        Random rng = new Random(seed);
+
+        int dimensions = baseDimension * shingleSize;
+        ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().dimensions(dimensions)
+                .shingleSize(shingleSize).transformMethod(TransformMethod.NORMALIZE).numberOfTrees(numberOfTrees)
+                .sampleSize(sampleSize).build();
+
+        int dataSize = 4 * sampleSize;
+        int testSize = sampleSize;
+        double[][] data = ShingledMultiDimDataWithKeys.getMultiDimData(dataSize + shingleSize - 1, 50, 100, 5,
+                rng.nextLong(), baseDimension, 5.0, false).data;
+
+        for (int i = 0; i < data.length - testSize; i++) {
+            forest.process(data[i], 0L);
+        }
+
+        // Convert to JSON and print the number of bytes
+
+        ThresholdedRandomCutForestMapper mapper = new ThresholdedRandomCutForestMapper();
+        ObjectMapper jsonMapper = new ObjectMapper();
+
+        String json = jsonMapper.writeValueAsString(mapper.toState(forest));
+
+        System.out.printf("JSON size = %d bytes%n", json.getBytes().length);
+
+        // Restore from JSON and compare anomaly scores produced by the two forests
+
+        ThresholdedRandomCutForest forest2 = mapper
+                .toModel(jsonMapper.readValue(json, ThresholdedRandomCutForestState.class));
+
+        for (int i = data.length; i < data.length; i++) {
+            AnomalyDescriptor result = forest.process(data[i], 0L);
+            AnomalyDescriptor shadow = forest2.process(data[i], 0L);
+            assert (Math.abs(result.getRCFScore() - shadow.getRCFScore()) < 1e-6);
+        }
+
+        System.out.println("Looks good!");
+    }
+}

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.7.0</version>
+    <version>3.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-parkservices</artifactId>

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/IRCFComputeDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/IRCFComputeDescriptor.java
@@ -16,6 +16,7 @@
 package com.amazon.randomcutforest.parkservices;
 
 import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.returntypes.DiVector;
 
@@ -56,6 +57,9 @@ public interface IRCFComputeDescriptor {
 
     // transformation method (if used)
     TransformMethod getTransformMethod();
+
+    // scoring strategy
+    ScoringStrategy getScoringStrategy();
 
     // an explicit copy operator
     RCFComputeDescriptor copyOf();

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
@@ -420,9 +420,9 @@ public class PredictorCorrector {
                 answer = significantScore || (delta > shiftAmount + DEFAULT_NORMALIZATION_PRECISION);
                 if (answer) {
                     boolean lower = (a < b - ignoreNearExpectedFromBelow[y])
-                            && (a < b * (1 - ignoreNearExpectedFromBelowByRatio[y]));
+                            && (a < b - ignoreNearExpectedFromBelowByRatio[y] * Math.abs(b));
                     boolean upper = (a > b + ignoreNearExpectedFromAbove[y])
-                            && (a > b * (1 + ignoreNearExpectedFromBelowByRatio[y]));
+                            && (a > b + ignoreNearExpectedFromAboveByRatio[y] * Math.abs(b));
                     answer = lower || upper;
                 }
             }
@@ -633,8 +633,8 @@ public class PredictorCorrector {
             // be useful
             Weighted<Double> temp = thresholders[DISTANCE_INDEX]
                     .getPrimaryThresholdAndGrade(scoreVector[DISTANCE_INDEX]);
-            choice = 1;
-            correctedScore = scoreVector[1];
+            choice = DISTANCE_INDEX;
+            correctedScore = scoreVector[DISTANCE_INDEX];
             workingGrade = temp.weight;
             workingThreshold = temp.index;
         }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/PredictorCorrector.java
@@ -816,16 +816,45 @@ public class PredictorCorrector {
         }
     }
 
-    void validateIgnore(double[] shift) {
-        checkArgument(shift.length == 4 * baseDimension, () -> "has to be of length " + 4 * baseDimension);
+    void validateIgnore(double[] shift, int length) {
+        checkArgument(shift.length == length, () -> "has to be of length " + 4 * baseDimension);
         for (double element : shift) {
             checkArgument(element >= 0, "has to be non-negative");
         }
     }
 
+    public void setIgnoreNearExpectedFromAbove(double[] ignoreSimilarShift) {
+        if (ignoreSimilarShift != null) {
+            validateIgnore(ignoreSimilarShift, baseDimension);
+            System.arraycopy(ignoreSimilarShift, 0, ignoreNearExpectedFromAbove, 0, baseDimension);
+        }
+    }
+
+    public void setIgnoreNearExpectedFromBelow(double[] ignoreSimilarShift) {
+        if (ignoreSimilarShift != null) {
+            validateIgnore(ignoreSimilarShift, baseDimension);
+            System.arraycopy(ignoreSimilarShift, 0, ignoreNearExpectedFromBelow, 0, baseDimension);
+        }
+    }
+
+    public void setIgnoreNearExpectedFromAboveByRatio(double[] ignoreSimilarShift) {
+        if (ignoreSimilarShift != null) {
+            validateIgnore(ignoreSimilarShift, baseDimension);
+            System.arraycopy(ignoreSimilarShift, 0, ignoreNearExpectedFromAboveByRatio, 0, baseDimension);
+        }
+    }
+
+    public void setIgnoreNearExpectedFromBelowByRatio(double[] ignoreSimilarShift) {
+        if (ignoreSimilarShift != null) {
+            validateIgnore(ignoreSimilarShift, baseDimension);
+            System.arraycopy(ignoreSimilarShift, 0, ignoreNearExpectedFromBelowByRatio, 0, baseDimension);
+        }
+    }
+
+    // to be used for the state classes only
     public void setIgnoreNearExpected(double[] ignoreSimilarShift) {
         if (ignoreSimilarShift != null) {
-            validateIgnore(ignoreSimilarShift);
+            validateIgnore(ignoreSimilarShift, 4 * baseDimension);
             System.arraycopy(ignoreSimilarShift, 0, ignoreNearExpectedFromAbove, 0, baseDimension);
             System.arraycopy(ignoreSimilarShift, baseDimension, ignoreNearExpectedFromBelow, 0, baseDimension);
             System.arraycopy(ignoreSimilarShift, 2 * baseDimension, ignoreNearExpectedFromAboveByRatio, 0,

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
@@ -33,7 +33,6 @@ import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.calibration.Calibration;
 import com.amazon.randomcutforest.parkservices.preprocessor.Preprocessor;
 import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
-import com.amazon.randomcutforest.returntypes.RangeVector;
 
 @Getter
 @Setter
@@ -203,12 +202,4 @@ public class RCFCaster extends ThresholdedRandomCutForest {
         return answer;
     }
 
-    public RangeVector computeErrorPercentile(double percentile, BiFunction<Float, Float, Float> error) {
-        return computeErrorPercentile(percentile, errorHorizon, error);
-    }
-
-    public RangeVector computeErrorPercentile(double percentile, int newHorizon,
-            BiFunction<Float, Float, Float> error) {
-        return errorHandler.computeErrorPercentile(percentile, newHorizon, error);
-    }
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
@@ -28,6 +28,7 @@ import lombok.Setter;
 
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.calibration.Calibration;
 import com.amazon.randomcutforest.parkservices.preprocessor.Preprocessor;
@@ -126,10 +127,11 @@ public class RCFCaster extends ThresholdedRandomCutForest {
     }
 
     // for mappers
-    public RCFCaster(ForestMode forestMode, TransformMethod transformMethod, RandomCutForest forest,
-            PredictorCorrector predictorCorrector, Preprocessor preprocessor, RCFComputeDescriptor descriptor,
-            int forecastHorizon, ErrorHandler errorHandler, int errorHorizon, Calibration calibrationMethod) {
-        super(forestMode, transformMethod, forest, predictorCorrector, preprocessor, descriptor);
+    public RCFCaster(ForestMode forestMode, TransformMethod transformMethod, ScoringStrategy scoringStrategy,
+            RandomCutForest forest, PredictorCorrector predictorCorrector, Preprocessor preprocessor,
+            RCFComputeDescriptor descriptor, int forecastHorizon, ErrorHandler errorHandler, int errorHorizon,
+            Calibration calibrationMethod) {
+        super(forestMode, transformMethod, scoringStrategy, forest, predictorCorrector, preprocessor, descriptor);
         this.forecastHorizon = forecastHorizon;
         this.errorHandler = errorHandler;
         this.errorHorizon = errorHorizon;

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.ImputationMethod;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.returntypes.DiVector;
 
@@ -40,6 +41,8 @@ public class RCFComputeDescriptor extends Point implements IRCFComputeDescriptor
     TransformMethod transformMethod = TransformMethod.NONE;
 
     ImputationMethod imputationMethod = ImputationMethod.PREVIOUS;
+
+    ScoringStrategy scoringStrategy = ScoringStrategy.EXPECTED_INVERSE_DEPTH;
 
     // the most important parameter of the forest
     int shingleSize;
@@ -211,6 +214,9 @@ public class RCFComputeDescriptor extends Point implements IRCFComputeDescriptor
         answer.setNumberOfNewImputes(numberOfNewImputes);
         answer.setLastAnomalyInternalTimestamp(lastAnomalyInternalTimestamp);
         answer.setLastExpecteRCFdPoint(lastExpectedRCFPoint);
+        answer.setScoringStrategy(scoringStrategy);
         return answer;
     }
+
+    double alternateGrade;
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/SequentialAnalysis.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/SequentialAnalysis.java
@@ -31,7 +31,7 @@ import com.amazon.randomcutforest.parkservices.returntypes.AnalysisDescriptor;
 public class SequentialAnalysis {
 
     /**
-     * provides a list of anomnalies given a block of data. While this is a fairly
+     * provides a list of anomalies given a block of data. While this is a fairly
      * simple function, it is provided as a reference such that users do not have
      * depend on interpretations of sequentian analysis
      * 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -151,24 +151,10 @@ public class ThresholdedRandomCutForest {
 
         predictorCorrector.setScoreDifferencing(builder.scoreDifferencing.orElse(DEFAULT_SCORE_DIFFERENCING));
         int base = builder.dimensions / builder.shingleSize;
-        double[] nearExpected = new double[4 * base];
-        builder.ignoreNearExpectedFromAbove.ifPresent(array -> {
-            validateNonNegativeArray(array, base);
-            System.arraycopy(array, 0, nearExpected, 0, base);
-        });
-        builder.ignoreNearExpectedFromBelow.ifPresent(array -> {
-            validateNonNegativeArray(array, base);
-            System.arraycopy(array, 0, nearExpected, base, base);
-        });
-        builder.ignoreNearExpectedFromAboveByRatio.ifPresent(array -> {
-            validateNonNegativeArray(array, base);
-            System.arraycopy(array, 0, nearExpected, 2 * base, base);
-        });
-        builder.ignoreNearExpectedFromBelowByRatio.ifPresent(array -> {
-            validateNonNegativeArray(array, base);
-            System.arraycopy(array, 0, nearExpected, 3 * base, base);
-        });
-        predictorCorrector.setIgnoreNearExpected(nearExpected);
+        builder.ignoreNearExpectedFromAbove.ifPresent(predictorCorrector::setIgnoreNearExpectedFromAbove);
+        builder.ignoreNearExpectedFromBelow.ifPresent(predictorCorrector::setIgnoreNearExpectedFromBelow);
+        builder.ignoreNearExpectedFromAboveByRatio.ifPresent(predictorCorrector::setIgnoreNearExpectedFromAboveByRatio);
+        builder.ignoreNearExpectedFromBelowByRatio.ifPresent(predictorCorrector::setIgnoreNearExpectedFromBelowByRatio);
         predictorCorrector.setLastStrategy(builder.scoringStrategy);
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -128,7 +128,7 @@ public class ThresholdedRandomCutForest {
 
         preprocessor = preprocessorBuilder.build();
         predictorCorrector = new PredictorCorrector(forest.getTimeDecay(), builder.anomalyRate, builder.adjustThreshold,
-                builder.learnNearIgnoreExpected, builder.dimensions / builder.shingleSize,
+                builder.learnIgnoreNearExpected, builder.dimensions / builder.shingleSize,
                 builder.randomSeed.orElse(0L));
         lastAnomalyDescriptor = new RCFComputeDescriptor(null, 0, builder.forestMode, builder.transformMethod,
                 builder.imputationMethod);
@@ -169,6 +169,7 @@ public class ThresholdedRandomCutForest {
             System.arraycopy(array, 0, nearExpected, 3 * base, base);
         });
         predictorCorrector.setIgnoreNearExpected(nearExpected);
+        predictorCorrector.setLastStrategy(builder.scoringStrategy);
     }
 
     void validateNonNegativeArray(double[] array, int num) {
@@ -388,10 +389,6 @@ public class ThresholdedRandomCutForest {
         predictorCorrector.setInitialThreshold(initial);
     }
 
-    public void setIgnoreNearExpected(double[] shift) {
-        predictorCorrector.setIgnoreNearExpected(shift);
-    }
-
     /**
      * @return a new builder.
      */
@@ -434,7 +431,7 @@ public class ThresholdedRandomCutForest {
         protected double[] weights = null;
         protected Optional<Double> useImputedFraction = Optional.empty();
         protected boolean adjustThreshold = DEFAULT_AUTO_THRESHOLD;
-        protected boolean learnNearIgnoreExpected = false;
+        protected boolean learnIgnoreNearExpected = false;
         protected Optional<Double> transformDecay = Optional.empty();
         protected Optional<double[]> ignoreNearExpectedFromAbove = Optional.empty();
         protected Optional<double[]> ignoreNearExpectedFromBelow = Optional.empty();
@@ -652,7 +649,7 @@ public class ThresholdedRandomCutForest {
         }
 
         public T learnIgnoreNearExpected(boolean learnNearIgnoreExpected) {
-            this.learnNearIgnoreExpected = learnNearIgnoreExpected;
+            this.learnIgnoreNearExpected = learnNearIgnoreExpected;
             return (T) this;
         }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForest.java
@@ -15,26 +15,6 @@
 
 package com.amazon.randomcutforest.parkservices;
 
-import com.amazon.randomcutforest.RandomCutForest;
-import com.amazon.randomcutforest.config.ForestMode;
-import com.amazon.randomcutforest.config.ImputationMethod;
-import com.amazon.randomcutforest.config.Precision;
-import com.amazon.randomcutforest.config.ScoringStrategy;
-import com.amazon.randomcutforest.config.TransformMethod;
-import com.amazon.randomcutforest.parkservices.preprocessor.IPreprocessor;
-import com.amazon.randomcutforest.parkservices.preprocessor.Preprocessor;
-import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
-import com.amazon.randomcutforest.parkservices.threshold.BasicThresholder;
-import com.amazon.randomcutforest.returntypes.RangeVector;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.function.Function;
-
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_BOUNDING_BOX_CACHE_FRACTION;
@@ -53,6 +33,27 @@ import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_LOWER_THRESHOLD_NORMALIZED;
 import static com.amazon.randomcutforest.parkservices.threshold.BasicThresholder.DEFAULT_SCORE_DIFFERENCING;
 import static java.lang.Math.max;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.function.Function;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.ImputationMethod;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.config.TransformMethod;
+import com.amazon.randomcutforest.parkservices.preprocessor.IPreprocessor;
+import com.amazon.randomcutforest.parkservices.preprocessor.Preprocessor;
+import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
+import com.amazon.randomcutforest.parkservices.threshold.BasicThresholder;
+import com.amazon.randomcutforest.returntypes.RangeVector;
 
 /**
  * This class provides a combined RCF and thresholder, both of which operate in
@@ -127,8 +128,8 @@ public class ThresholdedRandomCutForest {
 
         preprocessor = preprocessorBuilder.build();
         predictorCorrector = new PredictorCorrector(forest.getTimeDecay(), builder.anomalyRate, builder.adjustThreshold,
-                builder.learnNearIgnoreExpected,
-                builder.dimensions / builder.shingleSize, builder.randomSeed.orElse(0L));
+                builder.learnNearIgnoreExpected, builder.dimensions / builder.shingleSize,
+                builder.randomSeed.orElse(0L));
         lastAnomalyDescriptor = new RCFComputeDescriptor(null, 0, builder.forestMode, builder.transformMethod,
                 builder.imputationMethod);
 
@@ -161,11 +162,11 @@ public class ThresholdedRandomCutForest {
         });
         builder.ignoreNearExpectedFromAboveByRatio.ifPresent(array -> {
             validateNonNegativeArray(array, base);
-            System.arraycopy(array, base, nearExpected, 2 * base, base);
+            System.arraycopy(array, 0, nearExpected, 2 * base, base);
         });
         builder.ignoreNearExpectedFromBelowByRatio.ifPresent(array -> {
             validateNonNegativeArray(array, base);
-            System.arraycopy(array, base, nearExpected, 3 * base, base);
+            System.arraycopy(array, 0, nearExpected, 3 * base, base);
         });
         predictorCorrector.setIgnoreNearExpected(nearExpected);
     }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
@@ -295,9 +295,9 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
             if (result.getAnomalyGrade() > 0 && (numberOfImputed == 0 || (result.getTransformMethod() != DIFFERENCE)
                     && (result.getTransformMethod() != NORMALIZE_DIFFERENCE))) {
                 // we cannot predict expected value easily if there are gaps in the shingle
-                // this is doubly complicated for differenced transforms (if there are anu
+                // this is doubly complicated for differenced transforms (if there are any
                 // imputations in the shingle)
-                addRelevantAttribution(result);
+                populateAnomalyDescriptorDetails(result);
             }
             generateShingle(result, getTimeFactor(timeStampDeviations[0]), true, forest);
         }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
@@ -77,7 +77,6 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
             }
         }
         initialValues[valuesSeen] = temp;
-        ++valuesSeen;
     }
 
     /**
@@ -172,8 +171,6 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
             storeInitial(description.getCurrentInput(), description.getInputTimestamp(),
                     description.getMissingValues());
             return description;
-        } else if (valuesSeen == startNormalization) {
-            dischargeInitial(forest);
         }
 
         checkArgument(description.getInputTimestamp() > previousTimeStamps[shingleSize - 1],
@@ -197,11 +194,9 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
         lastShingledInput = Arrays.copyOf(savedShingledInput, savedShingledInput.length);
         lastShingledPoint = Arrays.copyOf(savedShingle, savedShingle.length);
 
-        if (point == null) {
-            return description;
+        if (point != null) {
+            description.setRCFPoint(point);
         }
-
-        description.setRCFPoint(point);
         description.setInternalTimeStamp(internalTimeStamp + description.getNumberOfNewImputes());
         return description;
     }
@@ -291,20 +286,21 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
     public AnomalyDescriptor postProcess(AnomalyDescriptor result, IRCFComputeDescriptor lastAnomalyDescriptor,
             RandomCutForest forest) {
 
+        if (valuesSeen == startNormalization - 1) {
+            dischargeInitial(forest);
+        }
+
         double[] point = result.getRCFPoint();
-        if (point == null) {
-            return result;
+        if (point != null) {
+            if (result.getAnomalyGrade() > 0 && (numberOfImputed == 0 || (result.getTransformMethod() != DIFFERENCE)
+                    && (result.getTransformMethod() != NORMALIZE_DIFFERENCE))) {
+                // we cannot predict expected value easily if there are gaps in the shingle
+                // this is doubly complicated for differenced transforms (if there are anu
+                // imputations in the shingle)
+                addRelevantAttribution(result);
+            }
+            generateShingle(result, timeStampDeviations[0].getMean(), true, forest);
         }
-
-        if (result.getAnomalyGrade() > 0 && (numberOfImputed == 0 || (result.getTransformMethod() != DIFFERENCE)
-                && (result.getTransformMethod() != NORMALIZE_DIFFERENCE))) {
-            // we cannot predict expected value easily if there are gaps in the shingle
-            // this is doubly complicated for differenced transforms (if there are anu
-            // imputations in the shingle)
-            addRelevantAttribution(result);
-        }
-
-        generateShingle(result, timeStampDeviations[0].getMean(), true, forest);
         ++valuesSeen;
         return result;
     }
@@ -324,7 +320,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
         Deviation[] deviations = getDeviations();
         Arrays.fill(previousTimeStamps, initialTimeStamps[0]);
         numberOfImputed = shingleSize;
-        for (int i = 0; i < valuesSeen; i++) {
+        for (int i = 0; i < valuesSeen + 1; i++) {
             // initial imputation; not using the global dependency
             long lastInputTimeStamp = previousTimeStamps[shingleSize - 1];
             if (internalTimeStamp > 0) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
@@ -772,7 +772,7 @@ public class Preprocessor implements IPreprocessor {
                 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return clipFactor;
         }
-        if (value - deviation[0].getMean() < -NORMALIZATION_SCALING_FACTOR * clipFactor
+        if (value - deviation[0].getMean() <= -NORMALIZATION_SCALING_FACTOR * clipFactor
                 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return -clipFactor;
         } else {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
@@ -15,14 +15,15 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor.transform;
 
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
-import com.amazon.randomcutforest.returntypes.RangeVector;
-import lombok.Getter;
-import lombok.Setter;
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 
 import java.util.Arrays;
 
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import lombok.Getter;
+import lombok.Setter;
+
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.returntypes.RangeVector;
 
 /**
  * A weighted transformer maintains several data structures ( currently 3X) that
@@ -210,7 +211,7 @@ public class WeightedTransformer implements ITransformer {
     }
 
     public double[] getSmoothedDeviations() {
-        checkArgument(deviations.length >= 3* weights.length, "incorrect call");
+        checkArgument(deviations.length >= 3 * weights.length, "incorrect call");
         double[] answer = new double[weights.length];
         for (int i = 0; i < weights.length; i++) {
             answer[i] = Math.abs(deviations[i + 2 * weights.length].getMean());

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
@@ -58,7 +58,6 @@ public class ThresholdedRandomCutForestMapper
         if (state.getScoringStrategy() != null && !state.getScoringStrategy().isEmpty()) {
             scoringStrategy = ScoringStrategy.valueOf(state.getScoringStrategy());
         }
-        ;
 
         RCFComputeDescriptor descriptor;
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestMapper.java
@@ -21,14 +21,16 @@ import lombok.Setter;
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.ImputationMethod;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.config.TransformMethod;
-import com.amazon.randomcutforest.parkservices.IRCFComputeDescriptor;
 import com.amazon.randomcutforest.parkservices.PredictorCorrector;
 import com.amazon.randomcutforest.parkservices.RCFComputeDescriptor;
 import com.amazon.randomcutforest.parkservices.ThresholdedRandomCutForest;
 import com.amazon.randomcutforest.parkservices.preprocessor.Preprocessor;
+import com.amazon.randomcutforest.parkservices.state.predictorcorrector.PredictorCorrectorMapper;
 import com.amazon.randomcutforest.parkservices.state.preprocessor.PreprocessorMapper;
 import com.amazon.randomcutforest.parkservices.state.preprocessor.PreprocessorState;
+import com.amazon.randomcutforest.parkservices.state.returntypes.ComputeDescriptorMapper;
 import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderMapper;
 import com.amazon.randomcutforest.parkservices.threshold.BasicThresholder;
 import com.amazon.randomcutforest.state.IStateMapper;
@@ -44,36 +46,55 @@ public class ThresholdedRandomCutForestMapper
     public ThresholdedRandomCutForest toModel(ThresholdedRandomCutForestState state, long seed) {
 
         RandomCutForestMapper randomCutForestMapper = new RandomCutForestMapper();
-        BasicThresholderMapper thresholderMapper = new BasicThresholderMapper();
         PreprocessorMapper preprocessorMapper = new PreprocessorMapper();
 
         RandomCutForest forest = randomCutForestMapper.toModel(state.getForestState());
-        BasicThresholder thresholder = thresholderMapper.toModel(state.getThresholderState());
         Preprocessor preprocessor = preprocessorMapper.toModel(state.getPreprocessorStates()[0]);
 
         ForestMode forestMode = ForestMode.valueOf(state.getForestMode());
         TransformMethod transformMethod = TransformMethod.valueOf(state.getTransformMethod());
 
-        RCFComputeDescriptor descriptor = new RCFComputeDescriptor(null, 0L);
-        descriptor.setRCFScore(state.getLastAnomalyScore());
-        descriptor.setInternalTimeStamp(state.getLastAnomalyTimeStamp());
-        descriptor.setAttribution(new DiVectorMapper().toModel(state.getLastAnomalyAttribution()));
-        descriptor.setRCFPoint(state.getLastAnomalyPoint());
-        descriptor.setExpectedRCFPoint(state.getLastExpectedPoint());
-        descriptor.setRelativeIndex(state.getLastRelativeIndex());
+        ScoringStrategy scoringStrategy = ScoringStrategy.EXPECTED_INVERSE_DEPTH;
+        if (state.getScoringStrategy() != null && !state.getScoringStrategy().isEmpty()) {
+            scoringStrategy = ScoringStrategy.valueOf(state.getScoringStrategy());
+        }
+        ;
+
+        RCFComputeDescriptor descriptor;
+
+        if (state.getLastDescriptorState() == null) {
+            descriptor = new RCFComputeDescriptor(null, 0L);
+            descriptor.setRCFScore(state.getLastAnomalyScore());
+            descriptor.setInternalTimeStamp(state.getLastAnomalyTimeStamp());
+            descriptor.setAttribution(new DiVectorMapper().toModel(state.getLastAnomalyAttribution()));
+            descriptor.setRCFPoint(state.getLastAnomalyPoint());
+            descriptor.setExpectedRCFPoint(state.getLastExpectedPoint());
+            descriptor.setRelativeIndex(state.getLastRelativeIndex());
+            descriptor.setScoringStrategy(scoringStrategy);
+        } else {
+            descriptor = new ComputeDescriptorMapper().toModel(state.getLastDescriptorState());
+        }
+
         descriptor.setForestMode(forestMode);
         descriptor.setTransformMethod(transformMethod);
+        descriptor.setScoringStrategy(scoringStrategy);
         descriptor
                 .setImputationMethod(ImputationMethod.valueOf(state.getPreprocessorStates()[0].getImputationMethod()));
 
-        PredictorCorrector predictorCorrector = new PredictorCorrector(thresholder, preprocessor.getInputLength());
-        predictorCorrector.setNumberOfAttributors(state.getNumberOfAttributors());
-        predictorCorrector.setLastScore(state.getLastScore());
-        predictorCorrector.setIgnoreNearExpectedFromAbove(state.getIgnoreSimilarFromAbove());
-        predictorCorrector.setIgnoreNearExpectedFromBelow(state.getIgnoreSimilarFromBelow());
+        PredictorCorrector predictorCorrector;
+        if (state.getPredictorCorrectorState() == null) {
+            BasicThresholderMapper thresholderMapper = new BasicThresholderMapper();
+            BasicThresholder thresholder = thresholderMapper.toModel(state.getThresholderState());
+            predictorCorrector = new PredictorCorrector(thresholder, preprocessor.getInputLength());
+            predictorCorrector.setNumberOfAttributors(state.getNumberOfAttributors());
+            predictorCorrector.setLastScore(new double[] { state.getLastScore() });
+        } else {
+            PredictorCorrectorMapper mapper = new PredictorCorrectorMapper();
+            predictorCorrector = mapper.toModel(state.getPredictorCorrectorState());
+        }
 
-        return new ThresholdedRandomCutForest(forestMode, transformMethod, forest, predictorCorrector, preprocessor,
-                descriptor);
+        return new ThresholdedRandomCutForest(forestMode, transformMethod, scoringStrategy, forest, predictorCorrector,
+                preprocessor, descriptor);
     }
 
     @Override
@@ -88,25 +109,17 @@ public class ThresholdedRandomCutForestMapper
 
         state.setForestState(randomCutForestMapper.toState(model.getForest()));
 
-        BasicThresholderMapper thresholderMapper = new BasicThresholderMapper();
-        state.setThresholderState(thresholderMapper.toState(model.getThresholder()));
-
         PreprocessorMapper preprocessorMapper = new PreprocessorMapper();
         state.setPreprocessorStates(
                 new PreprocessorState[] { preprocessorMapper.toState((Preprocessor) model.getPreprocessor()) });
-        state.setNumberOfAttributors(model.getPredictorCorrector().getNumberOfAttributors());
+
+        state.setPredictorCorrectorState(new PredictorCorrectorMapper().toState(model.getPredictorCorrector()));
         state.setForestMode(model.getForestMode().name());
         state.setTransformMethod(model.getTransformMethod().name());
+        state.setScoringStrategy(model.getScoringStrategy().name());
 
-        IRCFComputeDescriptor descriptor = model.getLastAnomalyDescriptor();
-        state.setLastAnomalyTimeStamp(descriptor.getInternalTimeStamp());
-        state.setLastAnomalyScore(descriptor.getRCFScore());
-        state.setLastAnomalyAttribution(new DiVectorMapper().toState(descriptor.getAttribution()));
-        state.setLastAnomalyPoint(descriptor.getRCFPoint());
-        state.setLastExpectedPoint(descriptor.getExpectedRCFPoint());
-        state.setLastRelativeIndex(descriptor.getRelativeIndex());
-        state.setLastScore(model.getLastScore());
-
+        state.setLastDescriptorState(
+                new ComputeDescriptorMapper().toState((RCFComputeDescriptor) model.getLastAnomalyDescriptor()));
         return state;
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
@@ -15,13 +15,15 @@
 
 package com.amazon.randomcutforest.parkservices.state;
 
-import static com.amazon.randomcutforest.state.Version.V3_7;
+import static com.amazon.randomcutforest.state.Version.V3_8;
 
 import java.io.Serializable;
 
 import lombok.Data;
 
+import com.amazon.randomcutforest.parkservices.state.predictorcorrector.PredictorCorrectorState;
 import com.amazon.randomcutforest.parkservices.state.preprocessor.PreprocessorState;
+import com.amazon.randomcutforest.parkservices.state.returntypes.ComputeDescriptorState;
 import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
 import com.amazon.randomcutforest.state.RandomCutForestState;
 import com.amazon.randomcutforest.state.returntypes.DiVectorState;
@@ -30,10 +32,14 @@ import com.amazon.randomcutforest.state.returntypes.DiVectorState;
 public class ThresholdedRandomCutForestState implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String version = V3_7;
+    private String version = V3_8;
     RandomCutForestState forestState;
+    // deprecated but not marked due to 2.1 models
     private BasicThresholderState thresholderState;
     private PreprocessorState[] preprocessorStates;
+
+    // following fields are deprecated, but not removed for compatibility with 2.1
+    // moels
     private double ignoreSimilarFactor;
     private double triggerFactor;
     private long lastAnomalyTimeStamp;
@@ -46,14 +52,17 @@ public class ThresholdedRandomCutForestState implements Serializable {
     private boolean inHighScoreRegion;
     private boolean ignoreSimilar;
     private int numberOfAttributors;
+    // end deprecated segment
 
     private long randomSeed;
 
     private String forestMode;
     private String transformMethod;
+    private String scoringStrategy;
+    @Deprecated
     private int lastRelativeIndex;
     private int lastReset;
-    private double[] ignoreSimilarFromAbove;
-    private double[] ignoreSimilarFromBelow;
+    private PredictorCorrectorState predictorCorrectorState;
+    private ComputeDescriptorState lastDescriptorState;
 
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/ThresholdedRandomCutForestState.java
@@ -39,7 +39,7 @@ public class ThresholdedRandomCutForestState implements Serializable {
     private PreprocessorState[] preprocessorStates;
 
     // following fields are deprecated, but not removed for compatibility with 2.1
-    // moels
+    // models
     private double ignoreSimilarFactor;
     private double triggerFactor;
     private long lastAnomalyTimeStamp;
@@ -59,7 +59,6 @@ public class ThresholdedRandomCutForestState implements Serializable {
     private String forestMode;
     private String transformMethod;
     private String scoringStrategy;
-    @Deprecated
     private int lastRelativeIndex;
     private int lastReset;
     private PredictorCorrectorState predictorCorrectorState;

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/errorhandler/ErrorHandlerMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/errorhandler/ErrorHandlerMapper.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.randomcutforest.parkservices.state;
+package com.amazon.randomcutforest.parkservices.state.errorhandler;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/errorhandler/ErrorHandlerState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/errorhandler/ErrorHandlerState.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.randomcutforest.parkservices.state;
+package com.amazon.randomcutforest.parkservices.state.errorhandler;
 
 import java.io.Serializable;
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.state.predictorcorrector;
+
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.parkservices.PredictorCorrector;
+import com.amazon.randomcutforest.parkservices.state.statistics.DeviationMapper;
+import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
+import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderMapper;
+import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.parkservices.threshold.BasicThresholder;
+import com.amazon.randomcutforest.state.IStateMapper;
+
+public class PredictorCorrectorMapper implements IStateMapper<PredictorCorrector, PredictorCorrectorState> {
+
+    @Override
+    public PredictorCorrectorState toState(PredictorCorrector model) {
+        PredictorCorrectorState state = new PredictorCorrectorState();
+        state.setLastScore(model.getLastScore());
+        state.setNumberOfAttributors(model.getNumberOfAttributors());
+        state.setIgnoreNearExpected(model.getIgnoreNearExpected());
+        BasicThresholderMapper mapper = new BasicThresholderMapper();
+        BasicThresholder[] thresholders = model.getThresholders();
+        BasicThresholderState thresholderState[] = new BasicThresholderState[thresholders.length];
+        for (int y = 0; y < thresholders.length; y++) {
+            thresholderState[y] = mapper.toState(thresholders[y]);
+        }
+        state.setThresholderStates(thresholderState);
+        DeviationMapper devMapper = new DeviationMapper();
+        Deviation[] deviations = model.getDeviations();
+        state.setAutoAdjust(model.isAutoAdjust());
+        if (state.isAutoAdjust()) {
+            DeviationState deviationState[] = new DeviationState[deviations.length];
+            for (int y = 0; y < thresholders.length; y++) {
+                deviationState[y] = devMapper.toState(deviations[y]);
+            }
+            state.setDeviationStates(deviationState);
+        }
+        state.setBaseDimension(model.getBaseDimension());
+        state.setLastStrategy(model.getLastStrategy().name());
+        state.setRandomSeed(model.getRandomSeed());
+        return state;
+    }
+
+    @Override
+    public PredictorCorrector toModel(PredictorCorrectorState state, long seed) {
+        BasicThresholderMapper mapper = new BasicThresholderMapper();
+        int num = state.getThresholderStates().length;
+        BasicThresholder[] thresholders = new BasicThresholder[num];
+        for (int i = 0; i < num; i++) {
+            thresholders[i] = mapper.toModel(state.getThresholderStates()[i]);
+        }
+        Deviation[] deviations = null;
+        if (state.isAutoAdjust()) {
+            DeviationMapper devMapper = new DeviationMapper();
+            deviations = new Deviation[state.getDeviationStates().length];
+            for (int y = 0; y < deviations.length; y++) {
+                deviations[y] = devMapper.toModel(state.getDeviationStates()[y]);
+            }
+        }
+        PredictorCorrector predictorCorrector = new PredictorCorrector(thresholders, deviations,
+                state.getBaseDimension(), state.getRandomSeed());
+        predictorCorrector.setNumberOfAttributors(state.getNumberOfAttributors());
+        predictorCorrector.setLastStrategy(ScoringStrategy.valueOf(state.getLastStrategy()));
+        predictorCorrector.setLastScore(state.getLastScore());
+        predictorCorrector.setIgnoreNearExpected(state.getIgnoreNearExpected());
+        predictorCorrector.setAutoAdjust(state.isAutoAdjust());
+        return predictorCorrector;
+    }
+
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
@@ -45,7 +45,7 @@ public class PredictorCorrectorMapper implements IStateMapper<PredictorCorrector
         state.setAutoAdjust(model.isAutoAdjust());
         if (state.isAutoAdjust()) {
             DeviationState deviationState[] = new DeviationState[deviations.length];
-            for (int y = 0; y < thresholders.length; y++) {
+            for (int y = 0; y < deviations.length; y++) {
                 deviationState[y] = devMapper.toState(deviations[y]);
             }
             state.setDeviationStates(deviationState);

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.state.predictorcorrector;
+
+import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
+import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
+import lombok.Data;
+
+import java.io.Serializable;
+
+import static com.amazon.randomcutforest.state.Version.V3_8;
+
+@Data
+public class PredictorCorrectorState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String version = V3_8;
+    private BasicThresholderState[] thresholderStates;
+    private double[] lastScore;
+    private String lastStrategy;
+    private int numberOfAttributors;
+    private int baseDimension;
+    private long randomSeed;
+    private boolean autoAdjust;
+    private double[] modeInformation; // multiple modes -- to be used in future
+    private DeviationState[] deviationStates; // in future to be used for learning deviations
+    private double[] ignoreNearExpected;
+
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
@@ -15,13 +15,14 @@
 
 package com.amazon.randomcutforest.parkservices.state.predictorcorrector;
 
-import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
-import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
-import lombok.Data;
+import static com.amazon.randomcutforest.state.Version.V3_8;
 
 import java.io.Serializable;
 
-import static com.amazon.randomcutforest.state.Version.V3_8;
+import lombok.Data;
+
+import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
+import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
 
 @Data
 public class PredictorCorrectorState implements Serializable {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices.state.returntypes;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.parkservices.RCFComputeDescriptor;
+import com.amazon.randomcutforest.state.IStateMapper;
+import com.amazon.randomcutforest.state.returntypes.DiVectorMapper;
+
+@Getter
+@Setter
+public class ComputeDescriptorMapper implements IStateMapper<RCFComputeDescriptor, ComputeDescriptorState> {
+
+    @Override
+    public RCFComputeDescriptor toModel(ComputeDescriptorState state, long seed) {
+
+        RCFComputeDescriptor descriptor = new RCFComputeDescriptor(null, 0L);
+        descriptor.setRCFScore(state.getLastAnomalyScore());
+        descriptor.setInternalTimeStamp(state.getLastAnomalyTimeStamp());
+        descriptor.setAttribution(new DiVectorMapper().toModel(state.getLastAnomalyAttribution()));
+        descriptor.setRCFPoint(state.getLastAnomalyPoint());
+        descriptor.setExpectedRCFPoint(state.getLastExpectedPoint());
+        descriptor.setRelativeIndex(state.getLastRelativeIndex());
+        descriptor.setScoringStrategy(ScoringStrategy.valueOf(state.getLastStrategy()));
+        return descriptor;
+    }
+
+    @Override
+    public ComputeDescriptorState toState(RCFComputeDescriptor descriptor) {
+
+        ComputeDescriptorState state = new ComputeDescriptorState();
+        state.setLastAnomalyTimeStamp(descriptor.getInternalTimeStamp());
+        state.setLastAnomalyScore(descriptor.getRCFScore());
+        state.setLastAnomalyAttribution(new DiVectorMapper().toState(descriptor.getAttribution()));
+        state.setLastAnomalyPoint(descriptor.getRCFPoint());
+        state.setLastExpectedPoint(descriptor.getExpectedRCFPoint());
+        state.setLastRelativeIndex(descriptor.getRelativeIndex());
+        state.setLastStrategy(descriptor.getScoringStrategy().name());
+        return state;
+    }
+
+}

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorState.java
@@ -13,21 +13,26 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.randomcutforest.parkservices.state;
+package com.amazon.randomcutforest.parkservices.state.returntypes;
 
-import static com.amazon.randomcutforest.state.Version.V3_8;
+import java.io.Serializable;
 
 import lombok.Data;
 
-import com.amazon.randomcutforest.parkservices.state.errorhandler.ErrorHandlerState;
+import com.amazon.randomcutforest.state.returntypes.DiVectorState;
 
 @Data
-public class RCFCasterState extends ThresholdedRandomCutForestState {
+public class ComputeDescriptorState implements Serializable {
     private static final long serialVersionUID = 1L;
-    private String version = V3_8;
 
-    private int forecastHorizon;
-    private ErrorHandlerState errorHandler;
-    private int errorHorizon;
-    private String calibrationMethod;
+    private long lastAnomalyTimeStamp;
+    private double lastAnomalyScore;
+    private DiVectorState lastAnomalyAttribution;
+    private double lastScore;
+    private double[] lastAnomalyPoint;
+    private double[] lastExpectedPoint;
+    private int lastRelativeIndex;
+    private int lastReset;
+    private String lastStrategy;
+
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholder.java
@@ -15,18 +15,18 @@
 
 package com.amazon.randomcutforest.parkservices.threshold;
 
-import com.amazon.randomcutforest.config.TransformMethod;
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
-import com.amazon.randomcutforest.util.Weighted;
-
-import java.util.List;
-
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SAMPLE_SIZE;
 import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SAMPLE_SIZE_COEFFICIENT_IN_TIME_DECAY;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.sqrt;
+
+import java.util.List;
+
+import com.amazon.randomcutforest.config.TransformMethod;
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.util.Weighted;
 
 public class BasicThresholder {
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -84,9 +84,15 @@ public class AnomalyDescriptorTest {
                         if (firstResult.getRelativeIndex() == 0) {
                             assertArrayEquals(firstResult.getPastValues(), firstResult.getCurrentInput(), 1e-10);
                         }
-                        if (firstResult.isReasonableForecast()) {
-                            assertNotNull(firstResult.getExpectedValuesList());
-                            assertNotNull(firstResult.getExpectedValuesList()[0]); // the expected value
+                        if (firstResult.getExpectedValuesList() != null
+                                && firstResult.getExpectedValuesList()[0] != null) {
+                            assert (firstResult.isReasonableForecast());
+                            // the converse is not true -- the algorithm can get confused by an anomaly
+                            // in the multivariate case and choose to not output imprecise answers
+                            // an obvious example is a (x,y) distribution where it is (0,0) or (1,1)
+                            // If the input is (0,1) then both answers are feasible -- but this becomes
+                            // increasingly difficult to ascertain (based on small data) as dimensions
+                            // increase
                         }
                         assertNotNull(firstResult.getRelevantAttribution());
                         assertEquals(firstResult.getRelevantAttribution().length, baseDimensions);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -18,6 +18,7 @@ package com.amazon.randomcutforest.parkservices;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
 
@@ -67,15 +68,15 @@ public class AnomalyDescriptorTest {
                     assertEquals(firstResult.getRCFScore(), 0);
                 } else {
                     // distances can be 0
-                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
-                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
+                    assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
+                    assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
                     assertEquals(firstResult.getScale().length, baseDimensions);
                     assertEquals(firstResult.getShift().length, baseDimensions);
                     assert (firstResult.getRelativeIndex() <= 0);
                     if (count == 82 && strategy != ScoringStrategy.DISTANCE) {
                         // because distances are 0 till sampleSize; by which time
                         // forecasts would be reasonable
-                        assert (firstResult.getAnomalyGrade() > 0);
+                        assertTrue(firstResult.getAnomalyGrade() > 0);
                         assert (!firstResult.isReasonableForecast());
                     }
                     if (firstResult.getAnomalyGrade() > 0) {
@@ -86,7 +87,7 @@ public class AnomalyDescriptorTest {
                         }
                         if (firstResult.getExpectedValuesList() != null
                                 && firstResult.getExpectedValuesList()[0] != null) {
-                            assert (firstResult.isReasonableForecast());
+                            assertTrue(firstResult.isReasonableForecast());
                             // the converse is not true -- the algorithm can get confused by an anomaly
                             // in the multivariate case and choose to not output imprecise answers
                             // an obvious example is a (x,y) distribution where it is (0,0) or (1,1)
@@ -100,10 +101,10 @@ public class AnomalyDescriptorTest {
                         // the reverse of this condition need not be true -- the predictor corrector
                         // often may declare grade 0 even when score is greater than threshold, to
                         // account for shingling and initial results that populate the thresholder
-                        assert (strategy == ScoringStrategy.MULTI_MODE_RECALL
+                        assertTrue(strategy == ScoringStrategy.MULTI_MODE_RECALL
                                 || firstResult.getRCFScore() >= firstResult.getThreshold());
                     } else {
-                        assert (firstResult.getRelativeIndex() == 0);
+                        assertTrue(firstResult.getRelativeIndex() == 0);
                     }
                 }
                 ++count;
@@ -144,8 +145,8 @@ public class AnomalyDescriptorTest {
                     assertEquals(firstResult.getRCFScore(), 0);
                 } else {
                     // distances can be 0
-                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
-                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
+                    assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
+                    assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
                     assertEquals(firstResult.getScale().length, baseDimensions + 1);
                     assertEquals(firstResult.getShift().length, baseDimensions + 1);
                     assert (firstResult.getRelativeIndex() <= 0);
@@ -158,7 +159,7 @@ public class AnomalyDescriptorTest {
                         assertEquals(firstResult.attribution.getHighLowSum(), firstResult.getRCFScore(), 1e-6);
                         assertNotNull(firstResult.getRelevantAttribution());
                         assertEquals(firstResult.getRelevantAttribution().length, baseDimensions);
-                        assert (strategy == ScoringStrategy.MULTI_MODE_RECALL
+                        assertTrue(strategy == ScoringStrategy.MULTI_MODE_RECALL
                                 || firstResult.getRCFScore() >= firstResult.getThreshold());
                     }
                 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -77,7 +77,7 @@ public class AnomalyDescriptorTest {
                         // because distances are 0 till sampleSize; by which time
                         // forecasts would be reasonable
                         assertTrue(firstResult.getAnomalyGrade() > 0);
-                        assert (!firstResult.isReasonableForecast());
+                        assertTrue(!firstResult.isReasonableForecast());
                     }
                     if (firstResult.getAnomalyGrade() > 0) {
                         assertNotNull(firstResult.getPastValues());

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -72,7 +72,7 @@ public class AnomalyDescriptorTest {
                     assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
                     assertEquals(firstResult.getScale().length, baseDimensions);
                     assertEquals(firstResult.getShift().length, baseDimensions);
-                    assert (firstResult.getRelativeIndex() <= 0);
+                    assertTrue(firstResult.getRelativeIndex() <= 0);
                     if (count == 82 && strategy != ScoringStrategy.DISTANCE) {
                         // because distances are 0 till sampleSize; by which time
                         // forecasts would be reasonable
@@ -149,7 +149,7 @@ public class AnomalyDescriptorTest {
                     assertTrue(strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
                     assertEquals(firstResult.getScale().length, baseDimensions + 1);
                     assertEquals(firstResult.getShift().length, baseDimensions + 1);
-                    assert (firstResult.getRelativeIndex() <= 0);
+                    assertTrue(firstResult.getRelativeIndex() <= 0);
                     if (firstResult.getAnomalyGrade() > 0) {
                         assertNotNull(firstResult.getPastValues());
                         assertEquals(firstResult.getPastValues().length, baseDimensions);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Random;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
+import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+
+public class AnomalyDescriptorTest {
+
+    @ParameterizedTest
+    @EnumSource(ScoringStrategy.class)
+    public void PastValuesTest(ScoringStrategy strategy) {
+        int sampleSize = 256;
+        long seed = new Random().nextLong();
+        System.out.println(" seed " + seed);
+        Random rng = new Random(seed);
+        int numTrials = 10; // just once since testing exact equality
+        int length = 40 * sampleSize;
+        for (int i = 0; i < numTrials; i++) {
+
+            int outputAfter = 2 + 1;
+            int shingleSize = 1 + rng.nextInt(15);
+            int baseDimensions = 1 + rng.nextInt(5);
+            int dimensions = baseDimensions * shingleSize;
+            ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(rng.nextLong())
+                    .outputAfter(outputAfter).scoringStrategy(strategy).internalShinglingEnabled(true)
+                    .shingleSize(shingleSize).build();
+
+            MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(length, 50, 100, 5,
+                    rng.nextLong(), baseDimensions);
+
+            int count = 0;
+            for (double[] point : dataWithKeys.data) {
+                AnomalyDescriptor firstResult = first.process(point, 0L);
+                assertArrayEquals(firstResult.getCurrentInput(), point, 1e-6);
+                assertEquals(firstResult.scoringStrategy, strategy);
+                if (count < outputAfter || count < shingleSize) {
+                    assertEquals(firstResult.getRCFScore(), 0);
+                } else {
+                    // distances can be 0
+                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
+                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
+                    assertEquals(firstResult.getScale().length, baseDimensions);
+                    assertEquals(firstResult.getShift().length, baseDimensions);
+                    assert (firstResult.getRelativeIndex() <= 0);
+                    if (firstResult.getAnomalyGrade() > 0) {
+                        assertNotNull(firstResult.getPastValues());
+                        assertEquals(firstResult.getPastValues().length, baseDimensions);
+                        if (firstResult.getRelativeIndex() == 0) {
+                            assertArrayEquals(firstResult.getPastValues(), firstResult.getCurrentInput(), 1e-10);
+                        }
+                        assertNotNull(firstResult.getRelevantAttribution());
+                        assertEquals(firstResult.getRelevantAttribution().length, baseDimensions);
+                        assertEquals(firstResult.attribution.getHighLowSum(), firstResult.getRCFScore(), 1e-6);
+                        // the reverse of this condition need not be true -- the predictor corrector
+                        // often may declare grade 0 even when score is greater than threshold, to
+                        // account for shingling and initial results that populate the thresholder
+                        assert (strategy == ScoringStrategy.MULTI_MODE_RECALL
+                                || firstResult.getRCFScore() >= firstResult.getThreshold());
+                    }
+                }
+                ++count;
+
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ScoringStrategy.class)
+    public void TimeAugmentedTest(ScoringStrategy strategy) {
+        int sampleSize = 256;
+        long seed = new Random().nextLong();
+        System.out.println(" seed " + seed);
+        Random rng = new Random(seed);
+        int numTrials = 10; // just once since testing exact equality
+        int length = 40 * sampleSize;
+        for (int i = 0; i < numTrials; i++) {
+
+            int outputAfter = 2 + 1;
+            int shingleSize = 1 + rng.nextInt(15);
+            int baseDimensions = 1 + rng.nextInt(5);
+            int dimensions = baseDimensions * shingleSize;
+            ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(rng.nextLong())
+                    .outputAfter(outputAfter).forestMode(ForestMode.TIME_AUGMENTED).scoringStrategy(strategy)
+                    .internalShinglingEnabled(true).shingleSize(shingleSize).build();
+
+            MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(length, 50, 100, 5,
+                    rng.nextLong(), baseDimensions);
+
+            int count = 0;
+            for (double[] point : dataWithKeys.data) {
+                AnomalyDescriptor firstResult = first.process(point, 0L);
+                assertArrayEquals(firstResult.getCurrentInput(), point, 1e-6);
+                assertEquals(firstResult.scoringStrategy, strategy);
+                if (count < outputAfter || count < shingleSize) {
+                    assertEquals(firstResult.getRCFScore(), 0);
+                } else {
+                    // distances can be 0
+                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.getRCFScore() > 0);
+                    assert (strategy == ScoringStrategy.DISTANCE || firstResult.threshold > 0);
+                    assertEquals(firstResult.getScale().length, baseDimensions + 1);
+                    assertEquals(firstResult.getShift().length, baseDimensions + 1);
+                    assert (firstResult.getRelativeIndex() <= 0);
+                    if (firstResult.getAnomalyGrade() > 0) {
+                        assertNotNull(firstResult.getPastValues());
+                        assertEquals(firstResult.getPastValues().length, baseDimensions);
+                        if (firstResult.getRelativeIndex() == 0) {
+                            assertArrayEquals(firstResult.getPastValues(), firstResult.getCurrentInput(), 1e-10);
+                        }
+                        assertEquals(firstResult.attribution.getHighLowSum(), firstResult.getRCFScore(), 1e-6);
+                        assertNotNull(firstResult.getRelevantAttribution());
+                        assertEquals(firstResult.getRelevantAttribution().length, baseDimensions);
+                        assert (strategy == ScoringStrategy.MULTI_MODE_RECALL
+                                || firstResult.getRCFScore() >= firstResult.getThreshold());
+                    }
+                }
+                ++count;
+
+            }
+        }
+    }
+}

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
@@ -15,6 +15,18 @@
 
 package com.amazon.randomcutforest.parkservices;
 
+import static com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys.generateShingledData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.Precision;
@@ -22,17 +34,6 @@ import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.state.ThresholdedRandomCutForestMapper;
 import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
 import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-
-import java.util.Arrays;
-import java.util.Random;
-
-import static com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys.generateShingledData;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("functional")
 public class ConsistencyTest {

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ConsistencyTest.java
@@ -15,17 +15,6 @@
 
 package com.amazon.randomcutforest.parkservices;
 
-import static com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys.generateShingledData;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Random;
-
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.Precision;
@@ -33,6 +22,17 @@ import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.state.ThresholdedRandomCutForestMapper;
 import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
 import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys.generateShingledData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("functional")
 public class ConsistencyTest {
@@ -46,7 +46,7 @@ public class ConsistencyTest {
         long seed = new Random().nextLong();
 
         int numTrials = 1; // just once since testing exact equality
-        int length = 400 * sampleSize;
+        int length = 40 * sampleSize;
         for (int i = 0; i < numTrials; i++) {
 
             RandomCutForest forest = RandomCutForest.builder().compact(true).dimensions(dimensions)
@@ -132,22 +132,29 @@ public class ConsistencyTest {
         long seed = new Random().nextLong();
         System.out.println(seed);
 
-        int numTrials = 1; // test is exact equality, reducing the number of trials
+        Random rng = new Random(seed);
+
+        int numTrials = 5; // test is exact equality, reducing the number of trials
         int numberOfTrees = 30; // and using fewer trees to speed up test
-        int length = 400 * sampleSize;
+        int length = 40 * sampleSize;
         int testLength = length;
         for (int i = 0; i < numTrials; i++) {
 
+            long newSeed = rng.nextLong();
+            int outputAfter = rng.nextInt(sampleSize * 10) + 1;
             ThresholdedRandomCutForest first = new ThresholdedRandomCutForest.Builder<>().compact(true)
-                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed).numberOfTrees(numberOfTrees)
-                    .internalShinglingEnabled(true).shingleSize(shingleSize).anomalyRate(0.01).build();
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(newSeed)
+                    .numberOfTrees(numberOfTrees).internalShinglingEnabled(true)
+                    // increasing outputAfter for internal shingling
+                    .outputAfter(outputAfter + shingleSize - 1).shingleSize(shingleSize).anomalyRate(0.01).build();
 
             ThresholdedRandomCutForest second = new ThresholdedRandomCutForest.Builder<>().compact(true)
-                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed).numberOfTrees(numberOfTrees)
-                    .internalShinglingEnabled(false).shingleSize(shingleSize).anomalyRate(0.01).build();
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(newSeed)
+                    .numberOfTrees(numberOfTrees).internalShinglingEnabled(false).outputAfter(outputAfter)
+                    .shingleSize(shingleSize).anomalyRate(0.01).build();
 
             MultiDimDataWithKey dataWithKeys = ShingledMultiDimDataWithKeys.getMultiDimData(length + testLength, 50,
-                    100, 5, seed + i, baseDimensions);
+                    100, 5, newSeed + i, baseDimensions);
 
             double[][] shingledData = generateShingledData(dataWithKeys.data, shingleSize, baseDimensions, false);
 
@@ -211,7 +218,6 @@ public class ConsistencyTest {
             long seed = new Random().nextLong();
             System.out.println("seed = " + seed);
 
-            // TransformMethod transformMethod = TransformMethod.NONE;
             ThresholdedRandomCutForest first = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
                     .randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
                     .internalShinglingEnabled(true).precision(precision).anomalyRate(0.01)
@@ -265,13 +271,13 @@ public class ConsistencyTest {
         }
     }
 
+    // streaming impute changes normalizations
     @ParameterizedTest
-    @EnumSource(value = TransformMethod.class, names = { "WEIGHTED", "NORMALIZE", "NORMALIZE_DIFFERENCE", "DIFFERENCE",
-            "SUBTRACT_MA" })
+    @EnumSource(TransformMethod.class)
     public void ImputeTest(TransformMethod transformMethod) {
 
         int sampleSize = 256;
-        int baseDimensions = 1;
+        int baseDimensions = 2;
         int shingleSize = 4;
         int dimensions = baseDimensions * shingleSize;
 
@@ -283,26 +289,25 @@ public class ConsistencyTest {
             Precision precision = Precision.FLOAT_32;
             long seed = new Random().nextLong();
             System.out.println("seed = " + seed);
-            double[] weights = new double[] { 1.7, 4.2 };
+            Random rng = new Random(seed);
+            double[] weights = new double[baseDimensions];
+            Arrays.fill(weights, 1.0);
 
+            int startNormalization = 10;
+            int outputAfter = startNormalization + shingleSize;
+            long newSeed = rng.nextLong();
             ThresholdedRandomCutForest first = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
-                    .randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
+                    .randomSeed(newSeed).numberOfTrees(numberOfTrees).shingleSize(shingleSize).sampleSize(sampleSize)
                     .internalShinglingEnabled(true).precision(precision).anomalyRate(0.01)
                     .forestMode(ForestMode.STANDARD).weightTime(0).transformMethod(transformMethod).normalizeTime(true)
-                    .outputAfter(32).initialAcceptFraction(0.125).weights(weights).build();
+                    .startNormalization(startNormalization).outputAfter(outputAfter).initialAcceptFraction(0.125)
+                    .weights(weights).build();
             ThresholdedRandomCutForest second = ThresholdedRandomCutForest.builder().compact(true)
-                    .dimensions(dimensions).randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize)
+                    .dimensions(dimensions).randomSeed(newSeed).numberOfTrees(numberOfTrees).shingleSize(shingleSize)
                     .sampleSize(sampleSize).internalShinglingEnabled(true).precision(precision).anomalyRate(0.01)
                     .forestMode(ForestMode.STREAMING_IMPUTE).weightTime(0).transformMethod(transformMethod)
-                    .normalizeTime(true).outputAfter(32).initialAcceptFraction(0.125).weights(weights).build();
-
-            // ensuring that the parameters are the same; otherwise the grades/scores cannot
-            // be the same
-            // weighTime has to be 0 in the above
-            first.setLowerThreshold(1.1);
-            second.setLowerThreshold(1.1);
-            first.setHorizon(0.75);
-            second.setHorizon(0.75);
+                    .startNormalization(startNormalization).normalizeTime(true).outputAfter(outputAfter)
+                    .initialAcceptFraction(0.125).weights(weights).build();
 
             Random noise = new Random(0);
 
@@ -312,7 +317,7 @@ public class ConsistencyTest {
 
             for (int j = 0; j < length; j++) {
                 // gap has to be asymptotically same
-                long timestamp = 100 * j + noise.nextInt(10) - 5;
+                long timestamp = 100 * j + 0 * noise.nextInt(10) - 5;
                 AnomalyDescriptor result = first.process(dataWithKeys.data[j], 0L);
                 AnomalyDescriptor test = second.process(dataWithKeys.data[j], timestamp);
                 assertEquals(result.getRCFScore(), test.getRCFScore(), 1e-6);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import static com.amazon.randomcutforest.config.TransformMethod.NORMALIZE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.returntypes.DiVector;
+
+public class PredictorCorrectorTest {
+
+    @Test
+    void AttributorTest() {
+        int sampleSize = 256;
+        int baseDimensions = 10;
+        int shingleSize = 10;
+        int dimensions = baseDimensions * shingleSize;
+        ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
+                .precision(Precision.FLOAT_32).randomSeed(0L).forestMode(ForestMode.STANDARD).shingleSize(shingleSize)
+                .anomalyRate(0.01).transformMethod(NORMALIZE).build();
+        DiVector test = new DiVector(baseDimensions * shingleSize);
+        assert (forest.predictorCorrector.getExpectedPoint(test, 0, baseDimensions, null, null) == null);
+        assertThrows(IllegalArgumentException.class, () -> forest.predictorCorrector.setNumberOfAttributors(-1));
+        forest.predictorCorrector.setNumberOfAttributors(baseDimensions);
+        assertThrows(NullPointerException.class,
+                () -> forest.predictorCorrector.getExpectedPoint(test, 0, baseDimensions, null, null));
+    }
+
+}

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
@@ -16,12 +16,22 @@
 package com.amazon.randomcutforest.parkservices;
 
 import static com.amazon.randomcutforest.config.TransformMethod.NORMALIZE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.config.ScoringStrategy;
+import com.amazon.randomcutforest.parkservices.state.predictorcorrector.PredictorCorrectorMapper;
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
 import com.amazon.randomcutforest.returntypes.DiVector;
 
 public class PredictorCorrectorTest {
@@ -41,6 +51,70 @@ public class PredictorCorrectorTest {
         forest.predictorCorrector.setNumberOfAttributors(baseDimensions);
         assertThrows(NullPointerException.class,
                 () -> forest.predictorCorrector.getExpectedPoint(test, 0, baseDimensions, null, null));
+        double[] array = new double[20];
+        Arrays.fill(array, 1.0);
+        DiVector testTwo = new DiVector(array, array);
+        assertThrows(NullPointerException.class,
+                () -> forest.predictorCorrector.getExpectedPoint(test, 0, baseDimensions, null, null));
+    }
+
+    @Test
+    void configTest() {
+        int sampleSize = 256;
+        int baseDimensions = 2;
+        int shingleSize = 10;
+        int dimensions = baseDimensions * shingleSize;
+        double[] testOne = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testTwo = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testThree = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testFour = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
+                .precision(Precision.FLOAT_32).randomSeed(0L).forestMode(ForestMode.STANDARD).shingleSize(shingleSize)
+                .anomalyRate(0.01).scoringStrategy(ScoringStrategy.DISTANCE).transformMethod(NORMALIZE)
+                .learnIgnoreNearExpected(true).ignoreNearExpectedFromAbove(testOne).ignoreNearExpectedFromBelow(testTwo)
+                .ignoreNearExpectedFromAboveByRatio(testThree).ignoreNearExpectedFromBelowByRatio(testFour).build();
+        PredictorCorrector predictorCorrector = forest.getPredictorCorrector();
+        double[] test = new double[1];
+        assertThrows(IllegalArgumentException.class, () -> predictorCorrector.setIgnoreNearExpected(test));
+        assertDoesNotThrow(() -> predictorCorrector.setIgnoreNearExpected(null));
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAbove, testOne, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelow, testTwo, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAboveByRatio, testThree, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelowByRatio, testFour, 1e-10);
+        assertNotNull(predictorCorrector.getDeviations());
+        assertEquals(predictorCorrector.lastStrategy, ScoringStrategy.DISTANCE);
+
+        PredictorCorrectorMapper mapper = new PredictorCorrectorMapper();
+        PredictorCorrector copy = mapper.toModel(mapper.toState(predictorCorrector));
+        assertArrayEquals(copy.ignoreNearExpectedFromAbove, testOne, 1e-10);
+        assertArrayEquals(copy.ignoreNearExpectedFromBelow, testTwo, 1e-10);
+        assertArrayEquals(copy.ignoreNearExpectedFromAboveByRatio, testThree, 1e-10);
+        assertArrayEquals(copy.ignoreNearExpectedFromBelowByRatio, testFour, 1e-10);
+        assertNotNull(copy.getDeviations());
+        assertEquals(copy.lastStrategy, ScoringStrategy.DISTANCE);
+        copy.deviationsAbove = new Deviation[1]; // changing the state
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> copy.getDeviations());
+        assertEquals("incorrect state", exception.getMessage());
+        copy.deviationsBelow = new Deviation[1];
+        exception = assertThrows(IllegalArgumentException.class, () -> copy.getDeviations());
+        assertEquals("length should be base dimension", exception.getMessage());
+
+        double[] another = new double[4 * baseDimensions];
+        assertDoesNotThrow(() -> predictorCorrector.setIgnoreNearExpected(another));
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAbove, new double[2]);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelow, new double[2]);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAboveByRatio, new double[2]);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelowByRatio, new double[2]);
+        another[0] = -1;
+        assertThrows(IllegalArgumentException.class, () -> predictorCorrector.setIgnoreNearExpected(another));
+
+        long randomSeed = new Random(0L).nextLong();
+        Random testRandom = new Random(randomSeed);
+        assertEquals(predictorCorrector.getRandomSeed(), randomSeed);
+        double nextDouble = predictorCorrector.nextDouble();
+        assertEquals(predictorCorrector.getRandomSeed(), testRandom.nextLong());
+        assertEquals(nextDouble, testRandom.nextDouble(), 1e-10);
+
     }
 
 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/PredictorCorrectorTest.java
@@ -107,6 +107,14 @@ public class PredictorCorrectorTest {
         assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelowByRatio, new double[2]);
         another[0] = -1;
         assertThrows(IllegalArgumentException.class, () -> predictorCorrector.setIgnoreNearExpected(another));
+        predictorCorrector.setIgnoreNearExpectedFromAbove(testOne);
+        predictorCorrector.setIgnoreNearExpectedFromBelow(testTwo);
+        predictorCorrector.setIgnoreNearExpectedFromAboveByRatio(testThree);
+        predictorCorrector.setIgnoreNearExpectedFromBelowByRatio(testFour);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAbove, testOne, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelow, testTwo, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromAboveByRatio, testThree, 1e-10);
+        assertArrayEquals(predictorCorrector.ignoreNearExpectedFromBelowByRatio, testFour, 1e-10);
 
         long randomSeed = new Random(0L).nextLong();
         Random testRandom = new Random(randomSeed);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TestGlobalLocalAnomalyDetector.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TestGlobalLocalAnomalyDetector.java
@@ -34,7 +34,7 @@ import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.Test;
 
-import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.ScoringStrategy;
 import com.amazon.randomcutforest.parkservices.returntypes.GenericAnomalyDescriptor;
 import com.amazon.randomcutforest.summarization.Summarizer;
 import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
@@ -214,7 +214,7 @@ public class TestGlobalLocalAnomalyDetector {
         reservoir.setZfactor(zFactor);
 
         ThresholdedRandomCutForest test = ThresholdedRandomCutForest.builder().dimensions(2).shingleSize(1)
-                .randomSeed(77).timeDecay(timedecay).forestMode(ForestMode.DISTANCE).build();
+                .randomSeed(77).timeDecay(timedecay).scoringStrategy(ScoringStrategy.DISTANCE).build();
         test.setZfactor(zFactor); // using the same apples to apples comparison
 
         String name = "clustering_example";

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
@@ -238,9 +238,11 @@ public class ThresholdedRandomCutForestTest {
         // only at most 76% imputed tuples are allowed in the forest
         // an additional one arise from the actual input
         assertEquals(forest.getForest().getTotalUpdates(), count + 1);
-        // triggerring consecutive anomalies (no differencing) -- this should fail
-        // because we discover previous point is still the cause
-        assertEquals(forest.process(newData, (long) count * 113 + 1113).getAnomalyGrade(), 0);
+        // triggerring consecutive anomalies (no differencing)
+        // Note Next will have an obvious issue with consecutive anomalies
+        if (method != NEXT) {
+            assertEquals(forest.process(newData, (long) count * 113 + 1113).getAnomalyGrade(), 1.0);
+        }
         assert (forest.process(new double[] { 20 }, (long) count * 113 + 1226).getAnomalyGrade() > 0);
 
         long stamp = (long) count * 113 + 1226;
@@ -434,7 +436,7 @@ public class ThresholdedRandomCutForestTest {
             ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true)
                     .dimensions(dimensions).randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize)
                     .sampleSize(sampleSize).precision(precision).anomalyRate(0.01).forestMode(ForestMode.STANDARD)
-                    .build();
+                    .transformMethod(transformMethod).build();
 
             long seed = new Random().nextLong();
             System.out.println("seed = " + seed);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/ThresholdedRandomCutForestTest.java
@@ -16,6 +16,7 @@
 package com.amazon.randomcutforest.parkservices;
 
 import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
+import static com.amazon.randomcutforest.config.ImputationMethod.LINEAR;
 import static com.amazon.randomcutforest.config.ImputationMethod.NEXT;
 import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
 import static com.amazon.randomcutforest.config.ImputationMethod.RCF;
@@ -26,7 +27,9 @@ import static com.amazon.randomcutforest.config.TransformMethod.NORMALIZE_DIFFER
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -147,6 +150,59 @@ public class ThresholdedRandomCutForestTest {
                     .forestMode(ForestMode.STANDARD).shingleSize(shingleSize).anomalyRate(0.01)
                     .transformMethod(NORMALIZE).startNormalization(111).stopNormalization(100).build();
         });
+        // change if baseDimension != 2
+        double[] testOne = new double[] { 0 };
+        double[] testTwo = new double[] { 0, -1 };
+        double[] testThree = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testFour = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testFive = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        double[] testSix = new double[] { new Random().nextDouble(), new Random().nextDouble() };
+        assertThrows(IllegalArgumentException.class, () -> {
+            ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
+                    .forestMode(ForestMode.STANDARD).shingleSize(shingleSize).anomalyRate(0.01)
+                    .transformMethod(NORMALIZE).ignoreNearExpectedFromAbove(testOne).build();
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
+                    .forestMode(ForestMode.STANDARD).shingleSize(shingleSize).anomalyRate(0.01)
+                    .transformMethod(NORMALIZE).ignoreNearExpectedFromAbove(testTwo).build();
+        });
+        assertDoesNotThrow(() -> {
+            ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
+                    .forestMode(ForestMode.STANDARD).shingleSize(shingleSize).anomalyRate(0.01)
+                    .transformMethod(NORMALIZE).ignoreNearExpectedFromAbove(testThree)
+                    .ignoreNearExpectedFromBelow(testFour).ignoreNearExpectedFromAboveByRatio(testFive)
+                    .ignoreNearExpectedFromBelowByRatio(testSix).build();
+            double[] array = forest.getPredictorCorrector().getIgnoreNearExpected();
+            assert (array.length == 4 * baseDimensions);
+            assert (array[0] == testThree[0]);
+            assert (array[1] == testThree[1]);
+            assert (array[2] == testFour[0]);
+            assert (array[3] == testFour[1]);
+            assert (array[4] == testFive[0]);
+            assert (array[5] == testFive[1]);
+            assert (array[6] == testSix[0]);
+            assert (array[7] == testSix[1]);
+            double random = new Random().nextDouble();
+            assertThrows(IllegalArgumentException.class, () -> forest.predictorCorrector.setSamplingRate(-1));
+            assertDoesNotThrow(() -> forest.predictorCorrector.setSamplingRate(random));
+            assertEquals(forest.predictorCorrector.getSamplingRate(), random, 1e-10);
+            long newSeed = forest.predictorCorrector.getRandomSeed();
+            assertEquals(new Random(seed).nextLong(), newSeed);
+            assertFalse(forest.predictorCorrector.autoAdjust);
+            assertNull(forest.predictorCorrector.getDeviations());
+        });
+        assertDoesNotThrow(() -> {
+            ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true)
+                    .dimensions(dimensions).precision(Precision.FLOAT_32).randomSeed(seed)
+                    .forestMode(ForestMode.STANDARD).shingleSize(shingleSize).anomalyRate(0.01)
+                    .transformMethod(NORMALIZE).learnIgnoreNearExpected(true).build();
+            assertTrue(forest.predictorCorrector.autoAdjust);
+            assert (forest.predictorCorrector.getDeviations().length == 2 * baseDimensions);
+        });
         ThresholdedRandomCutForest forest = ThresholdedRandomCutForest.builder().compact(true).dimensions(dimensions)
                 .precision(Precision.FLOAT_32).randomSeed(seed).forestMode(ForestMode.STANDARD).shingleSize(shingleSize)
                 .anomalyRate(0.01).transformMethod(NORMALIZE).startNormalization(111).stopNormalization(111).build();
@@ -239,8 +295,8 @@ public class ThresholdedRandomCutForestTest {
         // an additional one arise from the actual input
         assertEquals(forest.getForest().getTotalUpdates(), count + 1);
         // triggerring consecutive anomalies (no differencing)
-        // Note Next will have an obvious issue with consecutive anomalies
-        if (method != NEXT) {
+        // Note NEXT and LINEAR will have an obvious issue with consecutive anomalies
+        if (method != NEXT && method != LINEAR) {
             assertEquals(forest.process(newData, (long) count * 113 + 1113).getAnomalyGrade(), 1.0);
         }
         assert (forest.process(new double[] { 20 }, (long) count * 113 + 1226).getAnomalyGrade() > 0);

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>3.7.0</version>
+    <version>3.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>software.amazon.randomcutforest:randomcutforest</name>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>randomcutforest-serialization</artifactId>

--- a/Java/testutils/pom.xml
+++ b/Java/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>3.7.0</version>
+    <version>3.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION
*Issue #, if available:* resolves #388 and  #387

*Description of changes:*  Ensembles of models have long been used to refine results. However a significant drawback is that the space required to store the numerous model increases rapidly -- and by definition only one/few models are eventually used. One of the driving forces behind the creation of the RandomCutForest repository was to expose the RCF data structure (see https://opensearch.org/blog/random-cut-forests/) and even though it was originally used for anomaly detection, it has been used in forecasting and density estimation applications. In RCF 3.7 the forecasting capabilities were used in the predictor-corrector (an auto reinforcement) setup to reduce false positives -- this had only minimal increase in model size. This PR takes a step further and introduces multi-mode(l) operations, specifically using DISTANCE computation in density estimation to augment (as well as provide options for) the EXPECTED_INVERSE_DEPTH scoring. The latter is useful since it can provably provide conformal forecasts (RCFCast); and yet the recursive distance estimation provides a somewhat orthogonal option. The MULTI_MODE and MULTI_MODE_RECALL do increase precision and recall respectively over the current defaults; again with minimal increase in model size (however computation does increase). We intend to add other scoring strategies and (auto-)optimize the defaults in subsequent PRs. Please add an issue if any specific scoring mode is desirable. We will be adding CO_DISPLACEMENT eventually.

The PR also resolve a few corner cases of parameter settings and sundry issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
