### PR TITLE
improving precision

### DIFF
--- a/Java/core/src/main/java/com/amazon/randomcutforest/imputation/ConditionalSampleSummarizer.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/imputation/ConditionalSampleSummarizer.java
@@ -179,7 +179,7 @@ public class ConditionalSampleSummarizer {
         }
         int maxAllowed = min(queryPoint.length * MAX_NUMBER_OF_TYPICAL_PER_DIMENSION, MAX_NUMBER_OF_TYPICAL_ELEMENTS);
         maxAllowed = min(maxAllowed, num);
-        SampleSummary projectedSummary = Summarizer.summarize(typicalPoints, maxAllowed, num, false);
+        SampleSummary projectedSummary = Summarizer.l2summarize(typicalPoints, maxAllowed, num, false, 72);
 
         float[][] pointList = new float[projectedSummary.summaryPoints.length][];
         float[] likelihood = new float[projectedSummary.summaryPoints.length];

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Center.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Center.java
@@ -83,10 +83,6 @@ public class Center implements ICluster<float[]> {
         return weight;
     }
 
-    public boolean captureBeforeReset(float[] point, BiFunction<float[], float[], Double> distance) {
-        return previousWeight * distance.apply(point, representative) < 3 * previousSumOFRadius;
-    }
-
     // a standard reassignment using the median values and NOT the mean; the mean is
     // unlikely to
     // provide robust convergence

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/GenericMultiCenter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/GenericMultiCenter.java
@@ -72,10 +72,6 @@ public class GenericMultiCenter<R> implements ICluster<R> {
         this.shrinkage = shrinkage;
     }
 
