### PR TITLE
Fix calculation of gap thresholds

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -157,7 +157,7 @@ vector data point, scores the data point, and then updates the model with this
 point. The program output appends a column of anomaly scores to the input:
 
 ```text
-$ java -cp core/target/randomcutforest-core-4.1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
+$ java -cp core/target/randomcutforest-core-4.2.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner < ../example-data/rcf-paper.csv > example_output.csv
 $ tail example_output.csv
 -5.0029,0.0170,-0.0057,0.8129401629464965
 -4.9975,-0.0102,-0.0065,0.6591046054520615
@@ -176,8 +176,8 @@ read additional usage instructions, including options for setting model
 hyperparameters, using the `--help` flag:
 
 ```text
-$ java -cp core/target/randomcutforest-core-4.1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
-Usage: java -cp target/random-cut-forest-4.1.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
+$ java -cp core/target/randomcutforest-core-4.2.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner --help
+Usage: java -cp target/random-cut-forest-4.2.0.jar com.amazon.randomcutforest.runner.AnomalyScoreRunner [options] < input_file > output_file
 
 Compute scalar anomaly scores from the input rows and append them to the output rows.
 
@@ -239,14 +239,14 @@ framework. Build an executable jar containing the benchmark code by running
 To invoke the full benchmark suite:
 
 ```text
-% java -jar benchmark/target/randomcutforest-benchmark-4.1.0-jar-with-dependencies.jar
+% java -jar benchmark/target/randomcutforest-benchmark-4.2.0-jar-with-dependencies.jar
 ```
 
 The full benchmark suite takes a long time to run. You can also pass a regex at the command-line, then only matching
 benchmark methods will be executed.
 
 ```text
-% java -jar benchmark/target/randomcutforest-benchmark-4.1.0-jar-with-dependencies.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
+% java -jar benchmark/target/randomcutforest-benchmark-4.2.0-jar-with-dependencies.jar RandomCutForestBenchmark\.updateAndGetAnomalyScore
 ```
 
 [rcf-paper]: http://proceedings.mlr.press/v48/guha16.pdf

--- a/Java/benchmark/pom.xml
+++ b/Java/benchmark/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
   </parent>
 
   <artifactId>randomcutforest-benchmark</artifactId>

--- a/Java/core/pom.xml
+++ b/Java/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
   </parent>
 
   <artifactId>randomcutforest-core</artifactId>

