### PR TITLE
ci: Set explicit permissions for release drafter workflow

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   update_release_draft:
     name: Update draft release notes


### PR DESCRIPTION
Add permissions for writing to contents in the workflow.

*Issue #, if available:*

*Description of changes:*

Use minimal necessary permissions for release drafter to work. Missed this workflow in previous PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