-    public static <R> GenericMultiCenter<R> initialize(R coordinate, float weight) {
-        return new GenericMultiCenter<>(coordinate, weight, DEFAULT_SHRINKAGE, DEFAULT_NUMBER_OF_REPRESENTATIVES);
-    }
-
     public static <R> GenericMultiCenter<R> initialize(R coordinate, float weight, double shrinkage,
             int numberOfRepresentatives) {
         checkArgument(shrinkage >= 0 && shrinkage <= 1.0, " parameter has to be in [0,1]");
@@ -128,10 +124,6 @@ public class GenericMultiCenter<R> implements ICluster<R> {
 
     public double getWeight() {
         return weight;
-    }
-
-    public boolean captureBeforeReset(R point, BiFunction<R, R, Double> distanceFunction) {
-        return previousWeight * distance(point, distanceFunction) < 3 * previousSumOFRadius;
     }
 
     // reassignment may not be meaningful for generic types, without additional

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/ICluster.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/ICluster.java
@@ -48,9 +48,6 @@ public interface ICluster<R> {
     // weight computation
     double getWeight();
 
-    // is a point well expressed by the cluster? To be used in the future.
-    boolean captureBeforeReset(R point, BiFunction<R, R, Double> distance);
-
     // merge another cluster of same type
     void absorb(ICluster<R> other, BiFunction<R, R, Double> distance);
 

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/MultiCenter.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/MultiCenter.java
@@ -33,10 +33,6 @@ public class MultiCenter extends GenericMultiCenter<float[]> {
         this.assignedPoints = new ArrayList<>();
     }
 
-    public static MultiCenter initialize(float[] coordinate, float weight) {
-        return new MultiCenter(coordinate, weight, DEFAULT_SHRINKAGE, DEFAULT_NUMBER_OF_REPRESENTATIVES);
-    }
-
     public static MultiCenter initialize(float[] coordinate, float weight, double shrinkage,
             int numberOfRepresentatives) {
         checkArgument(shrinkage >= 0 && shrinkage <= 1.0, " parameter has to be in [0,1]");

--- a/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Summarizer.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/summarization/Summarizer.java
@@ -458,12 +458,12 @@ public class Summarizer {
      * @param maxAllowed      maximum number of groups/clusters
      * @param initial         a parameter controlling the initialization
      * @param reassignPerStep if reassignment is to be performed each step
+     * @param seed            random seed
      * @return a summarization
      */
-    public static SampleSummary summarize(List<Weighted<float[]>> points, int maxAllowed, int initial,
-            boolean reassignPerStep) {
-        return summarize(points, maxAllowed, initial, reassignPerStep, Summarizer::L2distance, new Random().nextLong(),
-                false);
+    public static SampleSummary l2summarize(List<Weighted<float[]>> points, int maxAllowed, int initial,
+            boolean reassignPerStep, long seed) {
+        return summarize(points, maxAllowed, initial, reassignPerStep, Summarizer::L2distance, seed, false);
     }
 
     /**
@@ -471,11 +471,11 @@ public class Summarizer {
      *
      * @param points     points in float[][], each of weight 1.0
      * @param maxAllowed maximum number of clusters one is interested in
+     * @param seed       random seed
      * @return a summarization
      */
-    public static SampleSummary summarize(float[][] points, int maxAllowed) {
-        return summarize(points, maxAllowed, 4 * maxAllowed, false, Summarizer::L2distance, new Random().nextLong(),
-                false);
+    public static SampleSummary l2summarize(float[][] points, int maxAllowed, long seed) {
+        return summarize(points, maxAllowed, 4 * maxAllowed, false, Summarizer::L2distance, seed, false);
     }
 
     /**
@@ -529,9 +529,9 @@ public class Summarizer {
                 clusterInitializer, seed, parallelEnabled, null);
     }
 
-    // same as above, with defaults
+    // same as above, with multicenter instead of generic
     public static List<ICluster<float[]>> multiSummarize(float[][] points, int maxAllowed, double shrinkage,
-            int numberOfRepresentatives) {
+            int numberOfRepresentatives, long seed) {
 
         ArrayList<Weighted<float[]>> weighted = new ArrayList<>();
         for (float[] point : points) {
@@ -540,7 +540,7 @@ public class Summarizer {
         BiFunction<float[], Float, ICluster<float[]>> clusterInitializer = (a, b) -> MultiCenter.initialize(a, b,
                 shrinkage, numberOfRepresentatives);
         return summarize(weighted, maxAllowed, 4 * maxAllowed, 1, true, DEFAULT_SEPARATION_RATIO_FOR_MERGE,
-                Summarizer::L2distance, clusterInitializer, new Random().nextLong(), true, null);
+                Summarizer::L2distance, clusterInitializer, seed, true, null);
     }
 
 }

--- a/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoundingBox.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/tree/BoundingBox.java
@@ -91,18 +91,6 @@ public class BoundingBox implements IBoundingBoxView {
         return new BoundingBox(minValuesMerged, maxValuesMerged, sum);
     }
 
-    public void replaceBox(float[] point) {
-        System.arraycopy(point, 0, minValues, 0, point.length);
-        System.arraycopy(point, 0, maxValues, 0, point.length);
-        rangeSum = 0;
-    }
-
-    public void copyFrom(BoundingBox otherBox) {
-        System.arraycopy(otherBox.minValues, 0, minValues, 0, otherBox.minValues.length);
-        System.arraycopy(otherBox.maxValues, 0, maxValues, 0, otherBox.maxValues.length);
-        rangeSum = otherBox.rangeSum;
-    }
-
     public double probabilityOfCut(float[] point) {
         double range = 0;
         for (int i = 0; i < point.length; i++) {

--- a/Java/core/src/test/java/com/amazon/randomcutforest/runner/SimpleDensityRunnerTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/runner/SimpleDensityRunnerTest.java
@@ -15,12 +15,21 @@
 
 package com.amazon.randomcutforest.runner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.returntypes.DensityOutput;
 
 public class SimpleDensityRunnerTest {
     private int numberOfTrees;
@@ -51,40 +60,57 @@ public class SimpleDensityRunnerTest {
         in = mock(BufferedReader.class);
         out = mock(PrintWriter.class);
     }
-    /*
-     * @Test public void testRun() throws IOException {
-     * when(in.readLine()).thenReturn("a,b") .thenReturn("1.0,2.0")
-     * .thenReturn("4.0,5.0") .thenReturn(null); runner.run(in, out);
-     * verify(out).println(
-     * "a,b,prob_mass_0_up,prob_mass_0_down,prob_mass_1_up,prob_mass_1_down");
-     * verify(out).println("1.0,2.0,0.0,0.0,0.0,0.0");
-     * verify(out).println("4.0,5.0,0.0,0.0,0.0,0.0"); }
-     * 
-     * @Test public void testWriteHeader() { String[] line = new String[] {"a",
-     * "b"}; runner.prepareAlgorithm(2); runner.writeHeader(line, out);
-     * verify(out).println(
-     * "a,b,prob_mass_0_up,prob_mass_0_down,prob_mass_1_up,prob_mass_1_down"); }
-     * 
-     * @Test public void testProcessLine() { String[] line = new String[] {"1.0",
-     * "2.0"}; runner.prepareAlgorithm(2); runner.processLine(line, out);
-     * verify(out).println("1.0,2.0,0.0,0.0,0.0,0.0"); }
-     * 
-     * @Test public void testSimpleDensityTransformer() { RandomCutForest forest =
-     * mock(RandomCutForest.class); when(forest.getDimensions()).thenReturn(2);
-     * 
-     * SimpleDensityRunner.SimpleDensityTransformer transformer = new
-     * SimpleDensityRunner.SimpleDensityTransformer(forest);
-     * 
-     * DensityOutput expected = new DensityOutput(2, 256); expected.probMass.high[0]
-     * = 0.0; expected.probMass.low[0] = 9.0; expected.probMass.high[1] = 8.0;
-     * expected.probMass.low[1] = 7.0;
-     * 
-     * when(forest.getSimpleDensity(1.0, 2.0)).thenReturn(expected);
-     * assertEquals(Arrays.asList("0.0", "9.0", "8.0", "7.0"),
-     * transformer.getResultValues(1.0, 2.0));
-     * assertEquals(Arrays.asList("prob_mass_0_up", "prob_mass_0_down",
-     * "prob_mass_1_up", "prob_mass_1_down"), transformer.getResultColumnNames());
-     * assertEquals(Arrays.asList("NA", "NA", "NA", "NA"),
-     * transformer.getEmptyResultValue()); }
-     */
+
+    @Test
+    public void testRun() throws IOException {
+        when(in.readLine()).thenReturn("a,b").thenReturn("1.0,2.0").thenReturn("4.0,5.0").thenReturn(null);
+        runner.run(in, out);
+
+        verify(out).println("a,b,prob_mass_0_up,prob_mass_0_down,prob_mass_1_up,prob_mass_1_down");
+        verify(out).println("1.0,2.0,0.000000,0.000000,0.000000,0.000000");
+        verify(out).println("4.0,5.0,0.000000,0.000000,0.000000,0.000000");
+    }
+
+    @Test
+    public void testWriteHeader() {
+        String[] line = new String[] { "a", "b" };
+        runner.prepareAlgorithm(2);
+        runner.writeHeader(line, out);
+        verify(out).println("a,b,prob_mass_0_up,prob_mass_0_down,prob_mass_1_up,prob_mass_1_down");
+    }
+
+    @Test
+    public void testProcessLine() {
+        String[] line = new String[] { "1.0", "2.0" };
+        runner.prepareAlgorithm(2);
+        runner.processLine(line, out);
+
+        verify(out).println("1.0,2.0,0.000000,0.000000,0.000000,0.000000");
+    }
+
+    @Test
+    public void testSimpleDensityTransformer() {
+        RandomCutForest forest = mock(RandomCutForest.class);
+        when(forest.getDimensions()).thenReturn(2);
+        SimpleDensityRunner.SimpleDensityTransformer transformer = new SimpleDensityRunner.SimpleDensityTransformer(
+                forest);
+
+        DensityOutput expected = new DensityOutput(2, 1);
+        expected.probMass.high[0] = 0.0;
+        expected.probMass.low[0] = 0.5;
+        expected.probMass.high[1] = 0.25;
+        expected.probMass.low[1] = 0.25;
+        expected.measure.high[0] = 0.0;
+        expected.measure.low[0] = 8.0;
+        expected.measure.high[1] = 8.0;
+        expected.measure.low[1] = 4.0;
+
+        when(forest.getSimpleDensity(new double[] { 1.0, 2.0 })).thenReturn(expected);
+        assertEquals(Arrays.asList("0.000000", "400.000000", "400.000000", "200.000000"),
+                transformer.getResultValues(1.0, 2.0));
+        assertEquals(Arrays.asList("prob_mass_0_up", "prob_mass_0_down", "prob_mass_1_up", "prob_mass_1_down"),
+                transformer.getResultColumnNames());
+        assertEquals(Arrays.asList("NA", "NA", "NA", "NA"), transformer.getEmptyResultValue());
+    }
+
 }

--- a/Java/core/src/test/java/com/amazon/randomcutforest/tree/BoundingBoxTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/tree/BoundingBoxTest.java
@@ -19,7 +19,9 @@ import static com.amazon.randomcutforest.TestUtils.EPSILON;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -59,10 +61,19 @@ public class BoundingBoxTest {
         assertThat((float) box2.getMaxValue(1), is(point2[1]));
         assertThat(box2.getRange(1), is(0.0));
         assertThat(box2.getRangeSum(), is(0.0));
+
+        assertTrue(box1.probabilityOfCut(point2) == 1.0);
+        assertTrue(box1.probabilityOfCut(point1) == 0.0);
     }
 
     @Test
     public void testGetMergedBoxWithOtherBox() {
+
+        assertThrows(IllegalStateException.class, () -> box1.addBox(box2));
+        assertThrows(IllegalArgumentException.class, () -> box1.addPoint(new float[1]));
+        assertThrows(IllegalArgumentException.class, () -> box1.addPoint(new float[2]));
+        assertDoesNotThrow(() -> box1.copy().addPoint(new float[2]));
+
         BoundingBox mergedBox = box1.getMergedBox(box2);
 
         assertThat(mergedBox.getDimensions(), is(2));

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/RCFCasterExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/parkservices/RCFCasterExample.java
@@ -15,11 +15,6 @@
 
 package com.amazon.randomcutforest.examples.parkservices;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Arrays;
-
 import com.amazon.randomcutforest.config.Precision;
 import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.examples.Example;
@@ -30,6 +25,11 @@ import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.returntypes.RangeVector;
 import com.amazon.randomcutforest.testutils.MultiDimDataWithKey;
 import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * The following example demonstrates the self calibration of RCFCast. Change
@@ -154,7 +154,7 @@ public class RCFCasterExample implements Example {
         float[] lowerError = result.getObservedErrorDistribution().lower;
         DiVector rmse = result.getErrorRMSE();
         float[] mean = result.getErrorMean();
-        float[] calibration = result.getCalibration();
+        float[] calibration = result.getIntervalPrecision();
 
         file.append(current + " " + 1000 + "\n");
         file.append("\n");

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/summarization/RCFMultiSummarizeExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/summarization/RCFMultiSummarizeExample.java
@@ -69,7 +69,8 @@ public class RCFMultiSummarizeExample implements Example {
         float[][] points = getData(dataSize, newDimensions, random.nextInt(), Summarizer::L2distance);
 
         double epsilon = 0.01;
-        List<ICluster<float[]>> summary = Summarizer.multiSummarize(points, 5 * newDimensions, 0.1, 5);
+        List<ICluster<float[]>> summary = Summarizer.multiSummarize(points, 5 * newDimensions, 0.1, 5,
+                random.nextLong());
         System.out.println(summary.size() + " clusters for " + newDimensions + " dimensions, seed : " + seed);
         double weight = summary.stream().map(e -> e.getWeight()).reduce(Double::sum).get();
         System.out.println(

--- a/Java/examples/src/main/java/com/amazon/randomcutforest/examples/summarization/RCFSummarizeExample.java
+++ b/Java/examples/src/main/java/com/amazon/randomcutforest/examples/summarization/RCFSummarizeExample.java
@@ -15,17 +15,17 @@
 
 package com.amazon.randomcutforest.examples.summarization;
 
-import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
-import static java.lang.Math.abs;
+import com.amazon.randomcutforest.examples.Example;
+import com.amazon.randomcutforest.returntypes.SampleSummary;
+import com.amazon.randomcutforest.summarization.Summarizer;
+import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
 
 import java.util.Arrays;
 import java.util.Random;
 import java.util.function.BiFunction;
 
-import com.amazon.randomcutforest.examples.Example;
-import com.amazon.randomcutforest.returntypes.SampleSummary;
-import com.amazon.randomcutforest.summarization.Summarizer;
-import com.amazon.randomcutforest.testutils.NormalMixtureTestData;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
+import static java.lang.Math.abs;
 
 /**
  * The following example is based off a test of summarization and provides an
@@ -67,7 +67,7 @@ public class RCFSummarizeExample implements Example {
 
         float[][] points = getData(dataSize, newDimensions, random.nextInt(), Summarizer::L2distance);
 
-        SampleSummary summary = Summarizer.summarize(points, 5 * newDimensions);
+        SampleSummary summary = Summarizer.l2summarize(points, 5 * newDimensions,42);
         System.out.println(
                 summary.summaryPoints.length + " clusters for " + newDimensions + " dimensions, seed : " + seed);
         double epsilon = 0.01;

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptor.java
@@ -22,10 +22,6 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.amazon.randomcutforest.config.ForestMode;
-import com.amazon.randomcutforest.config.ImputationMethod;
-import com.amazon.randomcutforest.config.TransformMethod;
-
 @Getter
 @Setter
 public class AnomalyDescriptor extends RCFComputeDescriptor {
@@ -72,11 +68,6 @@ public class AnomalyDescriptor extends RCFComputeDescriptor {
 
     public AnomalyDescriptor(double[] input, long inputTimeStamp) {
         super(input, inputTimeStamp);
-    }
-
-    public AnomalyDescriptor(double[] input, long inputTimeStamp, ForestMode forestMode,
-            TransformMethod transformMethod, ImputationMethod imputationMethod) {
-        super(input, inputTimeStamp, forestMode, transformMethod, imputationMethod);
     }
 
     public void setPastValues(double[] values) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ForecastDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/ForecastDescriptor.java
@@ -22,9 +22,6 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.amazon.randomcutforest.config.ForestMode;
-import com.amazon.randomcutforest.config.ImputationMethod;
-import com.amazon.randomcutforest.config.TransformMethod;
 import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.returntypes.RangeVector;
@@ -76,7 +73,7 @@ public class ForecastDescriptor extends AnomalyDescriptor {
      * the fraction of variables \predicted correctly over the error horizon. A
      * value of 1.0 is terrific.
      */
-    float[] calibration;
+    float[] intervalPrecision;
 
     public ForecastDescriptor(double[] input, long inputTimeStamp, int horizon) {
         super(input, inputTimeStamp);
@@ -87,18 +84,7 @@ public class ForecastDescriptor extends AnomalyDescriptor {
         Arrays.fill(this.observedErrorDistribution.upper, Float.MAX_VALUE);
         this.errorMean = new float[forecastLength];
         this.errorRMSE = new DiVector(forecastLength);
-        this.calibration = new float[forecastLength];
-    }
-
-    public ForecastDescriptor(double[] input, long inputTimeStamp, ForestMode forestMode,
-            TransformMethod transformMethod, ImputationMethod imputationMethod, int dimensions, int horizon) {
-        super(input, inputTimeStamp, forestMode, transformMethod, imputationMethod);
-        this.timedForecast = new TimedRangeVector(dimensions, horizon);
-        this.observedErrorDistribution = new RangeVector(dimensions);
-        Arrays.fill(this.observedErrorDistribution.lower, -Float.MAX_VALUE);
-        Arrays.fill(this.observedErrorDistribution.upper, Float.MAX_VALUE);
-        this.errorMean = new float[dimensions];
-        this.errorRMSE = new DiVector(dimensions);
+        this.intervalPrecision = new float[forecastLength];
     }
 
     void setObservedErrorDistribution(RangeVector base) {
@@ -108,8 +94,13 @@ public class ForecastDescriptor extends AnomalyDescriptor {
         System.arraycopy(base.lower, 0, this.observedErrorDistribution.lower, 0, base.lower.length);
     }
 
-    void setCalibration(float[] calibration) {
-        System.arraycopy(calibration, 0, this.calibration, 0, calibration.length);
+    void setIntervalPrecision(float[] calibration) {
+        System.arraycopy(calibration, 0, this.intervalPrecision, 0, calibration.length);
+    }
+
+    @Deprecated
+    float[] getCalibration() {
+        return (intervalPrecision == null) ? null : Arrays.copyOf(intervalPrecision, intervalPrecision.length);
     }
 
     void setErrorMean(float[] errorMean) {

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFCaster.java
@@ -16,11 +16,9 @@
 package com.amazon.randomcutforest.parkservices;
 
 import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_OUTPUT_AFTER_FRACTION;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
 
-import java.util.Optional;
 import java.util.function.BiFunction;
 
 import lombok.Getter;
@@ -39,8 +37,6 @@ import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
 public class RCFCaster extends ThresholdedRandomCutForest {
 
     public static double DEFAULT_ERROR_PERCENTILE = 0.1;
-
-    public static boolean USE_INTERPOLATION_IN_DISTRIBUTION = true;
 
     public static Calibration DEFAULT_CALIBRATION = Calibration.SIMPLE;
 
@@ -100,11 +96,6 @@ public class RCFCaster extends ThresholdedRandomCutForest {
                     "internal shingling only");
             if (errorHorizon == 0) {
                 errorHorizon = max(sampleSize, 2 * forecastHorizon);
-            }
-            if (outputAfter.isPresent()) {
-                startNormalization = Optional.of(outputAfter.get() + shingleSize - 1);
-            } else {
-                startNormalization = Optional.of((int) (sampleSize * DEFAULT_OUTPUT_AFTER_FRACTION) + shingleSize - 1);
             }
             validate();
             return new RCFCaster(this);
@@ -167,6 +158,7 @@ public class RCFCaster extends ThresholdedRandomCutForest {
     public ForecastDescriptor process(double[] inputPoint, long timestamp, int[] missingValues) {
         checkArgument(missingValues == null, "on the fly imputation and error estimation should not mix");
         ForecastDescriptor initial = new ForecastDescriptor(inputPoint, timestamp, forecastHorizon);
+        initial.setScoringStrategy(scoringStrategy);
         ForecastDescriptor answer;
         boolean cacheDisabled = (forest.getBoundingBoxCacheFraction() == 0);
         try {
@@ -174,21 +166,29 @@ public class RCFCaster extends ThresholdedRandomCutForest {
                 // turn caching on temporarily
                 forest.setBoundingBoxCacheFraction(1.0);
             }
-            // forecast first
-            // if calibration is not set then RCF has to produce the model errors; otherwise
-            // RCF can focus on p50
-            double centralty = (calibrationMethod == Calibration.NONE) ? 1.0 - 2 * errorHandler.percentile : 1.0;
-            TimedRangeVector timedForecast = extrapolate(forecastHorizon, true, centralty);
             // anomaly computation next; and subsequent update
             answer = preprocessor.postProcess(
                     predictorCorrector.detect(preprocessor.preProcess(initial, lastAnomalyDescriptor, forest),
                             lastAnomalyDescriptor, forest),
                     lastAnomalyDescriptor, forest);
+
+            if (answer.getAnomalyGrade() > 0) {
+                lastAnomalyDescriptor = answer.copyOf();
+            }
+
+            // if the last point was an anomaly then it would be corrected
+            // note that forecast would show up for a point even when the anomaly score is 0
+            // because anomaly designation needs X previous points and forecast needs X
+            // points
+            TimedRangeVector timedForecast = extrapolate(forecastHorizon);
             answer.setTimedForecast(timedForecast);
 
-            if (answer.internalTimeStamp >= forest.getShingleSize() - 1 + forest.getOutputAfter()) {
+            // note that internal timestamp of answer is 1 step in the past
+            // outputReady corresponds to first (and subsequent) forecast
+            if (forest.isOutputReady()) {
                 errorHandler.update(answer, calibrationMethod);
             }
+
         } finally {
             if (cacheDisabled) {
                 // turn caching off
@@ -196,9 +196,6 @@ public class RCFCaster extends ThresholdedRandomCutForest {
             }
         }
 
-        if (answer.getAnomalyGrade() > 0) {
-            lastAnomalyDescriptor = answer.copyOf();
-        }
         return answer;
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/RCFComputeDescriptor.java
@@ -93,9 +93,11 @@ public class RCFComputeDescriptor extends Point implements IRCFComputeDescriptor
      */
     int relativeIndex;
 
-    // useful for RCFCaster errors while the model is calibrating itself
-    // will be null except for RCFCaster
+    // useful for detecting noise
     double[] deviations;
+
+    // useful for calibration in RCFCaster
+    double[] postDeviations;
 
     // the multiplication factors to convert RCF representation to actuals/input
     double[] scale;

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/ImputePreprocessor.java
@@ -185,7 +185,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
         int savedNumberOfImputed = numberOfImputed;
         int lastActualInternal = internalTimeStamp;
 
-        double[] point = generateShingle(description, getTimeFactor(timeStampDeviations[0]), false, forest);
+        double[] point = generateShingle(description, getTimeFactor(timeStampDeviations[1]), false, forest);
 
         // restore state
         internalTimeStamp = lastActualInternal;
@@ -299,7 +299,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
                 // imputations in the shingle)
                 populateAnomalyDescriptorDetails(result);
             }
-            generateShingle(result, getTimeFactor(timeStampDeviations[0]), true, forest);
+            generateShingle(result, getTimeFactor(timeStampDeviations[1]), true, forest);
         }
         ++valuesSeen;
         return result;
@@ -427,7 +427,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
 
         updateForest(changeForest, newInput, timestamp, forest, false);
         if (changeForest) {
-            timeStampDeviations[0].update(timestamp - lastInputTimeStamp);
+            updateTimeStampDeviations(timestamp, lastInputTimeStamp);
             transformer.updateDeviation(newInput, savedInput);
         }
         return Arrays.copyOf(lastShingledPoint, lastShingledPoint.length);

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/Preprocessor.java
@@ -15,23 +15,6 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor;
 
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
-import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
-import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
-import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
-import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
-import static com.amazon.randomcutforest.parkservices.preprocessor.transform.WeightedTransformer.NUMBER_OF_STATS;
-import static java.lang.Math.log;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-
-import java.util.Arrays;
-import java.util.Optional;
-
-import lombok.Getter;
-import lombok.Setter;
-
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.config.ForestMode;
 import com.amazon.randomcutforest.config.ImputationMethod;
@@ -49,6 +32,22 @@ import com.amazon.randomcutforest.parkservices.returntypes.TimedRangeVector;
 import com.amazon.randomcutforest.parkservices.statistics.Deviation;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.returntypes.RangeVector;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
+import static com.amazon.randomcutforest.CommonUtils.toDoubleArray;
+import static com.amazon.randomcutforest.CommonUtils.toFloatArray;
+import static com.amazon.randomcutforest.RandomCutForest.DEFAULT_SHINGLE_SIZE;
+import static com.amazon.randomcutforest.config.ImputationMethod.FIXED_VALUES;
+import static com.amazon.randomcutforest.config.ImputationMethod.PREVIOUS;
+import static com.amazon.randomcutforest.parkservices.preprocessor.transform.WeightedTransformer.NUMBER_OF_STATS;
+import static java.lang.Math.exp;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 @Getter
 @Setter
@@ -86,10 +85,8 @@ public class Preprocessor implements IPreprocessor {
     public static double DEFAULT_USE_IMPUTED_FRACTION = 0.5;
 
     // minimum number of observations before using a model to predict any expected
-    // behavior
+    // behavior -- if we can score, we should predict
     public static int MINIMUM_OBSERVATIONS_FOR_EXPECTED = 100;
-
-    public static int DEFAULT_TIME_STATES = 3;
 
     public static int DEFAULT_DATA_QUALITY_STATES = 1;
 
@@ -98,8 +95,6 @@ public class Preprocessor implements IPreprocessor {
 
     // normalize time difference;
     protected boolean normalizeTime;
-
-    // protected boolean augmentTime;
 
     protected double weightTime;
 
@@ -220,7 +215,7 @@ public class Preprocessor implements IPreprocessor {
 
         Deviation[] deviationList = new Deviation[NUMBER_OF_STATS * inputLength];
         manageDeviations(deviationList, builder.deviations, transformDecay);
-        timeStampDeviations = new Deviation[DEFAULT_TIME_STATES];
+        timeStampDeviations = new Deviation[NUMBER_OF_STATS];
         manageDeviations(timeStampDeviations, builder.timeDeviations, transformDecay);
 
         if (transformMethod == TransformMethod.NONE) {
@@ -260,7 +255,7 @@ public class Preprocessor implements IPreprocessor {
     // last third
     // are filled with 0.1 * transformDecay and are reserved for smoothing
     void manageDeviations(Deviation[] deviationList, Optional<Deviation[]> original, double timeDecay) {
-        checkArgument(deviationList.length % 3 == 0, " has to be a multiple of three");
+        checkArgument(deviationList.length % NUMBER_OF_STATS == 0, " has to be a multiple of five");
         int usedDeviations = 0;
         if (original.isPresent()) {
             Deviation[] list = original.get();
@@ -271,10 +266,10 @@ public class Preprocessor implements IPreprocessor {
                 deviationList[i] = list[i].copy();
             }
         }
-        for (int i = usedDeviations; i < deviationList.length - deviationList.length / 3; i++) {
+        for (int i = usedDeviations; i < deviationList.length - 2 * deviationList.length / 5; i++) {
             deviationList[i] = new Deviation(timeDecay);
         }
-        usedDeviations = max(usedDeviations, deviationList.length - deviationList.length / 3);
+        usedDeviations = max(usedDeviations, deviationList.length - 2 * deviationList.length / 5);
         for (int i = usedDeviations; i < deviationList.length; i++) {
             deviationList[i] = new Deviation(0.1 * timeDecay);
         }
@@ -286,9 +281,11 @@ public class Preprocessor implements IPreprocessor {
      *
      * @return a boolean indicating th need to store initial values
      */
-    public static boolean requireInitialSegment(boolean normalizeTime, TransformMethod transformMethod) {
+    public static boolean requireInitialSegment(boolean normalizeTime, TransformMethod transformMethod,
+            ForestMode mode) {
         return (normalizeTime || transformMethod == TransformMethod.NORMALIZE
-                || transformMethod == TransformMethod.NORMALIZE_DIFFERENCE);
+                || transformMethod == TransformMethod.NORMALIZE_DIFFERENCE)
+                || transformMethod == TransformMethod.SUBTRACT_MA;
     }
 
     /**
@@ -324,7 +321,7 @@ public class Preprocessor implements IPreprocessor {
                 .setReasonableForecast((adjustedInternal > MINIMUM_OBSERVATIONS_FOR_EXPECTED) && (dataDimension >= 4));
         description.setScale(getScale());
         description.setShift(getShift());
-        description.setDeviations(transformer.getSmoothedDeviations());
+        description.setDeviations(getSmoothedDeviations());
         return description;
     }
 
@@ -344,7 +341,7 @@ public class Preprocessor implements IPreprocessor {
 
         double[] inputPoint = description.getCurrentInput();
         long timestamp = description.getInputTimestamp();
-        double[] scaledInput = getScaledInput(inputPoint, timestamp, null, timeStampDeviations[0].getMean());
+        double[] scaledInput = getScaledInput(inputPoint, timestamp, null, getTimeShift());
 
         if (scaledInput == null) {
             return description;
@@ -378,7 +375,7 @@ public class Preprocessor implements IPreprocessor {
             scale[inputLength] = (weightTime == 0) ? 0 : 1.0 / weightTime;
             if (normalizeTime) {
                 scale[inputLength] *= NORMALIZATION_SCALING_FACTOR
-                        * (timeStampDeviations[2].getMean() + DEFAULT_NORMALIZATION_PRECISION);
+                        * (timeStampDeviations[4].getMean() + DEFAULT_NORMALIZATION_PRECISION);
             }
             return scale;
         }
@@ -392,8 +389,27 @@ public class Preprocessor implements IPreprocessor {
         } else {
             double[] shift = new double[inputLength + 1];
             System.arraycopy(transformer.getShift(previous), 0, shift, 0, inputLength);
-            shift[inputLength] = timeStampDeviations[0].getMean() + previousTimeStamps[shingleSize - 1];
+            // time is always differenced
+            shift[inputLength] = ((normalizeTime) ? getTimeShift() : 0) + previousTimeStamps[shingleSize - 1];
             return shift;
+        }
+    }
+
+    public double[] getSmoothedDeviations() {
+        if (mode != ForestMode.TIME_AUGMENTED) {
+            double[] deviations = new double[2 * inputLength];
+            System.arraycopy(transformer.getSmoothedDeviations(), 0, deviations, 0, inputLength);
+            System.arraycopy(transformer.getSmoothedDifferenceDeviations(), 0, deviations, inputLength, inputLength);
+            return deviations;
+        } else {
+            double[] deviations = new double[2 * inputLength + 2];
+            System.arraycopy(transformer.getSmoothedDeviations(), 0, deviations, 0, inputLength);
+            System.arraycopy(transformer.getSmoothedDifferenceDeviations(), 0, deviations, inputLength + 1,
+                    inputLength);
+            // time is differenced (for now) or unchanged
+            deviations[inputLength + 1] = timeStampDeviations[4].getMean();
+            deviations[2 * inputLength + 1] = timeStampDeviations[4].getMean();
+            return deviations;
         }
     }
 
@@ -434,6 +450,8 @@ public class Preprocessor implements IPreprocessor {
             result.setPostShift(postShift);
             result.setTransformDecay(transformDecay);
         }
+        // after the insertions
+        result.setPostDeviations(getSmoothedDeviations());
         return result;
     }
 
@@ -517,15 +535,15 @@ public class Preprocessor implements IPreprocessor {
 
     // same as inverseMapTime, using explicit value also useful in forecast
     protected long inverseMapTimeValue(double gap, long timestamp) {
-        double factor = weightTime;
+        double factor = (weightTime == 0) ? 0 : 1.0 / weightTime;
         if (factor == 0) {
             return 0;
         }
         if (normalizeTime) {
-            return (long) Math.round(timestamp + timeStampDeviations[0].getMean()
-                    + NORMALIZATION_SCALING_FACTOR * gap * timeStampDeviations[2].getMean() / factor);
+            return (long) Math
+                    .round(timestamp + getTimeShift() + NORMALIZATION_SCALING_FACTOR * gap * getTimeScale() * factor);
         } else {
-            return (long) Math.round(gap / factor + timestamp);
+            return (long) Math.round(gap * factor + timestamp);
         }
     }
 
@@ -612,6 +630,16 @@ public class Preprocessor implements IPreprocessor {
         int horizon = ranges.values.length / baseDimension;
 
         int gap = (int) (internalTimeStamp - lastAnomalyDescriptor.getInternalTimeStamp());
+        double[] correction = lastAnomalyDescriptor.getDeltaShift();
+        if (correction != null) {
+            double decay = max(lastAnomalyDescriptor.getTransformDecay(),1.0/(3*shingleSize));
+            double factor = exp(-gap * decay);
+            for (int i = 0; i < correction.length; i++) {
+                correction[i] *= factor;
+            }
+        } else {
+            correction = new double[baseDimension];
+        }
         long localTimeStamp = previousTimeStamps[shingleSize - 1];
 
         TimedRangeVector timedRangeVector;
@@ -620,13 +648,11 @@ public class Preprocessor implements IPreprocessor {
             // Note that STREAMING_IMPUTE we are already using the time values
             // to fill in values -- moreover such missing values can be large in number
             // predicting next timestamps in the future in such a scenario would correspond
-            // to a
-            // joint prediction and TIME_AUGMENTED mode may be more suitable.
-            // and therefore for STREAMING_INPUTE the timestamps values are not predicted
-            // and kept at 0
+            // to a joint prediction and TIME_AUGMENTED mode may be more suitable.
+            // therefore for STREAMING_IMPUTE the timestamps values are not predicted
             if (mode != ForestMode.STREAMING_IMPUTE) {
-                double timeGap = (normalizeTime) ? 0 : timeStampDeviations[0].getMean();
-                double timeBound = (normalizeTime) ? 2.5 : 2.5 * timeStampDeviations[2].getMean();
+                double timeGap = getTimeDrift();
+                double timeBound = 1.3 * getTimeGapDifference();
 
                 for (int i = 0; i < horizon; i++) {
                     timedRangeVector.timeStamps[i] = inverseMapTimeValue(timeGap, localTimeStamp);
@@ -634,14 +660,14 @@ public class Preprocessor implements IPreprocessor {
                             inverseMapTimeValue(timeGap + timeBound, localTimeStamp));
                     timedRangeVector.lowerTimeStamps[i] = min(timedRangeVector.timeStamps[i],
                             inverseMapTimeValue(max(0, timeGap - timeBound), localTimeStamp));
-                    localTimeStamp = timedRangeVector.upperTimeStamps[i];
+                    localTimeStamp = timedRangeVector.timeStamps[i];
                 }
             }
         } else {
-            timedRangeVector = new TimedRangeVector(inputLength * horizon, horizon);
             if (gap <= shingleSize && lastAnomalyDescriptor.getExpectedRCFPoint() != null && gap == 1) {
                 localTimeStamp = lastAnomalyDescriptor.getExpectedTimeStamp();
             }
+            timedRangeVector = new TimedRangeVector(inputLength * horizon, horizon);
             for (int i = 0; i < horizon; i++) {
                 for (int j = 0; j < inputLength; j++) {
                     timedRangeVector.rangeVector.values[i * inputLength + j] = ranges.values[i * baseDimension + j];
@@ -657,7 +683,10 @@ public class Preprocessor implements IPreprocessor {
                 localTimeStamp = timedRangeVector.upperTimeStamps[i];
             }
         }
-        transformer.invertForecastRange(timedRangeVector.rangeVector, inputLength, getShingledInput(shingleSize - 1));
+        // the following is the post-anomaly transformation, can be impacted by
+        // anomalies
+        transformer.invertForecastRange(timedRangeVector.rangeVector, inputLength, getShingledInput(shingleSize - 1),
+                correction);
         return timedRangeVector;
     }
 
@@ -716,6 +745,33 @@ public class Preprocessor implements IPreprocessor {
         ++internalTimeStamp;
     }
 
+    protected void updateTimeStampDeviations(long timestamp, long previous) {
+        if (timeStampDeviations != null) {
+            timeStampDeviations[0].update(timestamp);
+            timeStampDeviations[1].update(timestamp - previous);
+            // smoothing - not used currently
+            timeStampDeviations[2].update(timeStampDeviations[0].getDeviation());
+            timeStampDeviations[3].update(timeStampDeviations[1].getMean());
+            timeStampDeviations[4].update(timeStampDeviations[1].getDeviation());
+        }
+    }
+
+    double getTimeScale() {
+        return 1.0 + getTimeGapDifference();
+    }
+
+    double getTimeGapDifference() {
+        return Math.abs(timeStampDeviations[4].getMean());
+    }
+
+    double getTimeShift() {
+        return timeStampDeviations[1].getMean();
+    }
+
+    double getTimeDrift() {
+        return timeStampDeviations[3].getMean();
+    }
+
     /**
      * updates the state of the preprocessor
      * 
@@ -725,13 +781,7 @@ public class Preprocessor implements IPreprocessor {
      * @param previous    the previous timestamp
      */
     protected void updateState(double[] inputPoint, double[] scaledInput, long timestamp, long previous) {
-        if (timeStampDeviations != null) {
-            double value = timestamp - previous;
-            timeStampDeviations[0].update(value);
-            timeStampDeviations[1].update(log(Math.max(1.0, 1.0 + value)));
-            // smoothing
-            timeStampDeviations[2].update(timeStampDeviations[0].getDeviation());
-        }
+        updateTimeStampDeviations(timestamp, previous);
         updateTimestamps(timestamp);
         double[] previousInput = (inputLength == lastShingledInput.length) ? lastShingledInput
                 : getShingledInput(shingleSize - 1);
@@ -763,25 +813,22 @@ public class Preprocessor implements IPreprocessor {
     }
 
     /**
-     * maps a value shifted to the current mean or to a relative space
+     * maps a value shifted to the current mean or to a relative space for time
      *
-     * @param value     input value of dimension
-     * @param deviation statistic
-     * @param factor    a control parameter for deviation
      * @return the normalized value
      */
-    protected double normalize(double value, Deviation[] deviation, double factor) {
-        double currentFactor = (factor != 0) ? factor : Math.abs(deviation[2].getMean());
-        if (value - deviation[0].getMean() >= NORMALIZATION_SCALING_FACTOR * clipFactor
+    protected double normalize(double value, double factor) {
+        double currentFactor = (factor != 0) ? factor : getTimeScale();
+        if (value - getTimeShift() >= NORMALIZATION_SCALING_FACTOR * clipFactor
                 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return clipFactor;
         }
-        if (value - deviation[0].getMean() <= -NORMALIZATION_SCALING_FACTOR * clipFactor
+        if (value - getTimeShift() <= -NORMALIZATION_SCALING_FACTOR * clipFactor
                 * (currentFactor + DEFAULT_NORMALIZATION_PRECISION)) {
             return -clipFactor;
         } else {
             // deviation cannot be 0
-            return (value - deviation[0].getMean())
+            return (value - getTimeShift())
                     / (NORMALIZATION_SCALING_FACTOR * (currentFactor + DEFAULT_NORMALIZATION_PRECISION));
         }
     }
@@ -803,7 +850,7 @@ public class Preprocessor implements IPreprocessor {
         } else {
             double timeShift = timestamp - previousTimeStamps[shingleSize - 1];
             scaledInput[normalized.length] = weightTime
-                    * ((normalizeTime) ? normalize(timeShift, timeStampDeviations, timeFactor) : timeShift);
+                    * ((normalizeTime) ? normalize(timeShift, timeFactor) : timeShift);
         }
         return scaledInput;
     }
@@ -955,7 +1002,7 @@ public class Preprocessor implements IPreprocessor {
         public Preprocessor build() {
             if (forestMode == ForestMode.STREAMING_IMPUTE) {
                 return new ImputePreprocessor(this);
-            } else if (requireInitialSegment(normalizeTime, transformMethod)) {
+            } else if (requireInitialSegment(normalizeTime, transformMethod, forestMode)) {
                 return new InitialSegmentPreprocessor(this);
             }
             return new Preprocessor(this);

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/ITransformer.java
@@ -25,7 +25,7 @@ import com.amazon.randomcutforest.returntypes.RangeVector;
  * (streaming/stochastic) normalization, etc.
  *
  * This interface class spells out the operations required from such
- * transformers. Some of the operations below are specific to the existing
+ * transformers. Some operations below are specific to the existing
  * implementation and required by the mappers to produce state classes.
  */
 
@@ -60,8 +60,9 @@ public interface ITransformer {
     // input length (number of variables in a multivariate analysis) baseDimension
     // and
     // previousInput[] corresponds to the last observed values of those input.
+    // correction is the effect of last anomaly
 
-    void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput);
+    void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput, double[] correction);
 
     // update the internal data structures based on the current (multivariate) input
     // inputPoint
@@ -82,7 +83,7 @@ public interface ITransformer {
     // predictor-corrector
     default double[] getShift(double[] previous) {
         return null;
-    };
+    }
 
     // used for converting RCF representations to actuals, used in
     // predictor-corrector
@@ -90,6 +91,9 @@ public interface ITransformer {
         return null;
     }
 
-    // used for computing errors in RCFcaster before the model is callibrated
+    // used for computing errors in RCFcaster before the model is calibrated
     double[] getSmoothedDeviations();
+
+    // used for determining noise
+    double[] getSmoothedDifferenceDeviations();
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/NormalizedDifferenceTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/NormalizedDifferenceTransformer.java
@@ -15,13 +15,14 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor.transform;
 
-import java.util.Arrays;
-
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.returntypes.RangeVector;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
-import com.amazon.randomcutforest.returntypes.RangeVector;
+import java.util.Arrays;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 
 @Getter
 @Setter
@@ -52,12 +53,13 @@ public class NormalizedDifferenceTransformer extends NormalizedTransformer {
      * @param previousInput the last input of length baseDimension
      */
     @Override
-    public void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput) {
+    public void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput,
+            double[] correction) {
 
         int inputLength = weights.length;
         int horizon = ranges.values.length / baseDimension;
         double[] last = Arrays.copyOf(previousInput, previousInput.length);
-
+        checkArgument(correction.length >= inputLength, " incorrect length ");
         for (int i = 0; i < horizon; i++) {
             for (int j = 0; j < inputLength; j++) {
                 double weight = (weights[j] == 0) ? 0 : getScale(j, deviations) / weights[j];

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformer.java
@@ -15,15 +15,14 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor.transform;
 
-import static com.amazon.randomcutforest.CommonUtils.checkArgument;
-
-import java.util.Arrays;
-
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import com.amazon.randomcutforest.returntypes.RangeVector;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
-import com.amazon.randomcutforest.returntypes.RangeVector;
+import java.util.Arrays;
+
+import static com.amazon.randomcutforest.CommonUtils.checkArgument;
 
 /**
  * A weighted transformer maintains several data structures ( currently 3X) that
@@ -42,7 +41,7 @@ import com.amazon.randomcutforest.returntypes.RangeVector;
 @Setter
 public class WeightedTransformer implements ITransformer {
 
-    public static int NUMBER_OF_STATS = 3;
+    public static int NUMBER_OF_STATS = 5;
 
     double[] weights;
 
@@ -84,16 +83,20 @@ public class WeightedTransformer implements ITransformer {
      * @param ranges        provides p50 values with upper and lower estimates
      * @param baseDimension the number of variables being forecast (often 1)
      * @param previousInput the last input of length baseDimension
+     * @param correction    correction due to last anomaly updates the RangeVector
+     *                      to the inverse transform and applies correction
      */
-    public void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput) {
+    public void invertForecastRange(RangeVector ranges, int baseDimension, double[] previousInput,
+            double[] correction) {
         int horizon = ranges.values.length / baseDimension;
         int inputLength = weights.length;
+        checkArgument(correction.length >= inputLength, " incorrect length ");
         for (int i = 0; i < horizon; i++) {
             for (int j = 0; j < inputLength; j++) {
                 double weight = (weights[j] == 0) ? 0 : getScale(j, deviations) / weights[j];
                 ranges.scale(i * baseDimension + j, (float) weight);
                 ranges.shift(i * baseDimension + j,
-                        (float) (getShift(j, deviations) + (i + 1) * deviations[j + inputLength].getMean()));
+                        (float) (getShift(j, deviations) + (i + 1) * getDrift(j, deviations)));
             }
         }
     }
@@ -117,6 +120,8 @@ public class WeightedTransformer implements ITransformer {
                 deviations[i + inputPoint.length].update(inputPoint[i] - previousInput[i]);
             }
             deviations[i + 2 * inputPoint.length].update(deviations[i].getDeviation());
+            deviations[i + 3 * inputPoint.length].update(deviations[i + inputPoint.length].getMean());
+            deviations[i + 4 * inputPoint.length].update(deviations[i + inputPoint.length].getDeviation());
         }
     }
 
@@ -194,6 +199,10 @@ public class WeightedTransformer implements ITransformer {
         return 0;
     }
 
+    protected double getDrift(int i, Deviation[] devs) {
+        return devs[i + 3 * weights.length].getMean();
+    }
+
     @Override
     public double[] getScale() {
         double[] answer = new double[weights.length];
@@ -213,11 +222,19 @@ public class WeightedTransformer implements ITransformer {
     }
 
     public double[] getSmoothedDeviations() {
-        checkArgument(deviations.length >= 3 * weights.length, "incorrect call");
         double[] answer = new double[weights.length];
         for (int i = 0; i < weights.length; i++) {
             answer[i] = Math.abs(deviations[i + 2 * weights.length].getMean());
         }
         return answer;
     }
+
+    public double[] getSmoothedDifferenceDeviations() {
+        double[] answer = new double[weights.length];
+        for (int i = 0; i < weights.length; i++) {
+            answer[i] = Math.abs(deviations[i + 4 * weights.length].getMean());
+        }
+        return answer;
+    }
+
 }

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorMapper.java
@@ -50,6 +50,7 @@ public class PredictorCorrectorMapper implements IStateMapper<PredictorCorrector
             }
             state.setDeviationStates(deviationState);
         }
+        state.setNoiseFactor(model.getNoiseFactor());
         state.setBaseDimension(model.getBaseDimension());
         state.setLastStrategy(model.getLastStrategy().name());
         state.setRandomSeed(model.getRandomSeed());
@@ -79,6 +80,7 @@ public class PredictorCorrectorMapper implements IStateMapper<PredictorCorrector
         predictorCorrector.setLastScore(state.getLastScore());
         predictorCorrector.setIgnoreNearExpected(state.getIgnoreNearExpected());
         predictorCorrector.setAutoAdjust(state.isAutoAdjust());
+        predictorCorrector.setNoiseFactor(state.getNoiseFactor());
         return predictorCorrector;
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/predictorcorrector/PredictorCorrectorState.java
@@ -15,14 +15,13 @@
 
 package com.amazon.randomcutforest.parkservices.state.predictorcorrector;
 
-import static com.amazon.randomcutforest.state.Version.V3_8;
+import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
+import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
+import lombok.Data;
 
 import java.io.Serializable;
 
-import lombok.Data;
-
-import com.amazon.randomcutforest.parkservices.state.statistics.DeviationState;
-import com.amazon.randomcutforest.parkservices.state.threshold.BasicThresholderState;
+import static com.amazon.randomcutforest.state.Version.V3_8;
 
 @Data
 public class PredictorCorrectorState implements Serializable {
@@ -35,6 +34,7 @@ public class PredictorCorrectorState implements Serializable {
     private int numberOfAttributors;
     private int baseDimension;
     private long randomSeed;
+    private double noiseFactor;
     private boolean autoAdjust;
     private double[] modeInformation; // multiple modes -- to be used in future
     private DeviationState[] deviationStates; // in future to be used for learning deviations

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorMapper.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorMapper.java
@@ -41,6 +41,8 @@ public class ComputeDescriptorMapper implements IStateMapper<RCFComputeDescripto
         descriptor.setShift(state.getLastShift());
         descriptor.setPostShift(state.getLastPostShift());
         descriptor.setTransformDecay(state.getTransformDecay());
+        descriptor.setPostDeviations(state.getPostDeviations());
+        descriptor.setScale(state.getLastScale());
         return descriptor;
     }
 
@@ -58,6 +60,8 @@ public class ComputeDescriptorMapper implements IStateMapper<RCFComputeDescripto
         state.setLastShift(descriptor.getShift());
         state.setLastPostShift(descriptor.getPostShift());
         state.setTransformDecay(descriptor.getTransformDecay());
+        state.setPostDeviations(descriptor.getPostDeviations());
+        state.setLastScale(descriptor.getScale());
         return state;
     }
 

--- a/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorState.java
+++ b/Java/parkservices/src/main/java/com/amazon/randomcutforest/parkservices/state/returntypes/ComputeDescriptorState.java
@@ -15,11 +15,10 @@
 
 package com.amazon.randomcutforest.parkservices.state.returntypes;
 
-import java.io.Serializable;
-
+import com.amazon.randomcutforest.state.returntypes.DiVectorState;
 import lombok.Data;
 
-import com.amazon.randomcutforest.state.returntypes.DiVectorState;
+import java.io.Serializable;
 
 @Data
 public class ComputeDescriptorState implements Serializable {
@@ -35,7 +34,8 @@ public class ComputeDescriptorState implements Serializable {
     private int lastReset;
     private String lastStrategy;
     private double[] lastShift;
+    private double[] lastScale;
     private double[] lastPostShift;
     private double transformDecay;
-
+    private double[] postDeviations;
 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/AnomalyDescriptorTest.java
@@ -77,7 +77,6 @@ public class AnomalyDescriptorTest {
                         // because distances are 0 till sampleSize; by which time
                         // forecasts would be reasonable
                         assertTrue(firstResult.getAnomalyGrade() > 0);
-                        assertTrue(!firstResult.isReasonableForecast());
                     }
                     if (firstResult.getAnomalyGrade() > 0) {
                         assertNotNull(firstResult.getPastValues());
@@ -85,16 +84,7 @@ public class AnomalyDescriptorTest {
                         if (firstResult.getRelativeIndex() == 0) {
                             assertArrayEquals(firstResult.getPastValues(), firstResult.getCurrentInput(), 1e-10);
                         }
-                        if (firstResult.getExpectedValuesList() != null
-                                && firstResult.getExpectedValuesList()[0] != null) {
-                            assertTrue(firstResult.isReasonableForecast());
-                            // the converse is not true -- the algorithm can get confused by an anomaly
-                            // in the multivariate case and choose to not output imprecise answers
-                            // an obvious example is a (x,y) distribution where it is (0,0) or (1,1)
-                            // If the input is (0,1) then both answers are feasible -- but this becomes
-                            // increasingly difficult to ascertain (based on small data) as dimensions
-                            // increase
-                        }
+
                         assertNotNull(firstResult.getRelevantAttribution());
                         assertEquals(firstResult.getRelevantAttribution().length, baseDimensions);
                         assertEquals(firstResult.attribution.getHighLowSum(), firstResult.getRCFScore(), 1e-6);

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TransformTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/TransformTest.java
@@ -15,16 +15,15 @@
 
 package com.amazon.randomcutforest.parkservices;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Random;
-
+import com.amazon.randomcutforest.config.TransformMethod;
+import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import com.amazon.randomcutforest.config.TransformMethod;
-import com.amazon.randomcutforest.testutils.ShingledMultiDimDataWithKeys;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransformTest {
 
@@ -72,8 +71,11 @@ public class TransformTest {
                     ++count;
                 }
             }
-            // normalized difference has scale correction
-            assertTrue(count < 2 * shingleSize || method == TransformMethod.NORMALIZE_DIFFERENCE);
+            // differencing introduces cascades
+            assertTrue(count < 2 * shingleSize
+                    || method == TransformMethod.NORMALIZE_DIFFERENCE
+                    || method == TransformMethod.SUBTRACT_MA
+                    || method == TransformMethod.DIFFERENCE);
         }
     }
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformerTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/preprocessor/transform/WeightedTransformerTest.java
@@ -15,14 +15,13 @@
 
 package com.amazon.randomcutforest.parkservices.preprocessor.transform;
 
+import com.amazon.randomcutforest.parkservices.statistics.Deviation;
+import org.junit.jupiter.api.Test;
+
 import static com.amazon.randomcutforest.parkservices.preprocessor.transform.WeightedTransformer.NUMBER_OF_STATS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-
-import com.amazon.randomcutforest.parkservices.statistics.Deviation;
 
 public class WeightedTransformerTest {
 
@@ -32,7 +31,9 @@ public class WeightedTransformerTest {
         assertThrows(IllegalArgumentException.class,
                 () -> new WeightedTransformer(new double[2], new Deviation[2 * NUMBER_OF_STATS]));
         Deviation[] deviations = new Deviation[NUMBER_OF_STATS];
-        deviations[0] = deviations[1] = deviations[2] = new Deviation(0);
+        for(int i=0;i<NUMBER_OF_STATS;i++) {
+            deviations[i] = new Deviation(0);
+        }
         assertDoesNotThrow(() -> new WeightedTransformer(new double[1], deviations));
     }
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/RCFCasterMapperTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/state/RCFCasterMapperTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.randomcutforest.parkservices.state;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
@@ -41,15 +42,15 @@ public class RCFCasterMapperTest {
         for (int trials = 0; trials < 1; trials++) {
 
             long seed = new Random().nextLong();
-
+            System.out.println(" seed " + seed);
             // note shingleSize == 8
             RCFCaster first = RCFCaster.builder().compact(true).dimensions(dimensions).precision(Precision.FLOAT_32)
                     .randomSeed(seed).internalShinglingEnabled(true).anomalyRate(0.01).shingleSize(shingleSize)
                     .calibration(Calibration.MINIMAL).forecastHorizon(forecastHorizon)
                     .transformMethod(TransformMethod.NORMALIZE).build();
 
-            Random r = new Random();
-            for (int i = 0; i < 2000 + new Random().nextInt(1000); i++) {
+            Random r = new Random(seed);
+            for (int i = 0; i < 2000 + r.nextInt(1000); i++) {
                 double[] point = r.ints(inputLength, 0, 50).asDoubleStream().toArray();
                 first.process(point, 0L);
             }
@@ -57,7 +58,18 @@ public class RCFCasterMapperTest {
             // serialize + deserialize
             RCFCasterMapper mapper = new RCFCasterMapper();
             RCFCaster second = mapper.toModel(mapper.toState(first));
-
+            assertArrayEquals(first.getErrorHandler().getIntervalPrecision(),
+                    second.getErrorHandler().getIntervalPrecision(), 1e-6f);
+            assertArrayEquals(first.getErrorHandler().getErrorRMSE().high, second.getErrorHandler().getErrorRMSE().high,
+                    1e-6f);
+            assertArrayEquals(first.getErrorHandler().getErrorRMSE().low, second.getErrorHandler().getErrorRMSE().low,
+                    1e-6f);
+            assertArrayEquals(first.getErrorHandler().getErrorDistribution().values,
+                    second.getErrorHandler().getErrorDistribution().values, 1e-6f);
+            assertArrayEquals(first.getErrorHandler().getErrorDistribution().upper,
+                    second.getErrorHandler().getErrorDistribution().upper, 1e-6f);
+            assertArrayEquals(first.getErrorHandler().getErrorDistribution().lower,
+                    second.getErrorHandler().getErrorDistribution().lower, 1e-6f);
             // update re-instantiated forest
             for (int i = 0; i < 100; i++) {
                 double[] point = r.ints(inputLength, 0, 50).asDoubleStream().toArray();
@@ -72,48 +84,29 @@ public class RCFCasterMapperTest {
     void verifyForecast(ForecastDescriptor firstResult, ForecastDescriptor secondResult, int inputLength) {
         RangeVector firstForecast = firstResult.getTimedForecast().rangeVector;
         RangeVector secondForecast = secondResult.getTimedForecast().rangeVector;
+        assertArrayEquals(firstForecast.values, secondForecast.values, 1e-6f);
+        assertArrayEquals(firstForecast.upper, secondForecast.upper, 1e-6f);
+        assertArrayEquals(firstForecast.lower, secondForecast.lower, 1e-6f);
 
         float[] firstErrorP50 = firstResult.getObservedErrorDistribution().values;
         float[] secondErrorP50 = secondResult.getObservedErrorDistribution().values;
+        assertArrayEquals(firstErrorP50, secondErrorP50, 1e-6f);
 
         float[] firstUpperError = firstResult.getObservedErrorDistribution().upper;
         float[] secondUpperError = secondResult.getObservedErrorDistribution().upper;
+        assertArrayEquals(firstUpperError, secondUpperError, 1e-6f);
 
         float[] firstLowerError = firstResult.getObservedErrorDistribution().lower;
         float[] secondLowerError = secondResult.getObservedErrorDistribution().lower;
+        assertArrayEquals(firstLowerError, secondLowerError, 1e-6f);
 
         DiVector firstRmse = firstResult.getErrorRMSE();
         DiVector secondRmse = secondResult.getErrorRMSE();
+        assertArrayEquals(firstRmse.high, secondRmse.high, 1e-6);
+        assertArrayEquals(firstRmse.low, secondRmse.low, 1e-6);
 
-        float[] firstMean = firstResult.getErrorMean();
-        float[] secondMean = secondResult.getErrorMean();
-
-        float[] firstCalibration = firstResult.getCalibration();
-        float[] secondCalibration = secondResult.getCalibration();
-
-        // block corresponding to the past; print the errors
-        for (int i = firstForecast.values.length / inputLength - 1; i >= 0; i--) {
-            for (int j = 0; j < inputLength; j++) {
-                int k = i * inputLength + j;
-                assertEquals(firstMean[k], secondMean[k], 1e-10);
-                assertEquals(firstRmse.high[k], secondRmse.high[k], 1e-10);
-                assertEquals(firstRmse.low[k], secondRmse.low[k], 1e-10);
-                assertEquals(firstErrorP50[k], secondErrorP50[k], 1e-10);
-                assertEquals(firstUpperError[k], secondUpperError[k], 1e-10);
-                assertEquals(firstLowerError[k], secondLowerError[k], 1e-10);
-                assertEquals(firstCalibration[k], secondCalibration[k], 1e-10);
-            }
-        }
-
-        // block corresponding to the future; the projections and the projected errors
-        for (int i = 0; i < firstForecast.values.length / inputLength; i++) {
-            for (int j = 0; j < inputLength; j++) {
-                int k = i * inputLength + j;
-                assertEquals(firstForecast.values[k], secondForecast.values[k], 1e-10);
-                assertEquals(firstForecast.upper[k], secondForecast.upper[k], 1e-10);
-                assertEquals(firstForecast.lower[k], secondForecast.lower[k], 1e-10);
-            }
-        }
+        assertArrayEquals(firstResult.getErrorMean(), secondResult.getErrorMean(), 1e-6f);
+        assertArrayEquals(firstResult.getIntervalPrecision(), secondResult.getIntervalPrecision(), 1e-6f);
     }
 
     @Test
@@ -125,7 +118,9 @@ public class RCFCasterMapperTest {
         int outputAfter = 32;
         for (int trials = 0; trials < 1; trials++) {
 
-            long seed = new Random().nextLong();
+            long seed = 5866003456555396674L;
+            new Random().nextLong();
+            System.out.println(" seed " + seed);
 
             // note shingleSize == 8
             RCFCaster first = RCFCaster.builder().compact(true).dimensions(dimensions).precision(Precision.FLOAT_32)
@@ -136,6 +131,11 @@ public class RCFCasterMapperTest {
             Random r = new Random();
             for (int i = 0; i < new Random().nextInt(outputAfter); i++) {
                 double[] point = r.ints(inputLength, 0, 50).asDoubleStream().toArray();
+                RCFCasterMapper mapper = new RCFCasterMapper();
+                RCFCaster shadow = mapper.toModel(mapper.toState(first));
+                ForecastDescriptor a = first.process(point, 0L);
+                ForecastDescriptor b = shadow.process(point, 0L);
+                assertEquals(a.getRCFScore(), b.getRCFScore(), 1e-6);
                 first.process(point, 0L);
             }
 

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/statistics/StatisticsTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/statistics/StatisticsTest.java
@@ -17,6 +17,7 @@ package com.amazon.randomcutforest.parkservices.statistics;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,9 +41,13 @@ public class StatisticsTest {
         Deviation deviation = new Deviation();
         assertEquals(deviation.getMean(), 0);
         assertTrue(deviation.isEmpty());
+        deviation.setCount(100);
+        assertTrue(deviation.isEmpty());
+        assertTrue(deviation.count == 100);
         deviation.update(-0);
-        assertEquals(1, deviation.count);
+        assertEquals(101, deviation.count);
         assertEquals(deviation.getMean(), 0);
+        assertFalse(deviation.isEmpty());
     }
 
 }

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/threshold/BasicThresholderTest.java
@@ -59,9 +59,9 @@ public class BasicThresholderTest {
         basicThresholder.setScoreDifferencing(0);
         assertFalse(basicThresholder.isDeviationReady());
         basicThresholder.setMinimumScores(5);
-        assertFalse(basicThresholder.isDeviationReady());
-        basicThresholder.setScoreDifferencing(1.0);
         assertTrue(basicThresholder.isDeviationReady());
+        basicThresholder.setScoreDifferencing(1.0);
+        assertFalse(basicThresholder.isDeviationReady());
 
         basicThresholder.updatePrimary(0.0);
         basicThresholder.updatePrimary(0.0);


### PR DESCRIPTION
*Issue #, if available:* 390

*Description of changes:* The main change in the PR is to improve precision. ThresholdedRCF had the capacity to use different streaming normalizations/transformations -- these transformations are now standardized and smoothened. As a consequence, it is feasible to use transformation A to determine significance, even though the goal is to use transformation B. This is an extension of the multi-mode capability and by default, improves the precision of the results significantly.

In addition, the PR removes unused (and unlikely to be used code) which have been remnants from version 1.0 and 2.0. It also adds more tests for branch coverage, specially for RandomCutTree. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