--- a/Java/core/src/main/java/com/amazon/randomcutforest/preprocessor/ImputePreprocessor.java
+++ b/Java/core/src/main/java/com/amazon/randomcutforest/preprocessor/ImputePreprocessor.java
@@ -142,7 +142,7 @@ public class ImputePreprocessor extends InitialSegmentPreprocessor {
          * continuously since we are always counting missing values that should
          * eventually be reset to zero. To address the issue, we add code in method
          * updateForest to decrement numberOfImputed when we move to a new timestamp,
-         * provided there is no imputation. This ensures th e imputation fraction does
+         * provided there is no imputation. This ensures the imputation fraction does
          * not increase as long as the imputation is continuing. This also ensures that
          * the forest update decision, which relies on the imputation fraction,
          * functions correctly. The forest is updated only when the imputation fraction

--- a/Java/core/src/test/java/com/amazon/randomcutforest/SampleSummaryTest.java
+++ b/Java/core/src/test/java/com/amazon/randomcutforest/SampleSummaryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -343,7 +344,11 @@ public class SampleSummaryTest {
         assertEquals(summary2.weightOfSamples, summary1.weightOfSamples, " sampling inconsistent");
         assertEquals(summary2.summaryPoints.length, summary1.summaryPoints.length,
                 " incorrect length of typical points");
-        assertEquals(clusters.size(), summary1.summaryPoints.length);
+        // due to randomization, they might not equal
+        assertTrue(
+                Math.abs(clusters.size() - summary1.summaryPoints.length) <= 1,
+                "The difference between clusters.size() and summary1.summaryPoints.length should be at most 1"
+        );
         double total = clusters.stream().map(ICluster::getWeight).reduce(0.0, Double::sum);
         assertEquals(total, summary1.weightOfSamples, 1e-3);
         // parallelization can produce reordering of merges

--- a/Java/examples/pom.xml
+++ b/Java/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.0</version>
     </parent>
 
     <artifactId>randomcutforest-examples</artifactId>

--- a/Java/parkservices/pom.xml
+++ b/Java/parkservices/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
   </parent>
 
   <artifactId>randomcutforest-parkservices</artifactId>

--- a/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/IgnoreTest.java
+++ b/Java/parkservices/src/test/java/com/amazon/randomcutforest/parkservices/IgnoreTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.randomcutforest.parkservices;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazon.randomcutforest.config.ForestMode;
+import com.amazon.randomcutforest.config.Precision;
+import com.amazon.randomcutforest.config.TransformMethod;
+
+public class IgnoreTest {
+    @Test
+    public void testAnomalies() {
+        // Initialize the forest parameters
+        int shingleSize = 8;
+        int numberOfTrees = 50;
+        int sampleSize = 256;
+        Precision precision = Precision.FLOAT_32;
+        int baseDimensions = 1;
+
+        long count = 0;
+        int dimensions = baseDimensions * shingleSize;
+
+        // Build the ThresholdedRandomCutForest
+        ThresholdedRandomCutForest forest = new ThresholdedRandomCutForest.Builder<>().compact(true)
+                .dimensions(dimensions).randomSeed(0).numberOfTrees(numberOfTrees).shingleSize(shingleSize)
+                .sampleSize(sampleSize).precision(precision).anomalyRate(0.01).forestMode(ForestMode.STREAMING_IMPUTE)
+                .transformMethod(TransformMethod.NORMALIZE).autoAdjust(true)
+                .ignoreNearExpectedFromAboveByRatio(new double[] { 0.1 })
+                .ignoreNearExpectedFromBelowByRatio(new double[] { 0.1 }).build();
+
+        // Generate the list of doubles
+        List<Double> randomDoubles = generateUniformRandomDoubles();
+
+        // List to store detected anomaly indices
+        List<Integer> anomalies = new ArrayList<>();
+
+        // Process each data point through the forest
+        for (double val : randomDoubles) {
+            double[] point = new double[] { val };
+            long newStamp = 100 * count;
+
+            AnomalyDescriptor result = forest.process(point, newStamp);
+
+            if (result.getAnomalyGrade() != 0) {
+                anomalies.add((int) count);
+            }
+            ++count;
+        }
+
+        // Expected anomalies
+        List<Integer> expectedAnomalies = Arrays.asList(273, 283, 505, 1323);
+
+        System.out.println("Anomalies detected at indices: " + anomalies);
+
+        // Verify that all expected anomalies are detected
+        assertTrue(anomalies.containsAll(expectedAnomalies),
+                "Anomalies detected do not contain all expected anomalies");
+    }
+
+    public static List<Double> generateUniformRandomDoubles() {
+        // Set fixed times for reproducibility
+        LocalDateTime startTime = LocalDateTime.of(2020, 1, 1, 0, 0, 0);
+        LocalDateTime endTime = LocalDateTime.of(2020, 1, 2, 0, 0, 0);
+        long totalIntervals = ChronoUnit.MINUTES.between(startTime, endTime);
+
+        // Generate timestamps (not used but kept for completeness)
+        List<LocalDateTime> timestamps = new ArrayList<>();
+        for (int i = 0; i < totalIntervals; i++) {
+            timestamps.add(startTime.plusMinutes(i));
+        }
+
+        // Initialize variables
+        Random random = new Random(0); // For reproducibility
+        double level = 0;
+        List<Double> logCounts = new ArrayList<>();
+
+        // Decide random change points where level will change
+        int numChanges = random.nextInt(6) + 5; // Random number between 5 and 10 inclusive
+
+        Set<Integer> changeIndicesSet = new TreeSet<>();
+        changeIndicesSet.add(0); // Ensure the first index is included
+
+        while (changeIndicesSet.size() < numChanges) {
+            int idx = random.nextInt((int) totalIntervals - 1) + 1; // Random index between 1 and totalIntervals -1
+            changeIndicesSet.add(idx);
+        }
+
+        List<Integer> changeIndices = new ArrayList<>(changeIndicesSet);
+
+        // Generate levels at each change point
+        List<Double> levels = new ArrayList<>();
+        for (int i = 0; i < changeIndices.size(); i++) {
+            if (i == 0) {
+                level = random.nextDouble() * 10; // Starting level between 0 and 10
+            } else {
+                double increment = -2 + random.nextDouble() * 7; // Random increment between -2 and 5
+                level = Math.max(0, level + increment);
+            }
+            levels.add(level);
+        }
+
+        // Now generate logCounts for each timestamp with even smoother transitions
+        int currentLevelIndex = 0;
+        for (int idx = 0; idx < totalIntervals; idx++) {
+            if (currentLevelIndex + 1 < changeIndices.size() && idx >= changeIndices.get(currentLevelIndex + 1)) {
+                currentLevelIndex++;
+            }
+            level = levels.get(currentLevelIndex);
+            double sineWave = Math.sin((idx % 300) * (Math.PI / 150)) * 0.05 * level;
+            double noise = (-0.01 * level) + random.nextDouble() * (0.02 * level); // Noise between -0.01*level and
+                                                                                   // 0.01*level
+            double count = Math.max(0, level + sineWave + noise);
+            logCounts.add(count);
+        }
+
+        // Introduce controlled changes for anomaly detection testing
+        for (int changeIdx : changeIndices) {
+            if (changeIdx + 10 < totalIntervals) {
+                logCounts.set(changeIdx + 5, logCounts.get(changeIdx + 5) * 1.05); // 5% increase
+                logCounts.set(changeIdx + 10, logCounts.get(changeIdx + 10) * 1.10); // 10% increase
+            }
+        }
+
+        // Output the generated logCounts
+        System.out.println("Generated logCounts of size: " + logCounts.size());
+        return logCounts;
+    }
+}

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.amazon.randomcutforest</groupId>
     <artifactId>randomcutforest-parent</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
     <packaging>pom</packaging>
 
     <name>software.amazon.randomcutforest:randomcutforest</name>

--- a/Java/serialization/pom.xml
+++ b/Java/serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.randomcutforest</groupId>
         <artifactId>randomcutforest-parent</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.0</version>
     </parent>
 
     <artifactId>randomcutforest-serialization</artifactId>

--- a/Java/testutils/pom.xml
+++ b/Java/testutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>randomcutforest-parent</artifactId>
     <groupId>software.amazon.randomcutforest</groupId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
   </parent>
 
   <artifactId>randomcutforest-testutils</artifactId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the calculation of `gapLow[y]` and `gapHigh[y]`, the expressions for the ratio-based thresholds were incorrectly using `Math.abs(a)` where `a = scale[y] * point[startPosition + y]`. Since `point[startPosition + y]` is the normalized value `(x - mean) / std`, multiplying by `scale[y]` (which is `std`) gives `(x - mean)`.

However, to accurately compute the thresholds based on the actual value `x`, we need to add back the mean (`shiftBase`). Therefore, `(a + shiftBase)` equals `(x - mean) + mean = x`.

The corrected code now uses `Math.abs(a + shiftBase)`. Read changes in PredictorCorrector for details.

Testing done:
1. added an IT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
